### PR TITLE
Added move finished confirmation message

### DIFF
--- a/droidlet/interpreter/craftassist/tasks.py
+++ b/droidlet/interpreter/craftassist/tasks.py
@@ -226,7 +226,7 @@ class Move(BaseMovementTask):
         if manhat_dist(tuple(agent.pos), self.target) <= self.approx:
             if len(self.replace) > 0:
                 logging.error("Move finished with non-empty replace set: {}".format(self.replace))
-            self.finished = True
+            self.finish(agent)
             return
 
         # get path
@@ -259,6 +259,10 @@ class Move(BaseMovementTask):
                 step_fn = getattr(agent, step_fn_name)
                 step_fn()
                 break
+
+    def finish(self, agent):
+        agent.send_chat("I finished my movement.")
+        self.finished = True
 
     def __repr__(self):
         return "<Move {} ±{}>".format(self.target, self.approx)


### PR DESCRIPTION
# Description

For tasks like build, destory, etc. Agent will send confirmation message like "I finished building this". But for move task the agent will say nothing.

This PR added the feature where the agent will say 'I finished my movement' once the move task is finished.


## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

**Before**

Agent say nothing once move task is completed.

**After**

Agent say 'I finished my movement.' once move task is completed.

# Testing

Tested locally and passed.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I have verified that all scripts in `tests/scripts` runs on hardware.
