### PR TITLE
Adding unit tests for CondaEnv and conda Launcher.

### DIFF
--- a/fbrp/src/fbrp/runtime/conda.py
+++ b/fbrp/src/fbrp/runtime/conda.py
@@ -76,9 +76,7 @@ class Launcher(BaseLauncher):
         self.proc_def = proc_def
         self.args = args
 
-    async def run(self):
-        life_cycle.set_state(self.name, life_cycle.State.STARTING)
-
+    async def activate_conda_env(self):
         # We grab the conda env variables separate from executing the run
         # command to simplify detecting pid and removing some race conditions.
         subprocess_env = os.environ.copy()
@@ -98,7 +96,10 @@ class Launcher(BaseLauncher):
         await envinfo.wait()
         lines = open(f"/tmp/fbrp_conda_{self.name}.env").read().split("\0")
         conda_env = dict(line.split("=", 1) for line in lines if "=" in line)
+        return conda_env
 
+
+    async def conda_run(self, conda_env):
         cmd = self.run_command
         if type(self.run_command) == list:
             cmd = shlex.join(self.run_command)
@@ -111,8 +112,9 @@ class Launcher(BaseLauncher):
             cwd=self.proc_def.root,
             env=conda_env,
         )
-        life_cycle.set_state(self.name, life_cycle.State.STARTED)
 
+
+    async def conda_gather(self):
         async def log_pipe(logger, pipe):
             while True:
                 line = await pipe.readline()
@@ -128,6 +130,15 @@ class Launcher(BaseLauncher):
             self.death_handler(),
             self.down_watcher(self.handle_down),
         )
+
+
+    async def run(self):
+        life_cycle.set_state(self.name, life_cycle.State.STARTING)
+        conda_env = await self.activate_conda_env()
+        await self.conda_run(conda_env)
+        life_cycle.set_state(self.name, life_cycle.State.STARTED)
+        await self.conda_gather()
+
 
     def get_pid(self):
         return self.proc.pid

--- a/fbrp/tests/fbrp/runtime/test_base.py
+++ b/fbrp/tests/fbrp/runtime/test_base.py
@@ -25,7 +25,6 @@ def async_return(result):
 
 
 class TestBaseLauncher(IsolatedAsyncioTestCase):
-
     @patch("argparse.Namespace")
     async def test_run(self, mock_namespace):
         mock_proc_def = Mock(spec=ProcDef(None, None, None, None, None, None, None))
@@ -33,12 +32,10 @@ class TestBaseLauncher(IsolatedAsyncioTestCase):
         with self.assertRaises(NotImplementedError):
             await base_launcher.run('', mock_proc_def, mock_namespace)
 
-
     def test_get_pid(self):
         base_launcher = BaseLauncher()
         with self.assertRaises(NotImplementedError):
             base_launcher.get_pid()
-
 
     @patch("fbrp.life_cycle.aio_proc_info_watcher")
     async def test_down_watcher_1(self, mock_proc_info_watcher):

