### PR TITLE
[Dashboard] Pull action dict on demand instead of agent sending each time

### DIFF
--- a/agents/droidlet_agent.py
+++ b/agents/droidlet_agent.py
@@ -41,6 +41,7 @@ class DroidletAgent(BaseAgent):
         self.perceive_on_chat = False
         self.agent_type = None
         self.scheduler = EmptyScheduler()
+        self.dialogue_manager = None
         self.dashboard_memory_dump_time = time.time()
         self.dashboard_memory = {
             "db": {},

--- a/agents/droidlet_agent.py
+++ b/agents/droidlet_agent.py
@@ -130,32 +130,39 @@ class DroidletAgent(BaseAgent):
                 "<dashboard> " + command
             )  # the chat is coming from a player called "dashboard"
             self.dashboard_chat = agent_chat
-            logical_form = {}
-            status = ""
-            try:
-                chat_parse = self.perception_modules["language_understanding"].get_logical_form(
-                    chat=command,
-                    parsing_model=self.perception_modules["language_understanding"].parsing_model,
-                )
-                logical_form = self.dialogue_manager.dialogue_object_mapper.postprocess_logical_form(
-                    speaker="dashboard", chat=command, logical_form=chat_parse
-                )
-                logging.debug("logical form is : %r" % (logical_form))
-                status = "Sent successfully"
-            except Exception as e:
-                logging.error("error in sending chat", e)
-                status = "Error in sending chat"
+            status = "Sent successfully"
             # update server memory
-            self.dashboard_memory["chatResponse"][command] = logical_form
             self.dashboard_memory["chats"].pop(0)
             self.dashboard_memory["chats"].append({"msg": command, "failed": False})
             payload = {
                 "status": status,
                 "chat": command,
-                "chatResponse": self.dashboard_memory["chatResponse"][command],
                 "allChats": self.dashboard_memory["chats"],
             }
             sio.emit("setChatResponse", payload)
+
+        @sio.on("getChatActionDict")
+        def get_chat_action_dict(sid, chat):
+            logging.debug(f"Looking for action dict for command [{chat}] in memory")
+            logical_form = None
+            try:
+                chat_memids, _ = self.memory.basic_search(f"SELECT MEMORY FROM Chat WHERE chat={chat}")
+                logical_form_triples = self.memory.get_triples(
+                    subj=chat_memids[0], pred_text="has_logical_form"
+                )
+                if logical_form_triples:
+                    logical_form = self.memory.get_logical_form_by_id(
+                        logical_form_triples[0][2]
+                    ).logical_form
+                if logical_form:
+                    logical_form = self.dialogue_manager.dialogue_object_mapper.postprocess_logical_form(speaker="dashboard", chat=chat, logical_form=logical_form)
+            except Exception as e:
+                logging.debug(f"Failed to find any action dict for command [{chat}] in memory")
+            
+            payload = {
+                "action_dict": logical_form
+            }
+            sio.emit("setLastChatActionDict", payload)
 
         @sio.on("terminateAgent")
         def terminate_agent(sid, msg):

