### PR TITLE
[remote-habitat] improve launch script ordering, to avoid race conditions

### DIFF
--- a/droidlet/lowlevel/locobot/remote/launch_navigation.sh
+++ b/droidlet/lowlevel/locobot/remote/launch_navigation.sh
@@ -1,12 +1,11 @@
 #!/bin/env bash
 set -ex
 
-
 python slam_service.py &
 timeout 10s bash -c "until python check_connected.py slam; do sleep 0.5; done;" || true
 
 python planning_service.py &
 timeout 10s bash -c "until python check_connected.py planner; do sleep 0.5; done;" || true
 
-python navigation_service.py
+python navigation_service.py &
 timeout 10s bash -c "until python check_connected.py navigation; do sleep 0.5; done;" || true

--- a/droidlet/lowlevel/locobot/remote/launch_pyro_habitat.sh
+++ b/droidlet/lowlevel/locobot/remote/launch_pyro_habitat.sh
@@ -27,6 +27,6 @@ echo $ip
 python remote_locobot.py --ip $ip $@ &
 # blocking wait for server to start
 timeout 1m bash -c "until python check_connected.py remotelocobot; do sleep 1; done;" || true
-./launch_navigation.sh &
+./launch_navigation.sh
 
 popd


### PR DESCRIPTION
There could be a race with the implementation of `launch_navigation.sh` in main, because of how it is invoked in `launch_pyro_habitat.sh`

I changed the ordering of invoking background processes to avoid this