--- a/fbrp/tests/fbrp/runtime/test_conda.py
+++ b/fbrp/tests/fbrp/runtime/test_conda.py
@@ -1,0 +1,83 @@
+import asyncio
+import os
+import unittest
+
+from fbrp.life_cycle import State
+from fbrp.process import ProcDef
+from fbrp.runtime.conda import CondaEnv, Launcher
+
+from unittest import IsolatedAsyncioTestCase
+from unittest import mock
+from unittest.mock import call, patch, mock_open
+
+
+class TestCondaEnv(unittest.TestCase):
+
+    def test_merge_and_fix_pip_1(self):
+        a = CondaEnv(channels=["conda-forge", "robostack", "pytorch"], dependencies=["ros-noetic-genpy"])
+        b = CondaEnv(channels=["pytorch", "nvidia"], dependencies=["pytorch", "numpy", "dataclasses"])
+        c = CondaEnv.merge(a, b)
+        self.assertTrue(len(c.channels) == 4)
+        self.assertListEqual(c.channels, sorted(["conda-forge", "robostack", "pytorch", "nvidia"]))
+        self.assertTrue(len(c.dependencies) == 4)
+        self.assertListEqual(c.dependencies, sorted(["pytorch", "ros-noetic-genpy", "numpy", "dataclasses"]))
+        self.assertFalse("pip" in c.dependencies)
+        c.fix_pip()
+        self.assertFalse("pip" in c.dependencies)
+
+
+    def test_merge_and_fix_pip_2(self):
+        a = CondaEnv(channels=["conda-forge", "robostack", "pytorch"], 
+                     dependencies=["ros-noetic-genpy", {"pip" : ["scipy", "cuda110", "pytorch"]}])
+        b = CondaEnv(channels=["pytorch", "nvidia"], dependencies=["pytorch", "numpy", "dataclasses"])
+        c = CondaEnv.merge(a, b)
+        self.assertTrue(len(c.channels) == 4)
+        self.assertListEqual(c.channels, sorted(["conda-forge", "robostack", "pytorch", "nvidia"]))
+        self.assertTrue(len(c.dependencies) == 5)
+        ref_deps = sorted(["pytorch", "ros-noetic-genpy", "numpy", "dataclasses"])
+        list_deps = []
+        for dep in c.dependencies:
+            if type(dep) == dict:
+                self.assertListEqual(sorted(dep["pip"]), sorted(["scipy", "cuda110", "pytorch"]))
+            else:
+                self.assertTrue(dep in ref_deps)
+                list_deps.append(dep)
+        self.assertFalse("pip" in c.dependencies)
+        c.fix_pip()
+        self.assertTrue("pip" in c.dependencies)
+
+
+class TestLauncher(IsolatedAsyncioTestCase):
+
+    @patch("builtins.open", new_callable=mock_open, read_data="env_var=data" + "\0")
+    @patch("argparse.Namespace")
+    async def test_activate_conda_env(self, mock_namespace, mock_file):
+        proc_def = ProcDef(name="test_conda", root=None, rule_file=None, runtime="BaseRuntime", cfg={}, deps=[], env={})
+        launcher = Launcher(name="test_conda", run_command=["python3", "alice.py"], proc_def=proc_def, args=mock_namespace)
+        os_env_patch = mock.patch.dict(os.environ, {"my_path": "path"})
+        os_env_patch.start()
+        conda_env = await launcher.activate_conda_env()
+        mock_file.assert_called_with(f"/tmp/fbrp_conda_test_conda.env")
+        self.assertTrue(len(conda_env) == 1)
+        self.assertDictEqual(conda_env, {"env_var" : "data"})
+        os_env_patch.stop()
+        
+
+    @patch("fbrp.life_cycle.set_state")
+    @patch("fbrp.runtime.conda.Launcher.conda_gather")
+    @patch("fbrp.runtime.conda.Launcher.conda_run")
+    @patch("fbrp.runtime.conda.Launcher.activate_conda_env")
+    @patch("argparse.Namespace")
+    async def test_run(self, mock_namespace, mock_activate_conda_env, mock_conda_run, mock_conda_gather, mock_set_state):
+        proc_def = ProcDef(name="test_conda", root=None, rule_file=None, runtime="BaseRuntime", cfg={}, deps=[], env={})
+        launcher = Launcher(name="test_conda", run_command=["python3", "alice.py"], proc_def=proc_def, args=mock_namespace)
+        conda_env = await launcher.run()
+        mock_activate_conda_env.assert_called_once()
+        mock_conda_run.assert_called_once()
+        mock_conda_gather.assert_called_once()
+        self.assertTrue(mock_set_state.call_count == 2)
+        mock_set_state.assert_has_calls([call("test_conda", State.STARTING), call("test_conda", State.STARTED)])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Description

Adding unit tests for CondaEnv and conda Launcher.

Fixes # (issue)

Beefing up unit tests

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [X] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [X] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [X] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

# Testing

```
(a0-env) giriman@devfair0439:~/ubuntu/rl/fairo/fbrp$ python3 tests/fbrp/runtime/test_conda.py 
..Could not find conda environment: fbrp_test_conda
You can list all discoverable environments with `conda info --envs`.

..
----------------------------------------------------------------------
Ran 4 tests in 0.640s

OK
```

Running all tests via pytest:

```
(a0-env) giriman@devfair0439:~/ubuntu/rl/fairo/fbrp$ pytest
============================================================================ test session starts =============================================================================
platform linux -- Python 3.9.7, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /private/home/giriman/ubuntu/rl/fairo, configfile: pyproject.toml
collected 9 items                                                                                                                                                            

tests/fbrp/runtime/test_base.py .....                                                                                                                                  [ 55%]
tests/fbrp/runtime/test_conda.py ....                                                                                                                                  [100%]

============================================================================= 9 passed in 1.24s ==============================================================================
(a0-env) giriman@devfair0439:~/ubuntu/rl/fairo/fbrp$ 
```

Running example to make sure refactor did not break code:

```
(a0-env) giriman@devfair0439:~/ubuntu/rl/fairo/fbrp$ python3 examples/01_basic/fsetup.py up
building proc...
creating conda env for proc. This will take a minute...
built proc

running proc...
(a0-env) giriman@devfair0439:~/ubuntu/rl/fairo/fbrp$ python3 examples/01_basic/fsetup.py logs
proc | b'i=4\n'
proc | b'i=5\n'
proc | b'i=6\n'
^C(a0-env) giriman@devfair0439:~/ubuntu/rl/fairo/fbrp$ python3 examples/01_basic/fsetup.py down
(a0-env) giriman@devfair0439:~/ubuntu/rl/fairo/fbrp$ 
```

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [X] I have added tests that show that the PR is functional.
- [X] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I have verified that all scripts in `tests/scripts` runs on hardware.
