### PR TITLE
[fbrp] add support for docker nvidia-runtime feature glxgear example

### DIFF
--- a/fbrp/examples/08_x11_env_vars/Dockerfile.opengl
+++ b/fbrp/examples/08_x11_env_vars/Dockerfile.opengl
@@ -1,0 +1,23 @@
+FROM ubuntu:focal
+
+# app : glxgears
+RUN apt update && \
+    apt install -y \
+        mesa-utils && \
+    rm -rf /var/lib/apt/lists/*
+
+# necessary opengl libraries
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      libglvnd0 \
+      libgl1 \
+      libglx0 \
+      libegl1 \
+      libgles2 && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV NVIDIA_VISIBLE_DEVICES \
+    ${NVIDIA_VISIBLE_DEVICES:-all}
+ENV NVIDIA_DRIVER_CAPABILITIES \
+    ${NVIDIA_DRIVER_CAPABILITIES:-all}
+
+CMD ["glxgears"]

--- a/fbrp/examples/08_x11_env_vars/fsetup.py
+++ b/fbrp/examples/08_x11_env_vars/fsetup.py
@@ -14,7 +14,7 @@ fbrp.process(
 )
 
 fbrp.process(
-    name="docker_proc",
+    name="docker_x11_proc",
     runtime=fbrp.Docker(
         dockerfile="./Dockerfile",
         mount=["/tmp/.X11-unix:/tmp/.X11-unix"],
@@ -26,6 +26,20 @@ fbrp.process(
         "my_docker_path" : "/tmp/",
         "my_docker_time_out" : "2",
     },
+)
+
+fbrp.process(
+    name="docker_opengl_proc",
+    runtime=fbrp.Docker(
+        dockerfile="./Dockerfile.opengl",
+        mount=["/tmp/.X11-unix:/tmp/.X11-unix"],
+        run_kwargs = {
+            "Env": [f"DISPLAY={os.getenv('DISPLAY')}"],
+            "HostConfig": {
+                "Runtime": "nvidia" #  default "runc"
+            }
+        }
+    )
 )
 
 fbrp.main()

--- a/fbrp/src/fbrp/runtime/docker.py
+++ b/fbrp/src/fbrp/runtime/docker.py
@@ -89,7 +89,7 @@ class Launcher(BaseLauncher):
                 "GroupAdd": [str(i) for i in os.getgroups()],
             },
         }
-        run_kwargs.update(self.kwargs)
+        util.nested_dict_update(run_kwargs, self.kwargs)
 
         self.proc = await docker.containers.create_or_replace(container, run_kwargs)
         await self.proc.start()

--- a/fbrp/src/fbrp/util.py
+++ b/fbrp/src/fbrp/util.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 import string
 import random
+import collections.abc
 
 
 def fail(msg):
@@ -79,3 +80,13 @@ def nfs_root(path):
 
 def random_string(alphabet=string.ascii_lowercase, length=16):
     return "".join(random.choices(alphabet, k=length))
+
+
+# https://stackoverflow.com/questions/3232943/update-value-of-a-nested-dictionary-of-varying-depth
+def nested_dict_update(d, u):
+    for k, v in u.items():
+        if isinstance(v, collections.abc.Mapping):
+            d[k] = nested_dict_update(d.get(k, {}), v)
+        else:
+            d[k] = v
+    return d


### PR DESCRIPTION
# Description
Some of the fbrp containers may need GPU support for computation or display purpose.
Here we provide an example running glxgears (from mesa-utils).

In summary, to run open application in docker:
* docker container needs to install libGL designed to work with drivers
* use nvidia container runtime if your GPU is nvidia

Expected result
![x11_and_glxgears](https://user-images.githubusercontent.com/13663916/142400181-20d23444-c577-4a6a-930e-9def47789669.png)

Reference
https://github.com/koenlek/docker_ros_nvidia/blob/master/patch-opengl-u1804.dockerfile

## Type of change



Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

If this PR introduces a change or fixes a bug, please add before and after screenshots (if this is causes a UX change) or before and after examples(this could be plain text, videos etc ) to demonstrate the change.

If this PR introduces a new feature, please also add examples or screenshots demonstrating the feature.

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I have verified that all scripts in `tests/scripts` runs on hardware.
