### PR TITLE
allow SELF or AGENT in special reference, these are synonymous for now

### DIFF
--- a/droidlet/dialog/map_to_dialogue_object.py
+++ b/droidlet/dialog/map_to_dialogue_object.py
@@ -22,11 +22,9 @@ class GreetingType(Enum):
 
 
 class DialogueObjectMapper(object):
-    def __init__(self,
-                 dialogue_object_classes,
-                 opts,
-                 low_level_interpreter_data,
-                 dialogue_manager):
+    def __init__(
+        self, dialogue_object_classes, opts, low_level_interpreter_data, dialogue_manager
+    ):
         self.dialogue_objects = dialogue_object_classes
         self.opts = opts
         self.low_level_interpreter_data = low_level_interpreter_data
@@ -34,12 +32,14 @@ class DialogueObjectMapper(object):
         self.safety_words = get_safety_words()
         self.greetings = get_greetings(self.opts.ground_truth_data_dir)
 
-    def get_dialogue_object(self, speaker: str, chat: str, parse: Dict, chat_status: str, chat_memid: str):
+    def get_dialogue_object(
+        self, speaker: str, chat: str, parse: Dict, chat_status: str, chat_memid: str
+    ):
         """Returns DialogueObject for a given chat and logical form"""
         # 1. If we are waiting on a response from the user (e.g.: an answer
         # to a clarification question asked), return None.
         if (len(self.dialogue_manager.dialogue_stack) > 0) and (
-                self.dialogue_manager.dialogue_stack[-1].awaiting_response
+            self.dialogue_manager.dialogue_stack[-1].awaiting_response
         ):
             return None
 
@@ -101,8 +101,10 @@ class DialogueObjectMapper(object):
         # Resolve any co-references like "this", "that" "there" using heuristics
         # and make updates in the dictionary in place.
         coref_resolve(self.dialogue_manager.memory, logical_form, chat)
-        logging.debug(
-            'logical form post co-ref "{}" -> {}'.format(hash_user(speaker), logical_form)
+        logging.info(
+            'logical form post co-ref and process_spans "{}" -> {}'.format(
+                hash_user(speaker), logical_form
+            )
         )
         return logical_form
 
@@ -147,5 +149,3 @@ class DialogueObjectMapper(object):
                     response_options = ["hi there!", "hello", "hey", "hi"]
                 return random.choice(response_options)
         return None
-
-

--- a/droidlet/interpreter/reference_object_helpers.py
+++ b/droidlet/interpreter/reference_object_helpers.py
@@ -24,7 +24,8 @@ def get_eid_from_special(agent_memory, S="AGENT", speaker=None):
         if not speaker:
             raise Exception("Asked for speakers memid but did not give speaker name")
         eid = agent_memory.get_player_by_name(speaker).eid
-    elif S == "AGENT":
+    # FIXME both of these seem to appear in lfs, probably just want one of them?
+    elif S == "AGENT" or S == "SELF":
         eid = agent_memory.get_mem_by_id(agent_memory.self_memid).eid
     return eid
 
@@ -43,7 +44,7 @@ def special_reference_search_data(interpreter, speaker, S, entity_id=None, agent
         mem = agent_memory.get_location_by_id(memid)
         q = "SELECT MEMORY FROM ReferenceObject WHERE uuid={}".format(memid)
     else:
-        if S == "AGENT" or S == "SPEAKER":
+        if S == "AGENT" or S == "SELF" or S == "SPEAKER":
             q = "SELECT MEMORY FROM Player WHERE eid={}".format(entity_id)
         elif S == "SPEAKER_LOOK":
             q = "SELECT MEMORY FROM Attention WHERE type_name={}".format(entity_id)


### PR DESCRIPTION
# Description

Currently "SELF" and "AGENT" both appear as possible fixed values in special_reference in logical forms.  however, before this change, only "AGENT" was interpreted correctly
Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

"special_reference" : {"fixed_value" : "SELF"}  would throw an error.  it is now handled with "SELF" as a synonym for "AGENT"

# Testing
Tested by hand

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I have verified that all scripts in `tests/scripts` runs on hardware.