--- a/droidlet/dashboard/web/src/StateManager.js
+++ b/droidlet/dashboard/web/src/StateManager.js
@@ -54,7 +54,7 @@ class StateManager {
   initialMemoryState = {
     objects: new Map(),
     humans: new Map(),
-    chatResponse: {},
+    lastChatActionDict: null,
     chats: [
       { msg: "", failed: false },
       { msg: "", failed: false },
@@ -75,6 +75,7 @@ class StateManager {
   constructor() {
     this.processMemoryState = this.processMemoryState.bind(this);
     this.setChatResponse = this.setChatResponse.bind(this);
+    this.setLastChatActionDict = this.setLastChatActionDict.bind(this);
     this.setConnected = this.setConnected.bind(this);
     this.updateAgentType = this.updateAgentType.bind(this);
     this.updateStateManagerMemory = this.updateStateManagerMemory.bind(this);
@@ -126,15 +127,15 @@ class StateManager {
 
     // Assumes that all socket events for a frame are received before the next frame
     this.curFeedState = {
-      rgbImg: null, 
-      depth: null, 
+      rgbImg: null,
+      depth: null,
       objects: [], // Can be changed by annotation tool
       origObjects: [], // Original objects sent from backend
       pose: null,
     };
     this.prevFeedState = {
-      rgbImg: null, 
-      depth: null, 
+      rgbImg: null,
+      depth: null,
       objects: [],
       pose: null,
     };
@@ -143,15 +144,15 @@ class StateManager {
       depth: false,
       objects: false,
       pose: false,
-    }
-    this.frameCount = 0 // For filenames when saving
-    this.categories = new Set()
-    this.properties = new Set()
-    this.annotationsSaved = true
-    this.offline = false
-    this.frameId = 0 // Offline frame count
-    this.offlineObjects = {} // Maps frame ids to masks
-    this.updateObjects = [false, false] // Update objects on the frame after the rgb image changes
+    };
+    this.frameCount = 0; // For filenames when saving
+    this.categories = new Set();
+    this.properties = new Set();
+    this.annotationsSaved = true;
+    this.offline = false;
+    this.frameId = 0; // Offline frame count
+    this.offlineObjects = {}; // Maps frame ids to masks
+    this.updateObjects = [false, false]; // Update objects on the frame after the rgb image changes
     this.useDesktopComponentOnMobile = true; // switch to use either desktop or mobile annotation on mobile device
     // TODO: Finish mobile annotation component (currently UI is finished, not linked up with backend yet)
   }
@@ -248,6 +249,7 @@ class StateManager {
     });
 
     socket.on("setChatResponse", this.setChatResponse);
+    socket.on("setLastChatActionDict", this.setLastChatActionDict);
     socket.on("memoryState", this.processMemoryState);
     socket.on("updateState", this.updateStateManagerMemory);
     socket.on("updateAgentType", this.updateAgentType);
@@ -308,7 +310,9 @@ class StateManager {
       alert("Received text message: " + res.chat);
     }
     this.memory.chats = res.allChats;
-    this.memory.chatResponse[res.chat] = res.chatResponse;
+
+    // once confirm that this chat has been sent, clear last chat action dict
+    this.memory.lastChatActionDict = null;
 
     this.refs.forEach((ref) => {
       if (ref instanceof InteractApp) {
@@ -320,6 +324,10 @@ class StateManager {
         ref.forceUpdate();
       }
     });
+  }
+
+  setLastChatActionDict(res) {
+    this.memory.lastChatActionDict = res.action_dict;
   }
 
   updateVoxelWorld(res) {
@@ -471,15 +479,17 @@ class StateManager {
       let newXyz = oldObj ? this.curFeedState.objects[id].xyz : null;
       // Get rid of masks with <3 points
       // We have this check because detector sometimes sends masks with <3 points to frontend
-      let i = 0
+      let i = 0;
       while (i < pointMap[id].length) {
         if (!pointMap[id][i] || pointMap[id][i].length < 3) {
           pointMap[id].splice(i, 1);
-          continue
+          continue;
         }
-        i++
+        i++;
       }
-      let newMask = pointMap[id].map(mask => mask.map((pt, i) => [pt.x * scale, pt.y * scale]))
+      let newMask = pointMap[id].map((mask) =>
+        mask.map((pt, i) => [pt.x * scale, pt.y * scale])
+      );
       let newBbox = this.getNewBbox(newMask);
 
       newObjects.push({
@@ -492,9 +502,9 @@ class StateManager {
         xyz: newXyz,
       });
     }
-    this.curFeedState.objects = newObjects
-    this.annotationsSaved = false
-    
+    this.curFeedState.objects = newObjects;
+    this.annotationsSaved = false;
+
     this.refs.forEach((ref) => {
       if (ref instanceof LiveObjects) {
         ref.setState({
@@ -502,9 +512,9 @@ class StateManager {
           updateFixup: true,
         });
       }
-    })
+    });
     if (this.offline) {
-      this.offlineObjects[this.frameId] = this.curFeedState.objects
+      this.offlineObjects[this.frameId] = this.curFeedState.objects;
     }
   }
 
@@ -526,43 +536,45 @@ class StateManager {
 
   startLabelPropagation() {
     // Update categories and properties
-    let prevObjects = this.prevFeedState.objects.filter(o => o.type === "annotate")
+    let prevObjects = this.prevFeedState.objects.filter(
+      (o) => o.type === "annotate"
+    );
     for (let i in prevObjects) {
-      this.categories.add(prevObjects[i].label)
-      let prevProperties = prevObjects[i].properties.split("\n ")
-      prevProperties.forEach(p => this.properties.add(p))
+      this.categories.add(prevObjects[i].label);
+      let prevProperties = prevObjects[i].properties.split("\n ");
+      prevProperties.forEach((p) => this.properties.add(p));
     }
 
     // Label prop
     if (prevObjects.length > 0) {
       let labelProps = {
-        prevRgbImg: this.prevFeedState.rgbImg, 
-        depth: this.curFeedState.depth, 
-        prevDepth: this.prevFeedState.depth, 
-        objects: prevObjects, 
+        prevRgbImg: this.prevFeedState.rgbImg,
+        depth: this.curFeedState.depth,
+        prevDepth: this.prevFeedState.depth,
+        objects: prevObjects,
         basePose: this.curFeedState.pose,
         prevBasePose: this.prevFeedState.pose,
-      }
-      this.socket.emit("label_propagation", labelProps)
+      };
+      this.socket.emit("label_propagation", labelProps);
     }
 
     // Save rgb/seg if needed
     if (!this.annotationsSaved) {
       let saveProps = {
-        rgb: this.prevFeedState.rgbImg, 
-        objects: prevObjects, 
+        rgb: this.prevFeedState.rgbImg,
+        objects: prevObjects,
         frameCount: this.frameCount,
         categories: [null, ...this.categories], // Include null so category indices start at 1
-      }
-      this.socket.emit("save_rgb_seg", saveProps)
-      this.annotationsSaved = true
+      };
+      this.socket.emit("save_rgb_seg", saveProps);
+      this.annotationsSaved = true;
     }
     // Reset
     this.stateProcessed.rgbImg = true;
     this.stateProcessed.depth = true;
     this.stateProcessed.objects = true;
     this.stateProcessed.pose = true;
-    this.frameCount++
+    this.frameCount++;
   }
 
   labelPropagationReturn(res) {
@@ -583,12 +595,12 @@ class StateManager {
           this.curFeedState.objects.push(res[i]);
         }
       }
-    })
+    });
     if (this.offline) {
-      this.offlineObjects[this.frameId] = this.curFeedState.objects
+      this.offlineObjects[this.frameId] = this.curFeedState.objects;
     }
     if (Object.keys(res).length > 0) {
-      this.annotationsSaved = false
+      this.annotationsSaved = false;
     }
   }
 
