### PR TITLE
patch git+git:// in requirements.txt with zip files

### DIFF
--- a/agents/locobot/requirements.txt
+++ b/agents/locobot/requirements.txt
@@ -7,7 +7,7 @@ krovetz
 -f https://dl.fbaipublicfiles.com/detectron2/wheels/cu111/torch1.9/index.html
 detectron2
 face_recognition
-git+git://github.com/waspinator/pycococreator.git@0.2.0
+https://github.com/waspinator/pycococreator/archive/refs/tags/0.2.0.zip
 pycocotools
 
 


### PR DESCRIPTION
Github deprecated unauthenticated `git://` calls, according to: https://github.blog/2021-09-01-improving-git-protocol-security-github/