### PR TITLE
perception bugfixes

### DIFF
--- a/droidlet/perception/craftassist/heuristic_perception.py
+++ b/droidlet/perception/craftassist/heuristic_perception.py
@@ -36,7 +36,9 @@ def all_nearby_objects(get_blocks, pos, boring_blocks, passable_blocks, max_radi
     i.e. this function returns list[list[((x, y, z), (id, meta))]]
     """
     pos = np.round(pos).astype("int32")
-    mask, off, blocks = all_close_interesting_blocks(get_blocks, pos, boring_blocks, passable_blocks, max_radius)
+    mask, off, blocks = all_close_interesting_blocks(
+        get_blocks, pos, boring_blocks, passable_blocks, max_radius
+    )
     components = connected_components(mask)
     logging.debug("all_nearby_objects found {} objects near {}".format(len(components), pos))
     xyzbms = [
@@ -59,7 +61,9 @@ def closest_nearby_object(get_blocks, pos, boring_blocks, passable_blocks):
     return objects[np.argmin(dists)]
 
 
-def all_close_interesting_blocks(get_blocks, pos, boring_blocks, passable_blocks, max_radius=MAX_RADIUS):
+def all_close_interesting_blocks(
+    get_blocks, pos, boring_blocks, passable_blocks, max_radius=MAX_RADIUS
+):
     """Find all "interesting" blocks close to pos, within a max_radius"""
     mx, my, mz = pos[0] - max_radius, pos[1] - max_radius, pos[2] - max_radius
     Mx, My, Mz = pos[0] + max_radius, pos[1] + max_radius, pos[2] + max_radius
@@ -531,21 +535,26 @@ class PerceptionWrapper:
             return CraftAssistPerceptionData()
 
         perceive_info = {}
+        perceive_info["in_perceive_area"] = {}
         # 1. perceive blocks in marked areas to perceive
         for pos, radius in self.agent.areas_to_perceive:
             # 1.1 Get block objects and their colors
             obj_tag_list = []
-            for obj in all_nearby_objects(self.agent.get_blocks, pos, self.boring_blocks, self.passable_blocks, radius):
+            for obj in all_nearby_objects(
+                self.agent.get_blocks, pos, self.boring_blocks, self.passable_blocks, radius
+            ):
                 color_tags = []
                 for idm in obj:
                     type_name = maybe_get_type_name(idm, self.block_data)
                     color_tags.extend(self.color_data["name_to_colors"].get(type_name, []))
                 obj_tag_list.append([obj, color_tags])
-            perceive_info["in_perceive_area"] = perceive_info.get("in_perceive_area", {})
-            perceive_info["in_perceive_area"]["block_object_attributes"] = obj_tag_list if obj_tag_list else None
+            perceive_info["in_perceive_area"]["block_object_attributes"] = (
+                obj_tag_list if obj_tag_list else None
+            )
             # 1.2 Get all holes in perception area
             holes = get_all_nearby_holes(
-                self.agent, pos, self.block_data, self.agent.low_level_data["fill_idmeta"], radius)
+                self.agent, pos, self.block_data, self.agent.low_level_data["fill_idmeta"], radius
+            )
             perceive_info["in_perceive_area"]["holes"] = holes if holes else None
             # 1.3 Get all air-touching blocks in perception area
             blocktypes, shifted_c, tags = get_nearby_airtouching_blocks(
@@ -562,7 +571,9 @@ class PerceptionWrapper:
 
         # 2. perceive blocks and their colors near the agent
         near_obj_tag_list = []
-        for objs in all_nearby_objects(self.agent.get_blocks, self.agent.pos, self.boring_blocks, self.passable_blocks):
+        for objs in all_nearby_objects(
+            self.agent.get_blocks, self.agent.pos, self.boring_blocks, self.passable_blocks
+        ):
             color_tags = []
             for obj in objs:
                 idm = obj[1]
@@ -570,14 +581,17 @@ class PerceptionWrapper:
                 color_tags.extend(self.color_data["name_to_colors"].get(type_name, []))
             near_obj_tag_list.append([objs, color_tags])
         perceive_info["near_agent"] = perceive_info.get("near_agent", {})
-        perceive_info["near_agent"]["block_object_attributes"] = near_obj_tag_list if near_obj_tag_list else None
+        perceive_info["near_agent"]["block_object_attributes"] = (
+            near_obj_tag_list if near_obj_tag_list else None
+        )
         # 3. Get all holes near agent
         holes = get_all_nearby_holes(
             self.agent,
             self.agent.pos,
             self.block_data,
             self.agent.low_level_data["fill_idmeta"],
-            radius=self.radius)
+            radius=self.radius,
+        )
         perceive_info["near_agent"]["holes"] = holes if holes else None
         # 4. Get all air-touching blocks near agent
         blocktypes, shifted_c, tags = get_nearby_airtouching_blocks(
@@ -592,8 +606,10 @@ class PerceptionWrapper:
         if tags and len(shifted_c) > 0:
             perceive_info["near_agent"]["airtouching_blocks"] = [shifted_c, tags]
 
-        return CraftAssistPerceptionData(in_perceive_area=perceive_info["in_perceive_area"],
-                                         near_agent=perceive_info["near_agent"])
+        return CraftAssistPerceptionData(
+            in_perceive_area=perceive_info["in_perceive_area"],
+            near_agent=perceive_info["near_agent"],
+        )
 
 
 def build_safe_diag_adjacent(bounds):


### PR DESCRIPTION
# Description

fixes a recent bug where if perception was called without being forced or with nothing to do, it would error out because the entries in various dicts were not created until they were updated (but were looked for anyway).  now they are just init in the beginning as empty

Fixes # (issue)
I think this should fix https://github.com/facebookresearch/fairo/issues/731

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

in mc heuristic and low-level perception, returns were being filled during the run of the .perceive(), and initted if they were empty, now they are initted at the beginning of the call

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I have verified that all scripts in `tests/scripts` runs on hardware.