@@ -610,177 +622,183 @@ class StateManager {
   }
 
   onSave() {
-    console.log("saving annotations, categories, and properties")
-    
+    console.log("saving annotations, categories, and properties");
+
     if (this.offline) {
       // Save categories and properties
       for (let key in this.offlineObjects) {
-        let objects = this.offlineObjects[key]
+        let objects = this.offlineObjects[key];
         for (let i in objects) {
-          let obj = objects[i]
-          this.categories.add(obj.label)
-          let properties = obj.properties.split("\n ")
-          properties.forEach(p => this.properties.add(p))
+          let obj = objects[i];
+          this.categories.add(obj.label);
+          let properties = obj.properties.split("\n ");
+          properties.forEach((p) => this.properties.add(p));
         }
       }
-      let categories = [null, ...this.categories] // Include null so category indices start at 1
-      let properties = [...this.properties]
-      this.socket.emit("save_categories_properties", categories, properties)
-      
+      let categories = [null, ...this.categories]; // Include null so category indices start at 1
+      let properties = [...this.properties];
+      this.socket.emit("save_categories_properties", categories, properties);
+
       // Save rgb/seg
-      let outputId = 0
+      let outputId = 0;
       for (let key in this.offlineObjects) {
-        let objects = this.offlineObjects[key]
-        let finalFrame = outputId === Object.keys(this.offlineObjects).length - 1
+        let objects = this.offlineObjects[key];
+        let finalFrame =
+          outputId === Object.keys(this.offlineObjects).length - 1;
         let saveProps = {
           filepath: this.filepath,
           frameId: parseInt(key),
           outputId,
-          objects, 
-          categories, 
+          objects,
+          categories,
           finalFrame, // When true, backend will save all annotations to COCO format
-        }
-        this.socket.emit("offline_save_rgb_seg", saveProps)
-        outputId++
+        };
+        this.socket.emit("offline_save_rgb_seg", saveProps);
+        outputId++;
       }
-
     } else {
       // Save current rgb/seg if needed
       if (!this.annotationsSaved) {
-        let curObjects = this.curFeedState.objects.filter(o => o.type === "annotate")
+        let curObjects = this.curFeedState.objects.filter(
+          (o) => o.type === "annotate"
+        );
         for (let i in curObjects) {
-          this.categories.add(curObjects[i].label)
-          let props = curObjects[i].properties.split("\n ")
-          props.forEach(p => this.properties.add(p))
+          this.categories.add(curObjects[i].label);
+          let props = curObjects[i].properties.split("\n ");
+          props.forEach((p) => this.properties.add(p));
         }
         let saveProps = {
-          rgb: this.curFeedState.rgbImg, 
-          objects: curObjects, 
+          rgb: this.curFeedState.rgbImg,
+          objects: curObjects,
           frameCount: this.frameCount,
           categories: [null, ...this.categories], // Include null so category indices start at 1
           callback: true, // Include boolean param to save annotations after -- ensures whatever the noun form of synchronous is
-        }
-        // This emit has a callback that calls saveAnnotations() 
-        this.socket.emit("save_rgb_seg", saveProps)
-        this.annotationsSaved = true
+        };
+        // This emit has a callback that calls saveAnnotations()
+        this.socket.emit("save_rgb_seg", saveProps);
+        this.annotationsSaved = true;
       } else {
-        this.saveAnnotations()
+        this.saveAnnotations();
       }
     }
   }
 
   saveAnnotations() {
     // Save annotations
-    let categories = [null, ...this.categories] // Include null so category indices start at 1
-    let properties = [...this.properties]
-    this.socket.emit("save_annotations", categories)
-    this.socket.emit("save_categories_properties", categories, properties)
+    let categories = [null, ...this.categories]; // Include null so category indices start at 1
+    let properties = [...this.properties];
+    this.socket.emit("save_annotations", categories);
+    this.socket.emit("save_categories_properties", categories, properties);
   }
 
   annotationRetrain(res) {
-    console.log("retrained!")
+    console.log("retrained!");
     this.refs.forEach((ref) => {
       if (ref instanceof LiveObjects || ref instanceof Retrainer) {
         ref.setState({
-          modelMetrics: res
-        })
+          modelMetrics: res,
+        });
       }
     });
   }
 
   goOffline(filepath) {
-    console.log("Going offline with filepath", filepath)
-    this.filepath = filepath
-    this.frameId = 0
-    this.offline = true
+    console.log("Going offline with filepath", filepath);
+    this.filepath = filepath;
+    this.frameId = 0;
+    this.offline = true;
 
     this.socket.emit("get_offline_frame", {
-      filepath: this.filepath, 
+      filepath: this.filepath,
       frameId: this.frameId,
-    })
-    this.socket.emit("start_offline_dashboard", filepath)
+    });
+    this.socket.emit("start_offline_dashboard", filepath);
     this.refs.forEach((ref) => {
       if (ref instanceof LiveObjects) {
         ref.setState({
           objects: [],
           modelMetrics: null,
           offline: true,
-        })
+        });
       }
