### PR TITLE
Fixed local install script for building docker container locally

### DIFF
--- a/tools/docker/Dockerfile.client
+++ b/tools/docker/Dockerfile.client
@@ -1,10 +1,10 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 ARG current_branch
 
 RUN apt-get -y update
-RUN apt-get install -y \
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
 	curl \
         cmake \
         g++ \


### PR DESCRIPTION
# Description

`./tools/docker/local_install.sh` let you build a docker container locally to run craftassist agent. As we updated some dependencies, they're not compatible with the old docker base image we use. Please see #689 

This PR upgrades the docker base image in `tools/docker/Dockerfile.client` from `ubuntu:18.04` to `ubuntu:20.04` and it fixed this issue.

Fixes #689 

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

**Before**

run `./tools/docker/local_install.sh` would fail

**After**

run `./tools/docker/local_install.sh` will succeed and build a docker container to let us run craftassist agent in it.

# Testing

Tested locally by running `./tools/docker/local_install.sh`

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I have verified that all scripts in `tests/scripts` runs on hardware.
