### PR TITLE
[refactor] Move out perception -> memory updates to agent -> memory (robot)

### DIFF
--- a/agents/locobot/locobot_agent.py
+++ b/agents/locobot/locobot_agent.py
@@ -235,15 +235,12 @@ class LocobotAgent(DroidletAgent):
         )
 
         previous_objects = DetectedObjectNode.get_all(self.memory)
-        new_state = self.perception_modules["vision"].perceive(
-            rgb_depth, xyz, previous_objects, force=force
-        )
-        if new_state is not None:
-            new_objects, updated_objects = new_state
-            for obj in new_objects:
-                obj.save_to_memory(self.memory)
-            for obj in updated_objects:
-                obj.save_to_memory(self.memory, update=True)
+        perception_output = self.perception_modules["vision"].perceive(rgb_depth,
+                                                               xyz,
+                                                               previous_objects,
+                                                               force=force)
+        self.memory.update(perception_output)
+
 
     def init_controller(self):
         """Instantiates controllers - the components that convert a text chat to task(s)."""

--- a/agents/locobot/locobot_agent.py
+++ b/agents/locobot/locobot_agent.py
@@ -235,6 +235,7 @@ class LocobotAgent(DroidletAgent):
         )
 
         previous_objects = DetectedObjectNode.get_all(self.memory)
+        # perception_output is a namedtuple of : new_detections, updated_detections, humans
         perception_output = self.perception_modules["vision"].perceive(rgb_depth,
                                                                xyz,
                                                                previous_objects,

--- a/droidlet/interpreter/robot/tests/base_fakeagent_test_case.py
+++ b/droidlet/interpreter/robot/tests/base_fakeagent_test_case.py
@@ -26,7 +26,8 @@ class BaseFakeAgentTestCase(unittest.TestCase):
         )
 
         self.speaker = self.agent.get_other_players()[0].name
-        self.agent.perceive()
+        perception_output = self.agent.perceive()
+        self.agent.memory.update(perception_output)
 
     def handle_logical_form(
         self, d, chatstr: str = "", answer: str = None, stop_on_chat=False, max_steps=10000

--- a/droidlet/interpreter/robot/tests/base_fakeagent_test_case.py
+++ b/droidlet/interpreter/robot/tests/base_fakeagent_test_case.py
@@ -26,8 +26,8 @@ class BaseFakeAgentTestCase(unittest.TestCase):
         )
 
         self.speaker = self.agent.get_other_players()[0].name
