### PR TITLE
active exploration heuristic 1

### DIFF
--- a/droidlet/lowlevel/locobot/locobot_mover_utils.py
+++ b/droidlet/lowlevel/locobot/locobot_mover_utils.py
@@ -90,6 +90,31 @@ def get_move_target_for_point(base_pos, target, eps=1):
     return [targetx, targetz, yaw]
 
 
+def get_step_target_for_move(base_pos, target, step_size=0.1):
+    """
+    Heuristic to get step target of step_size for going to from base_pos to target. 
+
+    Args:
+        base_pos ([x,z,yaw]): robot base in canonical coords
+        target ([x,y,z]): point target in canonical coords
+    
+    Returns:
+        move_target ([x,z,yaw]): robot base move target in canonical coords 
+    """
+
+    dx = target[0] - base_pos[0]
+    signx = 1 if dx > 0 else -1 
+
+    dz = target[2] - base_pos[1]
+    signz = 1 if dz > 0 else -1 
+
+    targetx = base_pos[0] + signx * (step_size)
+    targetz = base_pos[1] + signz * (step_size) 
+
+    yaw, _ = get_camera_angles([targetx, CAMERA_HEIGHT, targetz], target)
+    
+    return [targetx, targetz, yaw] 
+
 """
 Co-ordinate transform utils. Read more at https://github.com/facebookresearch/droidlet/blob/main/locobot/coordinates.MD
 """
@@ -110,3 +135,60 @@ def xyz_pyrobot_to_canonical_coords(xyz):
 def xyz_canonical_coords_to_pyrobot_coords(xyz):
     """converts 3D coords from canonical to pyrobot coords."""
     return xyz @ np.linalg.inv(pyrobot_to_canonical_frame)
+
+
+class ExaminedMap:
+    """A helper static class to maintain the state representations needed to track active exploration.
+
+    droidlet.interpreter.robot.tasks.CuriousExplore uses this to decide which objects to explore next.
+    The core of this class is the ExaminedMap.can_examine method. This is a heuristic.
+    Long term, this information should live in memory (#FIXME @anuragprat1k). 
+    
+    It works as follows -
+    1. for each new candidate coordinate, it fetches the closest examined coordinate.
+    2. if this closest coordinate is within a certain threshold (1 meter) of the current coordinate, 
+    or if that region has been explored upto a certain number of times (2, for redundancy),
+    it is not explored, since a 'close-enough' region in space has already been explored. 
+    """
+    examined = {}
+    examined_id = set()
+    last = None
+
+    @classmethod
+    def l1(cls, xyz, k):
+        """ returns the l1 distance between two standard coordinates"""
+        return np.linalg.norm(np.asarray([xyz[0], xyz[2]]) - np.asarray([k[0], k[2]]), ord=1)
+
+    @classmethod
+    def get_closest(cls, xyz):
+        """returns closest examined point to xyz"""
+        c = None
+        dist = 1.5
+        for k, v in cls.examined.items():
+            if cls.l1(k, xyz) < dist:
+                dist = cls.l1(k, xyz)
+                c = k
+        if c is None:
+            cls.examined[xyz] = 0
+            return xyz
+        return c
+
+    @classmethod
+    def update(cls, target):
+        """called each time a region is examined. Updates relevant states."""
+        cls.last = cls.get_closest(target['xyz'])
+        cls.examined_id.add(target['eid'])
+        cls.examined[cls.last] += 1
+
+    @classmethod
+    def can_examine(cls, x):
+        """decides whether to examine x or not."""
+        loc = x['xyz']
+        k = cls.get_closest(x['xyz'])
+        val = True
+        if cls.last is not None and cls.l1(cls.last, k) < 1:
+            val = False
+        val = cls.examined[k] < 2
+        print(f"can_examine {x['eid'], x['label'], x['xyz'][:2]}, closest {k[:2]}, can_examine {val}")
+        print(f"examined[k] = {cls.examined[k]}")
+        return val


### PR DESCRIPTION
# Description

This implements a heuristic-based `CuriousExplore` task on top of the default `Explore` task for robotic agents. It works as follows - 
1. Picks a detected object for exploration based on certain criteria (whether it is in a region that has been examined before (detections are flaky so instead of remembering which detections were explored it remembers regions in space), whether it is in-sight and within a certain distance (so that the agent does not go off exploring far away objects))
2. Calls the `ExamineDetection` task on the chosen detection. `ExamineDetection` plots a straightline course to the detection and calls the `Move` task for each step. 

Implemented it in this two step-fashion instead of just calling `Move` from curious explore because `ExamineDetection` allows us to focus on objects using different heuristics - moving in a straightline or circle or something else. 

This is what the output looks like. 

<img src="https://user-images.githubusercontent.com/57542204/124049162-e05f1d00-d9e5-11eb-8cfa-1fd798e1532d.gif" width=400 height=400>

Fixes # (issue)

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [x] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.