-    })
+    });
   }
 
   handleMaxFrames(maxFrames) {
-    this.maxOfflineFrames = maxFrames
-    console.log("max frames:", maxFrames)
+    this.maxOfflineFrames = maxFrames;
+    console.log("max frames:", maxFrames);
   }
 
   offlineLabelProp(srcFrame, curFrame) {
     // Get src frame's objects
-    let srcObjects = this.offlineObjects[srcFrame]
+    let srcObjects = this.offlineObjects[srcFrame];
     let props = {
       filepath: this.filepath,
       srcFrame,
-      curFrame, 
+      curFrame,
       objects: srcObjects,
-    }
+    };
 
     // Send objs and id to backend
-    this.socket.emit("offline_label_propagation", props)
+    this.socket.emit("offline_label_propagation", props);
   }
 
   previousFrame() {
     if (this.frameId === 0) {
-      console.log("no frames under 0")
-      return
+      console.log("no frames under 0");
+      return;
     }
-    this.frameId--
-    console.log("Prev frame", this.frameId)
+    this.frameId--;
+    console.log("Prev frame", this.frameId);
     this.socket.emit("get_offline_frame", {
-      filepath: this.filepath, 
-      frameId: this.frameId
-    })
+      filepath: this.filepath,
+      frameId: this.frameId,
+    });
     // Get objects
