### PR TITLE
FBRP clean up life-cycle management

### DIFF
--- a/fbrp/examples/07_rosmsg/frun.py
+++ b/fbrp/examples/07_rosmsg/frun.py
@@ -1,0 +1,18 @@
+import fbrp
+
+fbrp.process(
+    name="proc",
+    runtime=fbrp.Conda(
+        channels=[
+            "conda-forge",
+            "robostack",
+        ],
+        dependencies=[
+            "python>=3.7",
+            "ros-common-msgs",
+        ],
+        run_command=["python", "proc.py"],
+    ),
+)
+
+fbrp.main()

--- a/fbrp/examples/07_rosmsg/fsetup.py
+++ b/fbrp/examples/07_rosmsg/fsetup.py
@@ -1,17 +1,22 @@
 import fbrp
+import glob
+
+genmsg_py_bin = "${CONDA_PREFIX}/lib/genpy/genmsg_py.py"
+msg_files = glob.glob("my_msgs/*.msg")
 
 fbrp.process(
-    name="proc",
+    name="genmsgs",
     runtime=fbrp.Conda(
         channels=[
             "conda-forge",
             "robostack",
         ],
         dependencies=[
-            "python>=3.7",
-            "ros-common-msgs",
+            "ros-noetic-genpy",
         ],
-        run_command=["python", "proc.py"],
+        run_command=f"python {genmsg_py_bin} -p my_msgs -o my_msgs/py "
+        + " ".join(msg_files)
+        + f" ; python {genmsg_py_bin} -p my_msgs -o my_msgs/py --initpy",
     ),
 )
 

--- a/fbrp/examples/07_rosmsg/my_msgs/PsUtil.msg
+++ b/fbrp/examples/07_rosmsg/my_msgs/PsUtil.msg
@@ -1,0 +1,2 @@
+float64 cpu_usage
+float64 mem_usage

--- a/fbrp/examples/07_rosmsg/proc.py
+++ b/fbrp/examples/07_rosmsg/proc.py
@@ -1,8 +1,10 @@
 from geometry_msgs.msg import Point
+from my_msgs.py import PsUtil
 import time
 
 i = 0
 while True:
     print(Point(x=i, y=i ** 2, z=i ** 3))
+    print(PsUtil(cpu_usage=i, mem_usage=i ** 0.5))
     i += 1
     time.sleep(1)

