### PR TITLE
Disable move verbose if move is a subtask

### DIFF
--- a/droidlet/interpreter/craftassist/tasks.py
+++ b/droidlet/interpreter/craftassist/tasks.py
@@ -14,6 +14,7 @@ from droidlet.lowlevel.minecraft.craftassist_cuberite_utils.block_data import (
     BUILD_INTERCHANGEABLE_PAIRS,
 )
 from droidlet.base_util import npy_to_blocks_list, blocks_list_to_npy, to_block_pos
+from droidlet.dialog.dialogue_task import Say
 from droidlet.shared_data_struct.craftassist_shared_utils import astar, MOBS_BY_ID
 from droidlet.perception.craftassist.heuristic_perception import ground_height
 from droidlet.lowlevel.minecraft.mc_util import manhat_dist, strip_idmeta
@@ -194,7 +195,7 @@ class Move(BaseMovementTask):
             return
         self.target = to_block_pos(np.array(task_data["target"]))
         self.approx = task_data.get("approx", 1)
-        self.verbose = task_data.get("verbose", True)
+        self.verbose = task_data.get("verbose", False)
         self.path = None
         self.replace = set()
         self.last_stepped_time = agent.memory.get_time()
@@ -263,7 +264,7 @@ class Move(BaseMovementTask):
 
     def finish(self, agent):
         if self.verbose:
-            agent.send_chat("I finished my movement.")
+            Say(agent, task_data={"response_options": "I finished my movement."})
         self.finished = True
 
     def __repr__(self):

--- a/droidlet/interpreter/interpreter.py
+++ b/droidlet/interpreter/interpreter.py
@@ -222,7 +222,7 @@ class Interpreter(InterpreterBase):
             if pos is None:
                 raise ErrorWithResponse("I don't understand where you want me to move.")
             pos = self.post_process_loc(pos, self)
-            task_data = {"target": pos, "action_dict": d}
+            task_data = {"target": pos, "action_dict": d, "verbose": True}
             task = Move(agent, task_data)
             return task
 


### PR DESCRIPTION
# Description

This is a complementary PR to #765.

Clearly we can not send a confirmation message for every Move task -- if a move task is a subtask of others (e.g. build, destroy). We shouldn't send msg like 'I finished my movement'.

Fixed this by introducing a verbose flag as we did for Build task. This flag is disabled when a move task is created from a parent task.


## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.


# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I have verified that all scripts in `tests/scripts` runs on hardware.
