### PR TITLE
Update sets

### DIFF
--- a/agents/craftassist/tests/test_put_memory.py
+++ b/agents/craftassist/tests/test_put_memory.py
@@ -7,14 +7,18 @@ import unittest
 import droidlet.base_util
 import droidlet.lowlevel.minecraft.shape_helpers
 import droidlet.lowlevel.minecraft.shapes
+from droidlet.memory.memory_nodes import PlayerNode, SetNode
 from agents.craftassist.tests.base_craftassist_test_case import BaseCraftassistTestCase
 from droidlet.interpreter.tests.all_test_commands import *
+from droidlet.base_util import Player, Pos, Look
 
 
 class PutMemoryTestCase(BaseCraftassistTestCase):
     def setUp(self):
         super().setUp()
-        self.cube_right = self.add_object(droidlet.lowlevel.minecraft.shapes.cube(bid=(42, 0)), (9, 63, 4))
+        self.cube_right = self.add_object(
+            droidlet.lowlevel.minecraft.shapes.cube(bid=(42, 0)), (9, 63, 4)
+        )
         self.cube_left = self.add_object(droidlet.lowlevel.minecraft.shapes.cube(), (9, 63, 10))
         self.set_looking_at(list(self.cube_right.blocks.keys())[0])
 
@@ -42,6 +46,30 @@ class PutMemoryTestCase(BaseCraftassistTestCase):
         changes = self.handle_logical_form(d, answer="yes")
 
         self.assert_schematics_equal(changes.items(), self.cube_right.blocks.items())
+
+
+class PutSetMemoryTestCase(BaseCraftassistTestCase):
+    def setUp(self):
+        super().setUp()
+        memory = self.agent.memory
+        PlayerNode.create(memory, Player(10, "agent10", Pos(1, 63, 1), Look(0, 0)))
+        PlayerNode.create(memory, Player(11, "agent11", Pos(-2, 63, 1), Look(0, 0)))
+        PlayerNode.create(memory, Player(12, "agent12", Pos(-4, 63, -3), Look(0, 0)))
+
+        self.set_looking_at([1, 63, 1])
+
+    def test_build_set(self):
+        d = PUT_MEMORY_COMMANDS["you two are team alpha"]
+        self.handle_logical_form(d)
+        set_memids, _ = self.agent.memory.basic_search(
+            "SELECT MEMORIES FROM Set WHERE (has_name=team alpha)"
+        )
+        assert len(set_memids) == 1
+        set_memid = set_memids[0]
+        agent_memids = self.agent.memory.basic_search(
+            "SELECT MEMORIES FROM Player WHERE member_of=#={}".format(set_memid)
+        )
+        assert len(agent_memids) == 2
 
 
 if __name__ == "__main__":

--- a/droidlet/interpreter/filter_helper.py
+++ b/droidlet/interpreter/filter_helper.py
@@ -175,7 +175,7 @@ def interpret_argval_selector(interpreter, speaker, selector_d):
     return selector
 
 
