### PR TITLE
some error handling in the PutMemory interpreter, minor refactor

### DIFF
--- a/agents/droidlet_agent.py
+++ b/agents/droidlet_agent.py
@@ -244,6 +244,11 @@ class DroidletAgent(BaseAgent):
             # if it's not a whitelisted exception, immediatelly raise upwards,
             # unless you are in some kind of a debug mode
             if self.opts.agent_debug_mode:
+                _, interpreter_mems = self.memory.basic_search(
+                    "SELECT MEMORY FROM Interpreter WHERE finished = 0"
+                )
+                for i in interpreter_mems:
+                    i.finish()
                 return
             else:
                 raise e


### PR DESCRIPTION
# Description
Add some error handling to the PutMemory handler and refactor slightly.   if the logical form is mangled or if there are other errors it should deal with them more gracefully

Fixes # (issue)
not sure if it fixes  https://github.com/facebookresearch/fairo/issues/786, but it was inspired by it.  I was unable to repro

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.


# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I have verified that all scripts in `tests/scripts` runs on hardware.
