### PR TITLE
Fixes a couple of paths issues within robot perception models / download

### DIFF
--- a/agents/argument_parser.py
+++ b/agents/argument_parser.py
@@ -105,7 +105,7 @@ class ArgumentParser:
         loco_parser.add_argument("--backend", default="habitat")
         loco_parser.add_argument(
             "--perception_model_dir",
-            default="droidlet/artifacts/models/perception/locobot",
+            default="../../droidlet/artifacts/models/perception/locobot",
             help="path to perception model data dir",
         )
         loco_parser.add_argument(

--- a/agents/argument_parser.py
+++ b/agents/argument_parser.py
@@ -123,7 +123,7 @@ class ArgumentParser:
         for optname, optval in od.items():
             if "path" in optname or "dir" in optname:
                 if optval:
-                    od[optname] = os.path.join(base_path, optval)
+                    od[optname] = os.path.join(os.path.abspath(base_path), optval)
         return opts
 
     def parse(self):

--- a/agents/locobot/locobot_agent.py
+++ b/agents/locobot/locobot_agent.py
@@ -9,6 +9,8 @@ import random
 import logging
 import faulthandler
 from multiprocessing import set_start_method
+if __name__ == "__main__":
+    set_start_method("spawn", force=True)
 import shutil
 
 from droidlet import dashboard
@@ -345,7 +347,6 @@ if __name__ == "__main__":
     if not opts.dev:
         try_download_artifacts(agent="locobot")
 
-    set_start_method("spawn", force=True)
 
     sa = LocobotAgent(opts)
     sa.start()

--- a/agents/locobot/locobot_agent.py
+++ b/agents/locobot/locobot_agent.py
@@ -199,7 +199,6 @@ class LocobotAgent(DroidletAgent):
                 print("Error switching model:", os.path.join(model_path, things_file), "not found")
                 return
 
-            print("switching to", model_path)
             self.perception_modules["vision"] = Perception(model_path, default_keypoints_path=True)
 
     def init_memory(self):

--- a/droidlet/tools/artifact_scripts/fetch_artifacts_from_aws.py
+++ b/droidlet/tools/artifact_scripts/fetch_artifacts_from_aws.py
@@ -35,7 +35,7 @@ def fetch_test_assets_from_aws(agent=None):
         print("Overwriting the directory: %r" % test_artifact_path)
         shutil.rmtree(test_artifact_path, ignore_errors=True)  # force delete if directory has content in it
     mode = 0o777
-    os.mkdir(test_artifact_path, mode)
+    os.makedirs(test_artifact_path, mode, exist_ok=True)
 
     print("Writing to : %r" % test_artifact_path)
     process = Popen(
@@ -88,9 +88,8 @@ def fetch_artifact_from_aws(agent, artifact_name, model_name, checksum_file_name
             print("Model type not specified, defaulting to NLU model.")
         artifact_path = artifact_path + "/" + model_name
         artifact_name = artifact_name + '_' + model_name
-        if not os.path.isdir(artifact_path):
-            mode = 0o777
-            os.mkdir(artifact_path, mode)
+        mode = 0o777
+        os.makedirs(artifact_path, mode, exist_ok=True)
         if model_name != "nlu":
             artifact_path = artifact_path + "/" + agent
             artifact_name = artifact_name + "_" + agent
@@ -120,7 +119,7 @@ def fetch_artifact_from_aws(agent, artifact_name, model_name, checksum_file_name
         print("Overwriting the directory: %r" % artifact_path)
         shutil.rmtree(artifact_path, ignore_errors=True)  # force delete if directory has content in it
     mode = 0o777
-    os.mkdir(artifact_path, mode)
+    os.makedirs(artifact_path, mode, exist_ok=True)
 
 
     print("Writing to : %r" % write_path)


### PR DESCRIPTION
# Description

1. There were a few usages of `chdir`, but the directory wasn't changed back. I just removed the usages entirely.
2. We were using relative paths, that interacted with the usage of `chdir` and broke model loading. So, forced absolute paths in the arg-parser
3. @aszlam and I saw issues with usage of `os.mkdir`, so switched to `os.makedirs` where relevant
4. Added a progress-bar based download, native to python, rather than invoking `curl`

Fixes # (issue)

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

If this PR introduces a change or fixes a bug, please add before and after screenshots (if this is causes a UX change) or before and after examples(this could be plain text, videos etc ) to demonstrate the change.

If this PR introduces a new feature, please also add examples or screenshots demonstrating the feature.

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I have verified that all scripts in `tests/scripts` runs on hardware.