-def build_linear_extent_selector(interpreter, speaker, location_d):
+def build_linear_extent_selector(interpreter, speaker, location_d, n=1):
     """
     builds a MemoryFilter that selects by a linear_extent dict
     chooses memory location nearest to
@@ -198,7 +198,7 @@ def build_linear_extent_selector(interpreter, speaker, location_d):
     )
     polarity = "argmin"
     sa = ApplyAttribute(interpreter.memory, selector_attribute)
-    selector = ExtremeValueMemorySelector(interpreter.memory, polarity=polarity, ordinal=1)
+    selector = ExtremeValueMemorySelector(interpreter.memory, polarity=polarity, ordinal=n)
     selector.append(sa)
     mems_filter = MemidList(interpreter.memory, [mems[0].memid])
     not_mems_filter = NotFilter(interpreter.memory, [mems_filter])
@@ -211,7 +211,8 @@ def build_linear_extent_selector(interpreter, speaker, location_d):
 def interpret_selector(interpreter, speaker, selector_d):
     selector = None
     if selector_d.get("location"):
-        return build_linear_extent_selector(interpreter, speaker, selector_d["location"])
+        n = int(number_from_span(selector_d.get("ordinal", 1)))
+        return build_linear_extent_selector(interpreter, speaker, selector_d["location"], n=n)
     return_d = selector_d.get("return_quantity", "ALL")
     if type(return_d) is str:
         if return_d == "ALL":

--- a/droidlet/interpreter/reference_object_helpers.py
+++ b/droidlet/interpreter/reference_object_helpers.py
@@ -211,12 +211,6 @@ def filter_by_sublocation(
     filters_d = d.get("filters")
     assert filters_d is not None, "no filters: {}".format(d)
     default_loc = getattr(interpreter, "default_loc", SPEAKERLOOK)
-
-    # FIXME! remove this when DSL gets rid of location as selector:
-    get_nearest = False
-    if filters_d.get("location") and not filters_d["location"].get("relative_direction"):
-        get_nearest = True
-
     location = filters_d.get("location", default_loc)
     reldir = location.get("relative_direction")
     distance_sorted = False
@@ -289,52 +283,22 @@ def filter_by_sublocation(
         ]
         location_filtered_candidates.sort(key=lambda c: euclid_dist(c.get_pos(), ref_loc))
         distance_sorted = True
-        # FIXME! remove this when DSL gets rid of location as selector:
-        if get_nearest:  # this happens if a location was given in input, but no reldir
-            location_filtered_candidates = location_filtered_candidates[:1]
 
-    # FIXME lots of copied code between here and interpret_selector
     mems = location_filtered_candidates
     if location_filtered_candidates:  # could be [], if so will return []
-        selector_d = filters_d.get("selector", {})
-        return_d = selector_d.get("return_quantity", "ALL")
-        if type(return_d) is dict and return_d.get("random") and distance_sorted:
-            # FIXME? not going to follow spec here, grabbing by the sort...
-            try:
-                return_num = int(number_from_span(return_d["random"]))
-            except:
-                raise Exception(
-                    "malformed selector dict {}, tried to get number from return dict".format(
-                        return_d
-                    )
-                )
-            same = selector_d.get("same", "ALLOWED")
-            if same == "REQUIRED":
-                mems = [location_filtered_candidates[0]] * return_num
-            elif same == "DISALLOWED":
-                if return_num > len(location_filtered_candidates):
-                    raise ErrorWithResponse(
-                        "tried to get {} objects when I only can think of {}".format(
-                            return_num, len(location_filtered_candidates)
-                        )
-                    )
-                else:
-                    mems = location_filtered_candidates[:return_num]
-            else:
-                repeat_num = max(return_num - len(location_filtered_candidates), 0)
-                return_num = min(return_num, len(location_filtered_candidates))
-                mems = (
-                    location_filtered_candidates[:return_num]
-                    + location_filtered_candidates[0] * repeat_num
-                )
+        default_selector_d = {"location": {"location_type": "SPEAKER_LOOK"}}
+        selector_d = filters_d.get("selector", default_selector_d)
+        S = interpret_selector(interpreter, speaker, selector_d)
+        if S:
+            memids, _ = S(
+                [c.memid for c in location_filtered_candidates],
+                [None] * len(location_filtered_candidates),
+            )
+            mems = [interpreter.memory.get_mem_by_id(m) for m in memids]
         else:
-            S = interpret_selector(interpreter, speaker, selector_d)
-            if S:
-                memids, _ = S(
-                    [c.memid for c in location_filtered_candidates],
-                    [None] * len(location_filtered_candidates),
-                )
-                mems = [interpreter.memory.get_mem_by_id(m) for m in memids]
+            pass
+            # FIXME, warn/error here; mems is still the candidates
+
     return mems
 
 

--- a/droidlet/interpreter/reference_object_helpers.py
+++ b/droidlet/interpreter/reference_object_helpers.py
@@ -272,7 +272,7 @@ def filter_by_sublocation(
             location_filtered_candidates.sort(key=lambda p: p.get_pos())
             distance_sorted = True
     else:
-        # no reference direction: choose the closest
+        # no reference direction: sort by closest
         mems = interpreter.subinterpret["reference_locations"](interpreter, speaker, location)
         steps, reldir = interpret_relative_direction(interpreter, d)
         ref_loc, _ = interpreter.subinterpret["specify_locations"](
@@ -286,7 +286,8 @@ def filter_by_sublocation(
 
     mems = location_filtered_candidates
     if location_filtered_candidates:  # could be [], if so will return []
-        default_selector_d = {"location": {"location_type": "SPEAKER_LOOK"}}
+        default_selector_d = {"return_quantity": "ALL"}
+        # default_selector_d = {"location": {"location_type": "SPEAKER_LOOK"}}
         selector_d = filters_d.get("selector", default_selector_d)
         S = interpret_selector(interpreter, speaker, selector_d)
         if S:

--- a/droidlet/interpreter/tests/all_test_commands.py
+++ b/droidlet/interpreter/tests/all_test_commands.py
@@ -969,6 +969,22 @@ PUT_MEMORY_COMMANDS = {
             }
         },
     },
+    "you two are team alpha": {
+        "dialogue_type": "PUT_MEMORY",
+        "filters": {
+            "selector": {
+                "location": {"location_type": "SPEAKER_LOOK"},
+                "ordinal": "2",
+                "same": "DISALLOWED",
+            }
+        },
+        "upsert": {
+            "memory_data": {
+                "memory_type": "SET",
+                "triples": [{"pred_text": "has_name", "obj_text": "team alpha"}],
+            }
+        },
+    },
 }
 
 

--- a/droidlet/memory/memory_nodes.py
+++ b/droidlet/memory/memory_nodes.py
@@ -315,7 +315,7 @@ class TripleNode(MemoryNode):
 # actual set elements are handled as triples
 class SetNode(MemoryNode):
     """for representing sets of objects, so that it is easier to build complex relations
-    using RDF/triplestore format.  is currently fetal- not used in main codebase yet"""
+    using RDF/triplestore format."""
 
     TABLE_COLUMNS = ["uuid"]
     TABLE = "SetMems"
@@ -328,11 +328,11 @@ class SetNode(MemoryNode):
     @classmethod
     def create(cls, memory, snapshot=False) -> str:
         memid = cls.new(memory, snapshot=snapshot)
-        memory.db_write("INSERT INTO SetMems(uuid) VALUES (?)", memid, memory.get_time())
+        memory.db_write("INSERT INTO SetMems(uuid) VALUES (?)", memid)
         return memid
 
     def get_members(self):
-        return self.agent_memory.get_triples(pred_text="set_member_", obj=self.memid)
+        return self.agent_memory.get_triples(pred_text="member_of", obj=self.memid)
 
     def snapshot(self, agent_memory):
         return SetNode.create(agent_memory, snapshot=True)


### PR DESCRIPTION
# Description

makes Set memories functional, adds a test for them
Along the way fixes some unfinished business from moving ordinals in selector DSL; a lot of stuff is cleaner and more "properly" done.  in particular, ordinals work more reliably across selectors


## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

previously, Set memories weren't used- now we can use them with a put memory to bundle some memories into a set.
also, ordinals are (more) properly used in selectors


# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [x] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I have verified that all scripts in `tests/scripts` runs on hardware.
