### PR TITLE
fbrp x11 example

### DIFF
--- a/fbrp/examples/08_x11/Dockerfile
+++ b/fbrp/examples/08_x11/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:focal
+
+RUN apt update && \
+    apt install -y \
+        x11-apps && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["xclock"]

--- a/fbrp/examples/08_x11/fsetup.py
+++ b/fbrp/examples/08_x11/fsetup.py
@@ -1,0 +1,15 @@
+import fbrp
+import os
+
+fbrp.process(
+    name="proc",
+    runtime=fbrp.Docker(
+        dockerfile="./Dockerfile",
+        mount=["/tmp/.X11-unix:/tmp/.X11-unix"],
+        run_kwargs = {
+            "Env": [f"DISPLAY={os.environ['DISPLAY']}"],
+        }
+    ),
+)
+
+fbrp.main()

--- a/fbrp/src/fbrp/runtime/docker.py
+++ b/fbrp/src/fbrp/runtime/docker.py
@@ -41,7 +41,12 @@ class Launcher(BaseLauncher):
 
         # Environmental variables.
         env = util.common_env(self.proc_def)
-        env.update(self.kwargs.pop("Env", {}))
+        for kv in self.kwargs.pop("Env", []):
+            if "=" in kv:
+                k, v = kv.split("=", 1)
+                env[k] = v
+            else:
+                del env[kv]
 
         # Docker labels.
         labels = {
@@ -124,13 +129,14 @@ class Launcher(BaseLauncher):
 
 
 class Docker(BaseRuntime):
-    def __init__(self, image=None, dockerfile=None, mount=[], **kwargs):
+    def __init__(self, image=None, dockerfile=None, mount=[], build_kwargs={}, run_kwargs={}):
         if bool(image) == bool(dockerfile):
             util.fail("Docker process must define exactly one of image or dockerfile")
         self.image = image
         self.dockerfile = dockerfile
         self.mount = mount
-        self.kwargs = kwargs
+        self.build_kwargs = build_kwargs
+        self.run_kwargs = run_kwargs
 
     def _build(self, name: str, proc_def: ProcDef, args: argparse.Namespace):
         docker_api = docker.from_env()
@@ -149,7 +155,7 @@ class Docker(BaseRuntime):
                 "dockerfile": dockerfile_path,
                 "rm": True,
             }
-            build_kwargs.update(self.kwargs)
+            build_kwargs.update(self.build_kwargs)
 
             for line in docker_api.lowlevel.build(**build_kwargs):
                 lineinfo = json.loads(line.decode())
@@ -238,4 +244,4 @@ class Docker(BaseRuntime):
             ]
 
     def _launcher(self, name: str, proc_def: ProcDef, args: argparse.Namespace):
-        return Launcher(self.image, self.mount, name, proc_def, args, **self.kwargs)
+        return Launcher(self.image, self.mount, name, proc_def, args, **self.run_kwargs)


### PR DESCRIPTION
# Description

Add an example of running an X application in docker.
This requires mounting the X domain socket and setting the DISPLAY Env.

Maybe we can add a flag to do this automatically in the future?

In testing this, we found it best to split the build and run kwargs for docker.
Also, docker engine wants Env to be a list of string.
https://docs.docker.com/engine/api/v1.41/#operation/ContainerCreate
```
list of environment variables to set inside the container in the form ["VAR=value", ...]. A variable without = is removed from the environment, rather than to have an empty value.
```

Fixes # (issue)

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

...

# Testing

```
python3 examples/08_x11/fsetup.py -v up
```

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I have verified that all scripts in `tests/scripts` runs on hardware.