--- a/fbrp/setup.py
+++ b/fbrp/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="fbrp",
-    version="0.0.4",
+    version="0.0.5",
     author="Leonid Shamis",
     package_dir={"": "src"},
     packages=find_packages(
@@ -14,7 +14,7 @@ setup(
     python_requires=">=3.7",
     install_requires=[
         "aiodocker>=0.21.0",
-        "alephzero>=v0.3",
+        "alephzero>=0.3.8",
         "docker>=5.0.0",
         "psutil>=5.8.0",
         "pyyaml>=6.0",

--- a/fbrp/src/fbrp/__init__.py
+++ b/fbrp/src/fbrp/__init__.py
@@ -11,6 +11,7 @@ def main():
     import fbrp.cmd.logs
     import fbrp.cmd.ps
     import fbrp.cmd.up
+    import fbrp.cmd.wait
 
     parser = argparse.ArgumentParser(prog="fbrp")
     parser.add_argument("-v", "--verbose", default=False, action="store_true")

--- a/fbrp/src/fbrp/cmd/down.py
+++ b/fbrp/src/fbrp/cmd/down.py
@@ -18,4 +18,4 @@ class down_cmd:
             procs = set(procs) & set(given_proc_names)
 
         for proc_name in procs:
-            life_cycle.ask(proc_name, life_cycle.Ask.DOWN)
+            life_cycle.set_ask(proc_name, life_cycle.Ask.DOWN)

--- a/fbrp/src/fbrp/cmd/ps.py
+++ b/fbrp/src/fbrp/cmd/ps.py
@@ -1,4 +1,4 @@
-from fbrp import util
+from fbrp import life_cycle
 from fbrp import registrar
 import a0
 import argparse
@@ -13,23 +13,15 @@ class ps_cmd:
 
     @staticmethod
     def exec(args: argparse.Namespace):
-        try:
-            info_json = a0.Cfg("fbrp/state").read().payload
-        except:
+        state = life_cycle.system_state()
+        if not state.procs:
             print("No processes found.")
             return
 
-        procs_info = json.loads(info_json)
-        if all(info["state"] == "STOPPED" for info in procs_info.values()):
-            print("No processes found.")
-            return
+        name_col_width = max(len(name) for name in state.procs)
 
-        suffix_map = {
-            "STARTED": "",
-            "STARTING": " (starting)",
-            "STOPPING": " (stopping)",
-        }
-
-        for proc, info in sorted(procs_info.items()):
-            if info["state"] in suffix_map:
-                print(f"{info['timestamp']}  {proc}{suffix_map[info['state']]}")
+        for name, info in state.procs.items():
+            suffix = ""
+            if info.state == life_cycle.State.STOPPED:
+                suffix = f"(stopped code={info.return_code})"
+            print(name, " " * (name_col_width - len(name)), suffix)

--- a/fbrp/src/fbrp/cmd/up.py
+++ b/fbrp/src/fbrp/cmd/up.py
@@ -1,5 +1,6 @@
-from fbrp import util
+from fbrp import life_cycle
 from fbrp import registrar
+from fbrp import util
 from fbrp.cmd.base import BaseCommand
 import a0
 import argparse
@@ -72,6 +73,7 @@ class up_cmd(BaseCommand):
         if args.run:
             for name in names:
                 print(f"running {name}...")
+                life_cycle.set_ask(name, life_cycle.Ask.UP)
 
                 if os.fork() != 0:
                     continue
@@ -88,5 +90,7 @@ class up_cmd(BaseCommand):
                 # Set up configuration.
                 with util.common_env_context(proc_def):
                     a0.Cfg(a0.env.topic()).write(json.dumps(proc_def.cfg))
+                    life_cycle.set_launcher_running(name, True)
                     asyncio.run(proc_def.runtime._launcher(name, proc_def, args).run())
+                    life_cycle.set_launcher_running(name, False)
                     sys.exit(0)

--- a/fbrp/src/fbrp/cmd/wait.py
+++ b/fbrp/src/fbrp/cmd/wait.py
@@ -4,6 +4,7 @@ from fbrp import life_cycle
 from fbrp import registrar
 import argparse
 import threading
+import types
 
 
 @registrar.register_command("wait")
@@ -11,6 +12,7 @@ class wait_cmd:
     @classmethod
     def define_argparse(cls, parser: argparse.ArgumentParser):
         parser.add_argument("proc", action="append", nargs="*")
+        parser.add_argument("-t", "--timeout", action="store", type=float, default=0)
 
     @staticmethod
     def exec(args: argparse.Namespace):
@@ -20,10 +22,7 @@ class wait_cmd:
         if given_proc_names:
             procs = set(procs) & set(given_proc_names)
 
-        class Namespace:
-            pass
-
-        ns = Namespace()
+        ns = types.SimpleNamespace()
         ns.cv = threading.Condition()
         ns.sat = False
 
@@ -38,4 +37,4 @@ class wait_cmd:
         watcher = life_cycle.system_state_watcher(callback)
 
         with ns.cv:
-            ns.cv.wait_for(lambda: ns.sat)
+            ns.cv.wait_for(lambda: ns.sat, timeout=args.timeout or None)

--- a/fbrp/src/fbrp/cmd/wait.py
+++ b/fbrp/src/fbrp/cmd/wait.py
@@ -1,0 +1,41 @@
+from gc import callbacks
+import a0
+from fbrp import life_cycle
+from fbrp import registrar
+import argparse
+import threading
+
+
+@registrar.register_command("wait")
+class wait_cmd:
+    @classmethod
+    def define_argparse(cls, parser: argparse.ArgumentParser):
+        parser.add_argument("proc", action="append", nargs="*")
+
+    @staticmethod
+    def exec(args: argparse.Namespace):
+        procs = life_cycle.system_state().procs.keys()
+
+        given_proc_names = args.proc[0]
+        if given_proc_names:
+            procs = set(procs) & set(given_proc_names)
+
+        class Namespace:
+            pass
+
+        ns = Namespace()
+        ns.cv = threading.Condition()
+        ns.sat = False
+
+        def callback(sys_state):
+            for proc, info in sys_state.procs.items():
+                if proc in procs and info.state != life_cycle.State.STOPPED:
+                    return
+            with ns.cv:
+                ns.sat = True
+                ns.cv.notify()
+
+        watcher = life_cycle.system_state_watcher(callback)
+
+        with ns.cv:
+            ns.cv.wait_for(lambda: ns.sat)

--- a/fbrp/src/fbrp/life_cycle.py
+++ b/fbrp/src/fbrp/life_cycle.py
@@ -1,0 +1,53 @@
+import threading
+from fbrp import util
+import a0
+import dataclasses
+import enum
+import json
+import typing
+
+
+def from_dict(cls, obj):
+    if isinstance(obj, (tuple, list)):
+        return [from_dict(cls.__args__[0], f) for f in obj]
+    return cls(**{k: from_dict(cls.__annotations__[k], v) for k, v in obj.items()})
+
+
+@dataclasses.dataclass
+class ProcInfo:
+    class Ask(enum.Enum):
+        UP = "UP"
+        DOWN = "DOWN"
+
+    class State(enum.Enum):
+        STARTING = "STARTING"
+        STARTED = "STARTED"
+        STOPPING = "STOPPING"
+        STOPPED = "STOPPED"
+
+    ask: Ask
+    state: State
+    return_code: int
+    launcher_running: bool
+
+
+@dataclasses.dataclass
+class SystemState:
+    procs: typing.Mapping[str, ProcInfo]
+
+
+def system_state() -> SystemState:
+    return from_dict(SystemState, json.loads(a0.Cfg("fbrp/state").read().payload))
+
+
+def system_state_watcher(callback) -> a0.CfgWatcher:
+    def callback_wrapper(pkt):
+        callback(from_dict(SystemState, json.loads(pkt.payload)))
+
+    return a0.CfgWatcher("fbrp/state", callback_wrapper)
+
+
+def ask(proc_name, ask_):
+    a0.Cfg("fbrp/state").mergepatch({proc_name: {"ask": ask_}})
+    with util.common_env_context(proc_name):
+        a0.Publisher(f"fbrp/control/{proc_name}").pub(json.dumps({"ask": ask_}))

--- a/fbrp/src/fbrp/life_cycle.py
+++ b/fbrp/src/fbrp/life_cycle.py
@@ -5,49 +5,124 @@ import dataclasses
 import enum
 import json
 import typing
+import types
+
+_TOPIC = "fbrp/state"
+_CFG = a0.Cfg(_TOPIC)
 
 
-def from_dict(cls, obj):
-    if isinstance(obj, (tuple, list)):
-        return [from_dict(cls.__args__[0], f) for f in obj]
-    return cls(**{k: from_dict(cls.__annotations__[k], v) for k, v in obj.items()})
+class Ask(enum.Enum):
+    NONE = "NONE"
+    UP = "UP"
+    DOWN = "DOWN"
 
 
-@dataclasses.dataclass
+class State(enum.Enum):
+    UNKNOWN = "UNKNOWN"
+    STARTING = "STARTING"
+    STARTED = "STARTED"
+    STOPPING = "STOPPING"
+    STOPPED = "STOPPED"
+
+
+@dataclasses.dataclass(frozen=True)
 class ProcInfo:
-    class Ask(enum.Enum):
-        UP = "UP"
-        DOWN = "DOWN"
-
-    class State(enum.Enum):
-        STARTING = "STARTING"
-        STARTED = "STARTED"
-        STOPPING = "STOPPING"
-        STOPPED = "STOPPED"
-
     ask: Ask
     state: State
     return_code: int
     launcher_running: bool
+
+    def asdict(self):
+        return dict(
+            ask=self.ask.value,
+            state=self.state.value,
+            return_code=self.return_code,
+            launcher_running=self.launcher_running,
+        )
+
+    @classmethod
+    def fromdict(cls, dict_):
+        return cls(
+            ask=Ask(dict_.get("ask", Ask.NONE)),
+            state=State(dict_.get("state", State.UNKNOWN)),
+            return_code=dict_.get("return_code", 0),
+            launcher_running=dict_.get("launcher_running", False),
+        )
 
 
 @dataclasses.dataclass
 class SystemState:
     procs: typing.Mapping[str, ProcInfo]
 
+    def asdict(self):
+        return {"procs": {k: v.asdict() for k, v in self.procs.items()}}
+
+    @classmethod
+    def fromdict(cls, dict_):
+        return SystemState(
+            procs={k: ProcInfo.fromdict(v) for k, v in dict_.get("procs", {}).items()}
+        )
+
+
+def _ensure_setup() -> None:
+    _CFG.write_if_empty(json.dumps(SystemState(procs={}).asdict()))
+
 
 def system_state() -> SystemState:
-    return from_dict(SystemState, json.loads(a0.Cfg("fbrp/state").read().payload))
+    _ensure_setup()
+    return SystemState.fromdict(json.loads(_CFG.read().payload))
+
+
+def proc_info(proc_name) -> ProcInfo:
+    return system_state().procs[proc_name]
 
 
 def system_state_watcher(callback) -> a0.CfgWatcher:
+    _ensure_setup()
+
     def callback_wrapper(pkt):
-        callback(from_dict(SystemState, json.loads(pkt.payload)))
+        callback(SystemState.fromdict(json.loads(pkt.payload)))
 
-    return a0.CfgWatcher("fbrp/state", callback_wrapper)
+    return a0.CfgWatcher(_TOPIC, callback_wrapper)
 
 
-def ask(proc_name, ask_):
-    a0.Cfg("fbrp/state").mergepatch({proc_name: {"ask": ask_}})
-    with util.common_env_context(proc_name):
-        a0.Publisher(f"fbrp/control/{proc_name}").pub(json.dumps({"ask": ask_}))
+async def aio_system_state_watcher():
+    _ensure_setup()
+    async for pkt in a0.aio_cfg(_TOPIC):
+        yield SystemState.fromdict(json.loads(pkt.payload))
+
+
+def proc_info_watcher(proc_name, callback) -> a0.CfgWatcher:
+    ns = types.SimpleNamespace()
+    ns.last_proc_info = None
+
+    def callback_wrapper(system_state):
+        if ns.last_proc_info != system_state.procs.get(proc_name):
+            ns.last_proc_info = system_state.procs[proc_name]
+            callback(system_state.procs[proc_name])
+
+    return system_state_watcher(callback_wrapper)
+
+
+async def aio_proc_info_watcher(proc_name):
+    ns = types.SimpleNamespace()
+    ns.last_proc_info = None
+
+    async for system_state in aio_system_state_watcher():
+        if ns.last_proc_info != system_state.procs.get(proc_name):
+            ns.last_proc_info = system_state.procs[proc_name]
+            yield system_state.procs[proc_name]
+
+
+def set_ask(proc_name, ask):
+    _CFG.mergepatch({"procs": {proc_name: {"ask": ask.value}}})
+
+
+def set_state(proc_name, state, return_code=0):
+    _CFG.mergepatch(
+        {"procs": {proc_name: {"state": state.value, "return_code": return_code}}}
+    )
+
+
+def set_launcher_running(proc_name, launcher_running):
+    _CFG.mergepatch({"procs": {proc_name: {"launcher_running": launcher_running}}})

--- a/fbrp/src/fbrp/runtime/base.py
+++ b/fbrp/src/fbrp/runtime/base.py
@@ -1,10 +1,10 @@
 import asyncio
+from fbrp import life_cycle
 from fbrp.process import ProcDef
 import a0
 import argparse
 import asyncio
 import contextlib
-import enum
 import psutil
 import json
 
@@ -16,48 +16,29 @@ class BaseLauncher:
     async def run(self, name: str, proc_def: ProcDef, args: argparse.Namespace):
         raise NotImplementedError("Launcher hasn't implemented run!")
 
-    class State(enum.Enum):
-        STARTING = "STARTING"
-        STARTED = "STARTED"
-        STOPPING = "STOPPING"
-        STOPPED = "STOPPED"
-
-    def set_state(self, state: State):
-        a0.Cfg("fbrp/state").mergepatch(
-            {self.name: {"state": state.value, "timestamp": str(a0.TimeWall.now())}}
-        )
-
     def get_pid(self):
         raise NotImplementedError("Launcher hasn't implemented get_pid!")
 
-    def get_down_event(self):
-        if not hasattr(self, "_down_requested_event"):
-            self._down_requested_event = asyncio.Event()
-        return self._down_requested_event
-
-    async def command_handler(self):
-        async for pkt in a0.aio_sub(
-            f"fbrp/control/{self.name}", a0.INIT_AWAIT_NEW, a0.ITER_NEXT
-        ):
-            try:
-                cmd = json.loads(pkt.payload)
-                kwargs = cmd.get("kwargs", {})
-                if cmd["action"] == "down":
-                    self.get_down_event().set()
-                    await self.handle_down(**kwargs)
-            except:
-                pass
-
-    async def handle_down(self):
-        raise NotImplementedError("Launcher hasn't implemented handle_down!")
+    async def down_watcher(self, ondown):
+        async for proc_info in life_cycle.aio_proc_info_watcher(self.name):
+            if proc_info.ask == life_cycle.Ask.DOWN:
+                await ondown()
+                break
 
     async def log_psutil(self):
+        down_requested_event = asyncio.Event()
+
+        async def ondown():
+            down_requested_event.set()
+
+        asyncio.ensure_future(self.down_watcher(ondown))
+
         out = a0.Publisher(f"fbrp/psutil/{self.name}")
         while True:
             with contextlib.suppress(asyncio.TimeoutError):
                 # TODO(lshamis): Make polling interval configurable.
-                await asyncio.wait_for(self.get_down_event().wait(), 1.0)
-            if self.get_down_event().is_set():
+                await asyncio.wait_for(down_requested_event.wait(), 1.0)
+            if down_requested_event.is_set():
                 break
             pid = self.get_pid()
             if not pid:

--- a/fbrp/src/fbrp/runtime/docker.py
+++ b/fbrp/src/fbrp/runtime/docker.py
@@ -87,10 +87,10 @@ class Launcher(BaseLauncher):
 
         self.proc = await docker.containers.create_or_replace(container, run_kwargs)
         await self.proc.start()
-        life_cycle.set_state(self.name, life_cycle.State.STARTED)
 
         proc_info = await self.proc.show()
         self.proc_pid = proc_info["State"]["Pid"]
+        life_cycle.set_state(self.name, life_cycle.State.STARTED)
 
         async def log_pipe(logger, pipe):
             async for line in pipe:

--- a/fbrp/src/fbrp/runtime/docker.py
+++ b/fbrp/src/fbrp/runtime/docker.py
@@ -1,3 +1,4 @@
+from fbrp import life_cycle
 from fbrp import util
 from fbrp.runtime.base import BaseLauncher, BaseRuntime
 from fbrp.process import ProcDef
@@ -33,7 +34,7 @@ class Launcher(BaseLauncher):
         self.kwargs = kwargs
 
     async def run(self):
-        self.set_state(BaseLauncher.State.STARTING)
+        life_cycle.set_state(self.name, life_cycle.State.STARTING)
         docker = aiodocker.Docker()
 
         container = f"fbrp_{self.name}"
@@ -86,7 +87,7 @@ class Launcher(BaseLauncher):
 
         self.proc = await docker.containers.create_or_replace(container, run_kwargs)
         await self.proc.start()
-        self.set_state(BaseLauncher.State.STARTED)
+        life_cycle.set_state(self.name, life_cycle.State.STARTED)
 
         proc_info = await self.proc.show()
         self.proc_pid = proc_info["State"]["Pid"]
@@ -100,25 +101,26 @@ class Launcher(BaseLauncher):
             log_pipe(util.stderr_logger(), self.proc.log(stderr=True, follow=True)),
             self.log_psutil(),
             self.death_handler(),
-            self.command_handler(),
+            self.down_watcher(self.handle_down),
         )
+        await docker.close()
 
     def get_pid(self):
         return self.proc_pid
 
     async def death_handler(self):
-        await self.proc.wait()
-        self.set_state(BaseLauncher.State.STOPPED)
+        result = await self.proc.wait()
+        life_cycle.set_state(
+            self.name, life_cycle.State.STOPPED, return_code=result["StatusCode"]
+        )
         # TODO(lshamis): Restart policy goes here.
 
     async def handle_down(self):
-        self.set_state(BaseLauncher.State.STOPPING)
+        life_cycle.set_state(self.name, life_cycle.State.STOPPING)
         await self.proc.stop()
         with contextlib.suppress(asyncio.TimeoutError):
             await self.proc.wait(timeout=3.0)
         await self.proc.delete(force=True)
-        self.set_state(BaseLauncher.State.STOPPED)
-        sys.exit(0)
 
 
 class Docker(BaseRuntime):

--- a/fbrp/src/fbrp/util.py
+++ b/fbrp/src/fbrp/util.py
@@ -14,18 +14,18 @@ def fail(msg):
     sys.exit(1)
 
 
-def common_env(proc_name):
+def common_env(proc_def):
     return dict(
-        FBRP_NAME=proc_name,
-        A0_TOPIC=proc_name,
+        FBRP_NAME=proc_def.name,
+        A0_TOPIC=proc_def.name,
         PYTHONUNBUFFERED="1",
     )
 
 
 @contextlib.contextmanager
-def common_env_context(proc_name):
+def common_env_context(proc_def):
     old_environ = dict(os.environ)
-    os.environ.update(common_env(proc_name))
+    os.environ.update(common_env(proc_def))
     try:
         yield
     finally:
@@ -79,35 +79,3 @@ def nfs_root(path):
 
 def random_string(alphabet=string.ascii_lowercase, length=16):
     return "".join(random.choices(alphabet, k=length))
-
-
-
-
-
-
-
-
-# import subprocess
-
-# proc = subprocess.run("""
-# echo cat
-# export foo=bar
-# echo dog
-# export PATH=$PATH:/foo=bar
-# echo fbrp_export_env
-# env
-# """, shell=True, cwd="/tmp", env={}, stdout=subprocess.PIPE, executable='/bin/bash')
-
-# lines = proc.stdout.decode().split("\n")
-# lines = lines[lines.index("fbrp_export_env") + 1:-1]
-
-# proc_env = dict([kv.split("=", 1) for kv in lines])
-
-
-# proc2 = subprocess.run("""
-# env
-# """, shell=True, cwd="/dev/shm", env=proc_env, stdout=subprocess.PIPE, executable='/bin/bash')
-
-# proc2_env = dict([kv.split("=", 1) for kv in proc2.stdout.decode().split("\n")[:-1]])
-
-# print(proc2_env)

--- a/fbrp/src/fbrp/util.py
+++ b/fbrp/src/fbrp/util.py
@@ -14,18 +14,18 @@ def fail(msg):
     sys.exit(1)
 
 
-def common_env(proc_def):
+def common_env(proc_name):
     return dict(
-        FBRP_NAME=proc_def.name,
-        A0_TOPIC=proc_def.name,
+        FBRP_NAME=proc_name,
+        A0_TOPIC=proc_name,
         PYTHONUNBUFFERED="1",
     )
 
 
 @contextlib.contextmanager
-def common_env_context(proc_def):
+def common_env_context(proc_name):
     old_environ = dict(os.environ)
-    os.environ.update(common_env(proc_def))
+    os.environ.update(common_env(proc_name))
     try:
         yield
     finally:
@@ -79,3 +79,35 @@ def nfs_root(path):
 
 def random_string(alphabet=string.ascii_lowercase, length=16):
     return "".join(random.choices(alphabet, k=length))
+
+
+
+
+
+
+
+
+# import subprocess
+
+# proc = subprocess.run("""
+# echo cat
+# export foo=bar
+# echo dog
+# export PATH=$PATH:/foo=bar
+# echo fbrp_export_env
+# env
+# """, shell=True, cwd="/tmp", env={}, stdout=subprocess.PIPE, executable='/bin/bash')
+
+# lines = proc.stdout.decode().split("\n")
+# lines = lines[lines.index("fbrp_export_env") + 1:-1]
+
+# proc_env = dict([kv.split("=", 1) for kv in lines])
+
+
+# proc2 = subprocess.run("""
+# env
+# """, shell=True, cwd="/dev/shm", env=proc_env, stdout=subprocess.PIPE, executable='/bin/bash')
+
+# proc2_env = dict([kv.split("=", 1) for kv in proc2.stdout.decode().split("\n")[:-1]])
+
+# print(proc2_env)


### PR DESCRIPTION
# Description

Added `fbrp/life_cycle.py` to centralize, manage, and track state throughout FBRP.
FBRP commands have been cleaned up to use the life_cycle tool.
A new `wait` command is added to block the terminal until processes complete.

An example has been added `07_rosmsg` that generates python ros messages in a phase prior to primary execution. To run:
```
python examples/07_rosmsg/fsetup.py -v up
python examples/07_rosmsg/fsetup.py wait
python examples/07_rosmsg/frun.py -v up
python examples/07_rosmsg/frun.py logs
```

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [x] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

...

# Testing

Ran all the examples.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I have verified that all scripts in `tests/scripts` runs on hardware.
