### PR TITLE
Resolve corner case during controller update

### DIFF
--- a/polymetis/polymetis/python/polymetis/robot_interface.py
+++ b/polymetis/polymetis/python/polymetis/robot_interface.py
@@ -178,6 +178,7 @@ class BaseRobotInterface:
             log_interval = self.grpc_connection.SetController(msg_generator())
         except grpc.RpcError as e:
             print(e)
+            return
 
         if blocking:
             # Check policy termination
@@ -213,6 +214,7 @@ class BaseRobotInterface:
             update_interval = self.grpc_connection.UpdateController(msg_generator())
         except grpc.RpcError as e:
             print(e)
+            return
 
         episode_interval = self.grpc_connection.GetEpisodeInterval(EMPTY)
 

--- a/polymetis/polymetis/src/polymetis_server.cpp
+++ b/polymetis/polymetis/src/polymetis_server.cpp
@@ -311,6 +311,8 @@ Status PolymetisControllerServerImpl::UpdateController(
     interval->set_start(robot_state_buffer_.size());
     custom_controller_context_.controller_mtx.unlock();
   } else {
+    std::cout << "Warning: Tried to perform a controller update with no "
+                 "controller running.\n";
     interval->set_start(-1);
   }
 
@@ -335,6 +337,8 @@ Status PolymetisControllerServerImpl::TerminateController(
     interval->set_start(custom_controller_context_.episode_begin);
     interval->set_end(custom_controller_context_.episode_end);
   } else {
+    std::cout << "Warning: Tried to terminate controller with no controller "
+                 "running.\n";
     interval->set_start(-1);
     interval->set_end(-1);
   }

--- a/polymetis/polymetis/src/polymetis_server.cpp
+++ b/polymetis/polymetis/src/polymetis_server.cpp
@@ -304,7 +304,7 @@ Status PolymetisControllerServerImpl::UpdateController(
   param_dict_input_.push_back(param_dict_container.forward(empty_input_));
 
   // Update controller & set intervals
-  if (custom_controller_context_.status != UNINITIALIZED) {
+  if (custom_controller_context_.status == RUNNING) {
     custom_controller_context_.controller_mtx.lock();
     custom_controller_context_.custom_controller.get_method("update")(
         param_dict_input_);
@@ -323,7 +323,7 @@ Status PolymetisControllerServerImpl::TerminateController(
     ServerContext *context, const Empty *, LogInterval *interval) {
   std::lock_guard<std::mutex> service_lock(service_mtx_);
 
-  if (custom_controller_context_.status != UNINITIALIZED) {
+  if (custom_controller_context_.status == RUNNING) {
     custom_controller_context_.controller_mtx.lock();
     custom_controller_context_.status = TERMINATING;
     custom_controller_context_.controller_mtx.unlock();


### PR DESCRIPTION
# Description

Fixes issue where program crashes when trying to update/terminate while running the default controller.

- Fix RobotInterface to correctly catch and return from a `grpc.RpcError`
- Correctly handle the case when user tries to send a controller update / controller termination when the default controller is running
- Add warnings in the above case

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

When trying to update or terminate an ongoing controller.

### Before

Client: RobotInterface crashes from variable `log_interval` or `update_interval` not being initialized due to an unsuccessful RPC call.

Server: Refuse all future client connections without any warnings.

### After

Client: Returns None.

Server: Prints out a warning and does nothing.

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [x] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I have verified that all scripts in `tests/scripts` runs on hardware.