-        perception_output = self.agent.perceive()
-        self.agent.memory.update(perception_output)
+        self.agent.perceive()
+
 
     def handle_logical_form(
         self, d, chatstr: str = "", answer: str = None, stop_on_chat=False, max_steps=10000

--- a/droidlet/interpreter/robot/tests/fake_agent.py
+++ b/droidlet/interpreter/robot/tests/fake_agent.py
@@ -6,8 +6,6 @@ import numpy as np
 import re
 import logging
 import math
-from collections import namedtuple
-
 from droidlet.base_util import Look, to_player_struct
 from droidlet.interpreter.robot import dance
 from droidlet.memory.memory_nodes import PlayerNode
@@ -28,7 +26,7 @@ from droidlet.lowlevel.locobot.locobot_mover_utils import (
 from agents.locobot.self_perception import SelfPerception
 import droidlet.lowlevel.locobot.rotation as rotation
 from droidlet.perception.robot.tests.utils import get_fake_detection
-from droidlet.shared_data_struct.robot_shared_utils import Pos
+from droidlet.shared_data_struct.robot_shared_utils import Pos, RobotPerceptionData
 
 # marker creation should be somewhwere else....
 from droidlet.interpreter.robot import LocoGetMemoryHandler, PutMemoryHandler, LocoInterpreter
@@ -48,7 +46,7 @@ class FakeDetectorPerception:
         self.agent = agent
 
     def perceive(self, force=False):
-        return namedtuple("perception", [])()
+        return RobotPerceptionData()
 
     def add_detected_object(self, xyz, class_label=None, properties=[], colour=None):
         d = get_fake_detection(class_label, properties, xyz)

--- a/droidlet/interpreter/robot/tests/fake_agent.py
+++ b/droidlet/interpreter/robot/tests/fake_agent.py
@@ -27,8 +27,6 @@ from droidlet.lowlevel.locobot.locobot_mover_utils import (
 from agents.locobot.self_perception import SelfPerception
 import droidlet.lowlevel.locobot.rotation as rotation
 from droidlet.perception.robot.tests.utils import get_fake_detection
-
-# these should go in utils
 from droidlet.shared_data_struct.robot_shared_utils import Pos
 
 # marker creation should be somewhwere else....

--- a/droidlet/interpreter/robot/tests/fake_agent.py
+++ b/droidlet/interpreter/robot/tests/fake_agent.py
@@ -6,6 +6,7 @@ import numpy as np
 import re
 import logging
 import math
+from collections import namedtuple
 
 from droidlet.base_util import Look, to_player_struct
 from droidlet.interpreter.robot import dance
@@ -47,7 +48,7 @@ class FakeDetectorPerception:
         self.agent = agent
 
     def perceive(self, force=False):
-        return {}
+        return namedtuple("perception", [])()
 
     def add_detected_object(self, xyz, class_label=None, properties=[], colour=None):
         d = get_fake_detection(class_label, properties, xyz)

--- a/droidlet/interpreter/robot/tests/fake_agent.py
+++ b/droidlet/interpreter/robot/tests/fake_agent.py
@@ -445,13 +445,8 @@ class FakeAgent(DroidletAgent):
     def perceive(self, force=False):
         super().perceive(force=force)
         self.perception_modules["self"].perceive(force=force)
-        new_state = self.perception_modules["vision"].perceive(force=force)
-        if new_state is not None:
-            new_objects, updated_objects = new_state
-            for obj in new_objects:
-                obj.save_to_memory(self.memory)
-            for obj in updated_objects:
-                obj.save_to_memory(self.memory, update=True)
+        perception_output = self.perception_modules["vision"].perceive(force=force)
+        self.memory.update(perception_output)
 
     def set_logical_form(self, lf, chatstr, speaker):
         self.logical_form = {"logical_form": lf, "chatstr": chatstr, "speaker": speaker}

--- a/droidlet/interpreter/robot/tests/fake_agent.py
+++ b/droidlet/interpreter/robot/tests/fake_agent.py
@@ -446,7 +446,7 @@ class FakeAgent(DroidletAgent):
         super().perceive(force=force)
         self.perception_modules["self"].perceive(force=force)
         perception_output = self.perception_modules["vision"].perceive(force=force)
-        self.memory.update(perception_output)
+        return perception_output
 
     def set_logical_form(self, lf, chatstr, speaker):
         self.logical_form = {"logical_form": lf, "chatstr": chatstr, "speaker": speaker}

--- a/droidlet/interpreter/robot/tests/fake_agent.py
+++ b/droidlet/interpreter/robot/tests/fake_agent.py
@@ -47,7 +47,7 @@ class FakeDetectorPerception:
         self.agent = agent
 
     def perceive(self, force=False):
-        pass
+        return {}
 
     def add_detected_object(self, xyz, class_label=None, properties=[], colour=None):
         d = get_fake_detection(class_label, properties, xyz)
@@ -444,7 +444,7 @@ class FakeAgent(DroidletAgent):
         super().perceive(force=force)
         self.perception_modules["self"].perceive(force=force)
         perception_output = self.perception_modules["vision"].perceive(force=force)
-        return perception_output
+        self.memory.update(perception_output)
 
     def set_logical_form(self, lf, chatstr, speaker):
         self.logical_form = {"logical_form": lf, "chatstr": chatstr, "speaker": speaker}

--- a/droidlet/memory/craftassist/mc_memory.py
+++ b/droidlet/memory/craftassist/mc_memory.py
@@ -96,7 +96,7 @@ class MCAgentMemory(AgentMemory):
         self.perception_range = preception_range
 
     ############################################
-    ### Update world from perception updates ###
+    ### Update world with perception updates ###
     ############################################
 
     def update(self, perception_output={}, areas_to_perceive=[]):

--- a/droidlet/memory/robot/loco_memory.py
+++ b/droidlet/memory/robot/loco_memory.py
@@ -5,6 +5,7 @@ Copyright (c) Facebook, Inc. and its affiliates.
 import os
 import logging
 from typing import List
+from collections import namedtuple
 from droidlet.memory.memory_nodes import PlayerNode
 from droidlet.memory.sql_memory import AgentMemory
 from droidlet.memory.robot.loco_memory_nodes import *
@@ -41,24 +42,24 @@ class LocoAgentMemory(AgentMemory):
     ### Update world with perception updates ###
     ############################################
 
-    def update(self, perception_output={}):
+    def update(self, perception_output: namedtuple=None):
         """
         Updates the world with updates from agent's perception module.
 
         Args:
-            perception_output: Dict with members-
+            perception_output: namedtuple with members-
                 new_detections: List of new detections
                 updated_detections: List of detections with updates
                 humans: List of humans detected
         """
-        if perception_output.get("new_detections", []):
-            for detection in perception_output["new_detections"]:
+        if hasattr(perception_output, "new_detections") and perception_output.new_detections:
+            for detection in perception_output.new_detections:
                 DetectedObjectNode.create(self, detection)
-        if perception_output.get("updated_detections", []):
-            for detection in perception_output["updated_detections"]:
+        if hasattr(perception_output, "updated_detections") and perception_output.updated_detections:
+            for detection in perception_output.updated_detections:
                 DetectedObjectNode.update(self, detection)
-        if perception_output.get("humans", []):
-            for human in perception_output["humans"]:
+        if hasattr(perception_output, "humans") and perception_output.humans:
+            for human in perception_output.humans:
                 HumanPoseNode.create(self, human)
 
     #################

--- a/droidlet/memory/robot/loco_memory.py
+++ b/droidlet/memory/robot/loco_memory.py
@@ -37,8 +37,29 @@ class LocoAgentMemory(AgentMemory):
         self._safe_pickle_saved_attrs = {}
         self.dances = {}
 
-    def update(self):
-        pass
+    ############################################
+    ### Update world with perception updates ###
+    ############################################
+
+    def update(self, perception_output={}):
+        """
+        Updates the world with updates from agent's perception module.
+
+        Args:
+            perception_output: Dict with members-
+                new_detections: List of new detections
+                updated_detections: List of detections with updates
+                humans: List of humans detected
+        """
+        if perception_output.get("new_detections", []):
+            for detection in perception_output["new_detections"]:
+                DetectedObjectNode.create(self, detection)
+        if perception_output.get("updated_detections", []):
+            for detection in perception_output["updated_detections"]:
+                DetectedObjectNode.update(self, detection)
+        if perception_output.get("humans", []):
+            for human in perception_output["humans"]:
+                HumanPoseNode.create(self, human)
 
     #################
     ###  Players  ###

--- a/droidlet/memory/robot/loco_memory.py
+++ b/droidlet/memory/robot/loco_memory.py
@@ -47,18 +47,20 @@ class LocoAgentMemory(AgentMemory):
         Updates the world with updates from agent's perception module.
 
         Args:
-            perception_output: namedtuple with members-
-                new_detections: List of new detections
-                updated_detections: List of detections with updates
+            perception_output: namedtuple with attributes -
+                new_objects: List of new detections
+                updated_objects: List of detections with updates
                 humans: List of humans detected
         """
-        if hasattr(perception_output, "new_detections") and perception_output.new_detections:
-            for detection in perception_output.new_detections:
+        if not perception_output:
+            return
+        if perception_output.new_objects:
+            for detection in perception_output.new_objects:
                 DetectedObjectNode.create(self, detection)
-        if hasattr(perception_output, "updated_detections") and perception_output.updated_detections:
-            for detection in perception_output.updated_detections:
+        if perception_output.updated_objects:
+            for detection in perception_output.updated_objects:
                 DetectedObjectNode.update(self, detection)
-        if hasattr(perception_output, "humans") and perception_output.humans:
+        if perception_output.humans:
             for human in perception_output.humans:
                 HumanPoseNode.create(self, human)
 

--- a/droidlet/memory/sql_memory.py
+++ b/droidlet/memory/sql_memory.py
@@ -176,7 +176,6 @@ class AgentMemory:
         """
         self.time.add_tick(ticks)
 
-    # TODO list of all "updatable" mems, do a mem.update() ?
     def update(self):
         pass
 

--- a/droidlet/perception/robot/handlers/core.py
+++ b/droidlet/perception/robot/handlers/core.py
@@ -57,9 +57,6 @@ class WorldObject:
     def get_masked_img(self):
         raise NotImplementedError
 
-    def save_to_memory(self):
-        raise NotImplementedError
-
     def to_struct(self):
         raise NotImplementedError
 

--- a/droidlet/perception/robot/handlers/detector.py
+++ b/droidlet/perception/robot/handlers/detector.py
@@ -17,9 +17,6 @@ from detectron2.data import MetadataCatalog
 from detectron2.utils.visualizer import ColorMode
 from detectron2.config import get_cfg
 from detectron2.engine.defaults import DefaultPredictor
-
-import droidlet.memory.robot.loco_memory as loco_memory
-
 from .core import AbstractHandler, WorldObject
 from droidlet.shared_data_structs import RGBDepth
 from ..detectron.detector.utils import get_predictor

--- a/droidlet/perception/robot/handlers/detector.py
+++ b/droidlet/perception/robot/handlers/detector.py
@@ -184,12 +184,6 @@ class Detection(WorldObject):
         self.facial_rec_tag = face_tag
         self.feature_repr = None
 
-    def save_to_memory(self, memory, update=False):
-        if update:
-            loco_memory.DetectedObjectNode.update(memory, self)
-        else:
-            loco_memory.DetectedObjectNode.create(memory, self)
-
     def _maybe_bbox(self, bbox, mask):
         if hasattr(bbox, "tensor"):
             bbox = bbox.tensor.tolist()[0]

--- a/droidlet/perception/robot/handlers/human_pose.py
+++ b/droidlet/perception/robot/handlers/human_pose.py
@@ -160,9 +160,6 @@ class Human(WorldObject):
         WorldObject.__init__(self, label="human_pose", center=keypoints.nose[:2], rgb_depth=rgb_depth)
         self.keypoints = keypoints
 
-    def save_to_memory(self, memory):
-        loco_memory.HumanPoseNode.create(memory, self)
-
     def to_struct(self):
         return {"xyz": list(self.xyz), "keypoints": self.keypoints._asdict()}
 

--- a/droidlet/perception/robot/handlers/human_pose.py
+++ b/droidlet/perception/robot/handlers/human_pose.py
@@ -4,7 +4,6 @@ Copyright (c) Facebook, Inc. and its affiliates.
 import cv2
 import os
 import logging
-import droidlet.memory.robot.loco_memory as loco_memory
 import numpy as np
 from .core import AbstractHandler, WorldObject
 from droidlet.shared_data_structs import RGBDepth

--- a/droidlet/perception/robot/perception.py
+++ b/droidlet/perception/robot/perception.py
@@ -1,6 +1,7 @@
 """
 Copyright (c) Facebook, Inc. and its affiliates.
 """
+from collections import namedtuple
 from droidlet.parallel import BackgroundTask
 from droidlet.perception.robot.handlers import (
     ObjectDetection,
@@ -95,15 +96,15 @@ class Perception:
             old_image, detections, humans, old_xyz = None, None, None, None
 
         self.log(rgb_depth, detections, humans, old_image)
-        perception_output = {}
+        perceive_output = namedtuple("perception", ["new_detections", "updated_detections", "humans"])
+        new_detections, updated_detections  = None, None
         if detections is not None:
             if previous_objects is not None:
-                new_detections, updated_detections = self.vision.deduplicate(
+                new_detections_dedup, updated_detections_dedup = self.vision.deduplicate(
                     detections, previous_objects
                 )
-                perception_output["new_detections"] = new_detections
-                perception_output["updated_detections"] = updated_detections
-        perception_output["humans"] = humans
+                new_detections, updated_detections = new_detections_dedup, updated_detections_dedup
+        perception_output = perceive_output(new_detections, updated_detections, humans)
         return perception_output
 
     def log(self, rgb_depth, detections, humans, old_rgb_depth):

--- a/droidlet/perception/robot/perception.py
+++ b/droidlet/perception/robot/perception.py
@@ -1,15 +1,12 @@
 """
 Copyright (c) Facebook, Inc. and its affiliates.
 """
-import time
-
 from droidlet.parallel import BackgroundTask
 from droidlet.perception.robot.handlers import (
     ObjectDetection,
     FaceRecognition,
     HumanPose,
     ObjectTracking,
-    DetectLaserPointer,
     ObjectDeduplicator,
 )
 from droidlet.interpreter.robot.objects import AttributeDict

--- a/droidlet/perception/robot/perception.py
+++ b/droidlet/perception/robot/perception.py
@@ -1,7 +1,6 @@
 """
 Copyright (c) Facebook, Inc. and its affiliates.
 """
-from collections import namedtuple
 from droidlet.parallel import BackgroundTask
 from droidlet.perception.robot.handlers import (
     ObjectDetection,
@@ -11,6 +10,7 @@ from droidlet.perception.robot.handlers import (
     ObjectDeduplicator,
 )
 from droidlet.interpreter.robot.objects import AttributeDict
+from droidlet.shared_data_struct.robot_shared_utils import RobotPerceptionData
 from droidlet.event import sio
 import queue
 
@@ -96,15 +96,13 @@ class Perception:
             old_image, detections, humans, old_xyz = None, None, None, None
 
         self.log(rgb_depth, detections, humans, old_image)
-        perceive_output = namedtuple("perception", ["new_detections", "updated_detections", "humans"])
-        new_detections, updated_detections  = None, None
+        new_detections, updated_detections = None, None
         if detections is not None:
             if previous_objects is not None:
-                new_detections_dedup, updated_detections_dedup = self.vision.deduplicate(
+                new_detections, updated_detections = self.vision.deduplicate(
                     detections, previous_objects
                 )
-                new_detections, updated_detections = new_detections_dedup, updated_detections_dedup
-        perception_output = perceive_output(new_detections, updated_detections, humans)
+        perception_output = RobotPerceptionData(new_detections, updated_detections, humans)
         return perception_output
 
     def log(self, rgb_depth, detections, humans, old_rgb_depth):

--- a/droidlet/perception/robot/perception.py
+++ b/droidlet/perception/robot/perception.py
@@ -79,7 +79,7 @@ class Perception:
 
     def perceive(self, rgb_depth, xyz, previous_objects, force=False):
         """Called by the core event loop for the agent to run all perceptual
-        models and save their state to memory. It fetches the results of
+        models and get the state. It fetches the results of
         SlowPerception if they are ready.
 
         Args:
@@ -98,14 +98,16 @@ class Perception:
             old_image, detections, humans, old_xyz = None, None, None, None
 
         self.log(rgb_depth, detections, humans, old_image)
+        perception_output = {}
         if detections is not None:
-            current_objects = detections + humans
             if previous_objects is not None:
-                new_objects, updated_objects = self.vision.deduplicate(
-                    current_objects, previous_objects
+                new_detections, updated_detections = self.vision.deduplicate(
+                    detections, previous_objects
                 )
-            return (new_objects, updated_objects)
-        return None
+                perception_output["new_detections"] = new_detections
+                perception_output["updated_detections"] = updated_detections
+        perception_output["humans"] = humans
+        return perception_output
 
     def log(self, rgb_depth, detections, humans, old_rgb_depth):
         """Log all relevant data from the perceptual models for the dashboard.

--- a/droidlet/perception/robot/tests/test_perception.py
+++ b/droidlet/perception/robot/tests/test_perception.py
@@ -4,6 +4,7 @@ Copyright (c) Facebook, Inc. and its affiliates.
 import os
 import unittest
 import logging
+from collections import namedtuple
 from timeit import Timer
 from unittest.mock import MagicMock
 from droidlet.perception.robot import (
@@ -108,7 +109,7 @@ class MemoryStoringTest(unittest.TestCase):
         # get fake human pose
         h = get_fake_humanpose()
         # save to memory
-        perception_output = {"new_detections": [d], "humans": [h]}
+        perception_output = namedtuple("perception", ["new_detections", "humans"])([d], [h])
         self.agent.memory.update(perception_output)
 
         # retrieve detected objects
@@ -133,18 +134,17 @@ class MemoryStoringTest(unittest.TestCase):
         self.assertGreaterEqual(len(detections), 5)  # 9 exactly
         # insert once to setup dedupe tests
         self.deduplicator(detections, [])
-        self.agent.memory.update({"new_detections": detections})
+        self.agent.memory.update(namedtuple("detections", ["new_detections"])(detections))
 
         objs_init = DetectedObjectNode.get_all(self.agent.memory)
 
         # Insert with dedupe
         previous_objects = DetectedObjectNode.get_all(self.agent.memory)
-        detection_output = {}
+        detectionTuple = namedtuple("detections", ["new_detections", "updated_detections"])
         if previous_objects is not None:
             new_objects, updated_objects = self.deduplicator(detections, previous_objects)
-            detection_output["new_detections"] = new_objects
-            detection_output["updated_detections"] = updated_objects
-        self.agent.memory.update(detection_output)
+            detection_output = detectionTuple(new_objects, updated_objects)
+            self.agent.memory.update(detection_output)
 
         # Assert that some objects get deduped
         objs_t1 = DetectedObjectNode.get_all(self.agent.memory)

--- a/droidlet/perception/robot/tests/test_perception.py
+++ b/droidlet/perception/robot/tests/test_perception.py
@@ -109,8 +109,8 @@ class MemoryStoringTest(unittest.TestCase):
         # get fake human pose
         h = get_fake_humanpose()
         # save to memory
-        for obj in [d, h]:
-            obj.save_to_memory(self.agent.memory)
+        perception_output = {"new_detections": [d], "humans": [h]}
+        self.agent.memory.update(perception_output)
 
         # retrieve detected objects
         o = DetectedObjectNode.get_all(self.agent.memory)
@@ -134,19 +134,18 @@ class MemoryStoringTest(unittest.TestCase):
         self.assertGreaterEqual(len(detections), 5)  # 9 exactly
         # insert once to setup dedupe tests
         self.deduplicator(detections, [])
-        for obj in detections:
-            obj.save_to_memory(self.agent.memory)
+        self.agent.memory.update({"new_detections": detections})
 
         objs_init = DetectedObjectNode.get_all(self.agent.memory)
 
         # Insert with dedupe
         previous_objects = DetectedObjectNode.get_all(self.agent.memory)
+        detection_output = {}
         if previous_objects is not None:
             new_objects, updated_objects = self.deduplicator(detections, previous_objects)
-            for obj in new_objects:
-                obj.save_to_memory(self.agent.memory)
-            for obj in updated_objects:
-                obj.save_to_memory(self.agent.memory, update=True)
+            detection_output["new_detections"] = new_objects
+            detection_output["updated_detections"] = updated_objects
+        self.agent.memory.update(detection_output)
 
         # Assert that some objects get deduped
         objs_t1 = DetectedObjectNode.get_all(self.agent.memory)

--- a/droidlet/perception/robot/tests/test_perception.py
+++ b/droidlet/perception/robot/tests/test_perception.py
@@ -12,7 +12,6 @@ from droidlet.perception.robot import (
     ObjectDeduplicator,
     Perception,
     Detection,
-    Human,
 )
 from droidlet.interpreter.robot import dance
 from droidlet.memory.robot.loco_memory import LocoAgentMemory

--- a/droidlet/shared_data_struct/robot_shared_utils.py
+++ b/droidlet/shared_data_struct/robot_shared_utils.py
@@ -3,3 +3,6 @@ from collections import namedtuple
 
 Pos = namedtuple("pos", ["x", "y", "z"])
 Marker = namedtuple("Marker", "markerId pos color category properties")
+RobotPerceptionData = namedtuple("perception",
+                               ["new_objects", "updated_objects", "humans"],
+                               defaults=[None, None, None])

--- a/droidlet/shared_data_structs.py
+++ b/droidlet/shared_data_structs.py
@@ -1,5 +1,4 @@
 import heapq
-
 import numpy as np
 import time
 from droidlet.lowlevel.locobot.locobot_mover_utils import xyz_pyrobot_to_canonical_coords


### PR DESCRIPTION
# Description

This PR moves out updates from perception handlers that were being directly written to memory. This refactors the `perception -> memory` write to an `update` function in `LocoAgentMemory` that the agent calls.

This changes makes things consistent for all droidlet agents (previous PR: https://github.com/facebookresearch/fairo/pull/719 ). Also updated unit tests.

Fixes #337 

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [x] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

# Testing

Testing on CI + devfair. We have tests in `robot/perception` and `robot/interpreter/fake_agent` that test for the change.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I have verified that all scripts in `tests/scripts` runs on hardware.