-    this.curFeedState.objects = this.offlineObjects[this.frameId] || []
+    this.curFeedState.objects = this.offlineObjects[this.frameId] || [];
     this.refs.forEach((ref) => {
       if (ref instanceof LiveObjects) {
         ref.setState({
           objects: this.curFeedState.objects,
         });
       }
-    })
+    });
 
     // Run label prop
-    let curFrameHasObjects = this.offlineObjects[this.frameId] && this.offlineObjects[this.frameId].length > 0
+    let curFrameHasObjects =
+      this.offlineObjects[this.frameId] &&
+      this.offlineObjects[this.frameId].length > 0;
     if (this.offlineObjects[this.frameId + 1] && !curFrameHasObjects) {
-      this.offlineLabelProp(this.frameId + 1, this.frameId)
+      this.offlineLabelProp(this.frameId + 1, this.frameId);
     }
   }
 
   nextFrame() {
     if (this.frameId === this.maxOfflineFrames) {
-      console.log("no frames over", this.maxOfflineFrames)
-      return
+      console.log("no frames over", this.maxOfflineFrames);
+      return;
     }
-    this.frameId++
-    console.log("Next frame", this.frameId)
+    this.frameId++;
+    console.log("Next frame", this.frameId);
     this.socket.emit("get_offline_frame", {
-      filepath: this.filepath, 
-      frameId: this.frameId
-    })
-    this.curFeedState.objects = this.offlineObjects[this.frameId] || []
+      filepath: this.filepath,
+      frameId: this.frameId,
+    });
+    this.curFeedState.objects = this.offlineObjects[this.frameId] || [];
     this.refs.forEach((ref) => {
       if (ref instanceof LiveObjects) {
         ref.setState({
           objects: this.curFeedState.objects,
         });
       }
-    })
+    });
 
     // Run label prop
-    let curFrameHasObjects = this.offlineObjects[this.frameId] && this.offlineObjects[this.frameId].length > 0
+    let curFrameHasObjects =
+      this.offlineObjects[this.frameId] &&
+      this.offlineObjects[this.frameId].length > 0;
     if (this.offlineObjects[this.frameId - 1] && !curFrameHasObjects) {
-      this.offlineLabelProp(this.frameId - 1, this.frameId)
+      this.offlineLabelProp(this.frameId - 1, this.frameId);
     }
   }
 
@@ -906,10 +924,10 @@ class StateManager {
           });
         }
       });
