### PR TITLE
adjust locobot view pane positions in main pane

### DIFF
--- a/droidlet/dashboard/web/src/components/LocoView.js
+++ b/droidlet/dashboard/web/src/components/LocoView.js
@@ -34,7 +34,7 @@ class LocoView extends React.Component {
         type={"rgb"}
         height={320}
         width={320}
-        offsetH={320 + 80}
+        offsetH={10}
         offsetW={10}
         stateManager={stateManager}
         />
@@ -42,21 +42,21 @@ class LocoView extends React.Component {
         type={"depth"}
         height={320}
         width={320}
-        offsetH={320 + 80}
+        offsetH={10}
         offsetW={10 + 320 + 10}
         stateManager={stateManager}
         />
         <LiveObjects
         height={320}
         width={320}
-        offsetH={320 + 60 + 320 + 30}
+        offsetH={10 + 320 + 10}
         offsetW={10}
         stateManager={stateManager}
         />
         <LiveHumans
         height={320}
         width={320}
-        offsetH={320 + 60 + 320 + 30}
+        offsetH={10 + 320 + 10}
         offsetW={10 + 320 + 10}
         stateManager={stateManager}
         />


### PR DESCRIPTION
# Description

A recent update on main changed the way the LocoView component is displayed, pushing the locobot view windows down too low to see in some cases.  This fix adjusts the manual offsets to be reasonable.

## Type of change

Please check the options that are relevant.

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [X] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

**Before - zoomed out as the locobot windows aren't visible otherwise**
<img width="881" alt="Screen Shot 2021-11-05 at 2 39 29 PM" src="https://user-images.githubusercontent.com/42893316/140581673-b087e3c6-c396-4b6d-8898-e58b8ba53ceb.png">

**After**
<img width="605" alt="Screen Shot 2021-11-05 at 2 37 56 PM" src="https://user-images.githubusercontent.com/42893316/140581679-2a8bf7e7-e29e-4be8-8f3a-8e251bfbc3cd.png">

# Checklist:

- [X] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I have verified that all scripts in `tests/scripts` runs on hardware.
