### PR TITLE
update split masks to separate old and new data

### DIFF
--- a/droidlet/tools/hitl/nsp_retrain_infra.py
+++ b/droidlet/tools/hitl/nsp_retrain_infra.py
@@ -210,8 +210,13 @@ class NSPRetrainingJob(DataGenerator):
         test_mask = torch.Tensor(test_mask).bool()
         mask_dict = {'annotated': {'train': train_mask, 'valid': valid_mask, 'test': test_mask}}
         logging.info(f"Mask dictionary: {mask_dict}")
-        mask_filepath = batch_config_dir + '/split_masks.pth'
+        mask_filename = f"split_masks_opts-{opts.retrain_data_splits[0]}-{opts.retrain_data_splits[1]}-{opts.retrain_data_splits[2]}.pth"
+        mask_filepath = os.path.join(batch_config_dir, mask_filename)
         torch.save(mask_dict, mask_filepath)
+
+        upload_key = batch_id + "/split_masks/" + mask_filename 
+        response = s3.upload_file(mask_filepath, 'droidlet-hitl', upload_key)
+        logging.info(response)
 
         return batch_config_dir
 

--- a/droidlet/tools/hitl/nsp_retrain_infra.py
+++ b/droidlet/tools/hitl/nsp_retrain_infra.py
@@ -195,15 +195,6 @@ class NSPRetrainingJob(DataGenerator):
         elif opts.retrain_data_splits[2] == 1: test_mask = new_test_mask
         else: test_mask = [True if old_test_mask[i] or new_test_mask[i] else False for i in range(total_rows)]
 
-        # Debug logging info
-        logging.info(f"Total data rows: {total_rows}")
-        logging.info(f"Old data rows: {total_rows - new_data_rows}")
-        logging.info(f"Length of old train mask: {len(old_train_mask)}")
-        logging.info(f"Length of new train mask: {len(new_train_mask)}")
-        logging.info(f"Old data train points: {sum(1 for i in old_train_mask if i)}")
-        logging.info(f"Old data valid points: {sum(1 for i in old_valid_mask if i)}")
-        logging.info(f"Old data test points: {sum(1 for i in old_test_mask if i)}")
-
         perc_new = (new_data_rows / total_rows)*100
         perc_train = sum(1 for i in train_mask if i)*100 / total_rows
         perc_valid = sum(1 for i in valid_mask if i)*100 / total_rows


### PR DESCRIPTION
# Description

Changes the way NSP retraining split masks are generated so that old and new data are handled separately.

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [X] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Previously there were two options for generating the split masks:
 - Resampled - old+new data were mixed and split into new train/valid/test sets
 - Not resampled - old training data and all new data are used for training, but the valid and test sets are only the old versions

This creates the potential issue that a model trained with --resampled=false could see data used in training in evaluation if evaluated using the other masks.

With this change, new 80/10/10 train/valid/test masks are generated for the new data, and the user can specify which sets to mix or not.  Any of the three (train, valid and test) may contain either only old data, only new data, or a mix of the two.  Regardless of the choices, the splits remain constant so that data used in training is never seen in in valid or test.

# Testing

Run nsp_retrain_infra.py from the command line to verify that splits are generated as expected.

# Checklist:

- [X] I have performed manual end-to-end testing of the feature in my environment.
- [X] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [X] New and existing unit tests pass locally with my changes.
- [X] I have added relevant collaborators to review the PR before merge.