-    } 
+    }
     if (this.updateObjects[0]) {
       // Current frame is when rgb changes. This is needed to ensure correctness
-      this.updateObjects[1] = true 
+      this.updateObjects[1] = true;
     }
     if (this.checkRunLabelProp()) {
       this.startLabelPropagation();

--- a/droidlet/dashboard/web/src/components/Interact/InteractApp.js
+++ b/droidlet/dashboard/web/src/components/Interact/InteractApp.js
@@ -77,7 +77,7 @@ class InteractApp extends Component {
       this.state.chats[idx]["msg"]
     );
 
-    // then wait 3 seconds for the logical form of last chat and show the Fail page
+    // then wait 3 seconds for the logical form of last chat and show the Fail page (by setting currentView)
     setTimeout(() => {
       this.setState({
         currentView: 2,
@@ -85,10 +85,6 @@ class InteractApp extends Component {
         failidx: idx,
       });
     }, 3000);
-  }
-
-  getLastChatActionDict() {
-    setTimeout();
   }
 
   render() {

--- a/droidlet/dashboard/web/src/components/Interact/InteractApp.js
+++ b/droidlet/dashboard/web/src/components/Interact/InteractApp.js
@@ -13,7 +13,7 @@ class InteractApp extends Component {
     super(props);
     this.initialState = {
       currentView: 1,
-      chatResponse: "",
+      lastChatActionDict: "",
       status: "",
       chats: [{ msg: "", failed: false }],
       failidx: -1,
@@ -71,12 +71,24 @@ class InteractApp extends Component {
   }
 
   goToQuestion(idx) {
-    //change the state to switch view to show Fail page
-    this.setState({
-      currentView: 2,
-      chats: this.state.chats,
-      failidx: idx,
-    });
+    // first send request to retrieve the logic form of last sent command before showing NSP Error annotation page to users
+    this.props.stateManager.socket.emit(
+      "getChatActionDict",
+      this.state.chats[idx]["msg"]
+    );
+
+    // then wait 3 seconds for the logical form of last chat and show the Fail page
+    setTimeout(() => {
+      this.setState({
+        currentView: 2,
+        chats: this.state.chats,
+        failidx: idx,
+      });
+    }, 3000);
+  }
+
+  getLastChatActionDict() {
+    setTimeout();
   }
 
   render() {

--- a/droidlet/dashboard/web/src/components/Interact/Question.js
+++ b/droidlet/dashboard/web/src/components/Interact/Question.js
@@ -182,7 +182,6 @@ class Question extends Component {
     No -> mark as aprsing error.
     */
 
-    // this.state.action_dict = chatResponses[chatMsg];
     if (this.state.action_dict) {
       if ("dialogue_type" in this.state.action_dict) {
         var dialogue_type = this.state.action_dict.dialogue_type;
@@ -262,6 +261,20 @@ class Question extends Component {
         // NOTE: This should never happen ...
         question_word = "did you want me to do nothing ?";
       }
+    } else {
+      //end screen, user can put any additional feedback
+      return (
+        <div>
+          <h3> Thanks for marking this error! </h3>
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={() => this.props.goToMessage()}
+          >
+            Done
+          </Button>
+        </div>
+      );
     }
     return (
       <div className="question">
@@ -298,9 +311,9 @@ class Question extends Component {
   }
 
   componentDidMount() {
-    var chatResponses = this.props.stateManager.memory.chatResponse;
+    var lastChatActionDict = this.props.stateManager.memory.lastChatActionDict;
     var chatMsg = this.props.chats[this.props.failidx].msg;
-    this.setState({ action_dict: chatResponses[chatMsg] });
+    this.setState({ action_dict: lastChatActionDict });
   }
 
   render() {


### PR DESCRIPTION
# Description

This PR changes the command syncing logic of dashboard:

Previously whenever a chat is sent from dashboard to agent, agent will query NLU to get the logical form(LF) of the command and send back to dashboard. This is problematic because it requires an additional query from NLU (just to get the LF of the command, compared to agent stepping itself to parse the chat and get LF)
Now the agent will not send back LF when receive any command from dashboard. Instead dashboard will send request to agent asking for LF of certain chat when user marks errors. The agent will get the logical form from memory (since agent should have already processed that chat and stored the LF in memory by then) instead of querying NLU again.

Fixes: #748 

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.


# Testing

Tested on devfair.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I have verified that all scripts in `tests/scripts` runs on hardware.
