### PR TITLE
Declare dialogue_manager in droidlet_agent before instantiation

### DIFF
--- a/agents/droidlet_agent.py
+++ b/agents/droidlet_agent.py
@@ -31,6 +31,7 @@ class DroidletAgent(BaseAgent):
         logging.info("Agent.__init__ started")
         self.name = name or default_agent_name()
         self.opts = opts
+        self.dialogue_manager = None
         self.init_physical_interfaces()
         super(DroidletAgent, self).__init__(opts, name=self.name)
         self.uncaught_error_count = 0
@@ -41,7 +42,7 @@ class DroidletAgent(BaseAgent):
         self.perceive_on_chat = False
         self.agent_type = None
         self.scheduler = EmptyScheduler()
-        self.dialogue_manager = None
+        
         self.dashboard_memory_dump_time = time.time()
         self.dashboard_memory = {
             "db": {},


### PR DESCRIPTION
# Description

As stated here (https://github.com/facebookresearch/fairo/pull/751#discussion_r735933802) we are explicitly declaring dialogue_manager as a member of DroidletAgent. The declaration is put at the wrong place (after super class init() called which will instantiate the dialogue_manager). Move it to the beginning of __init__() fn to declare it first and then instantiate it should fix the issue.


## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

If this PR introduces a change or fixes a bug, please add before and after screenshots (if this is causes a UX change) or before and after examples(this could be plain text, videos etc ) to demonstrate the change.

If this PR introduces a new feature, please also add examples or screenshots demonstrating the feature.

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I have verified that all scripts in `tests/scripts` runs on hardware.
