### PR TITLE
[fbrp] no escape

### DIFF
--- a/fbrp/examples/07_rosmsg/fsetup.py
+++ b/fbrp/examples/07_rosmsg/fsetup.py
@@ -1,8 +1,13 @@
 import fbrp
-import glob
 
-genmsg_py_bin = "${CONDA_PREFIX}/lib/genpy/genmsg_py.py"
-msg_files = glob.glob("my_msgs/*.msg")
+genmsg_py = [
+    "python",
+    fbrp.NoEscape("${CONDA_PREFIX}/lib/genpy/genmsg_py.py"),
+    "-p",
+    "my_msgs",
+    "-o",
+    "my_msgs/py",
+]
 
 fbrp.process(
     name="genmsgs",
@@ -14,9 +19,11 @@ fbrp.process(
         dependencies=[
             "ros-noetic-genpy",
         ],
-        run_command=f"python {genmsg_py_bin} -p my_msgs -o my_msgs/py "
-        + " ".join(msg_files)
-        + f" ; python {genmsg_py_bin} -p my_msgs -o my_msgs/py --initpy",
+        setup_commands=[
+            genmsg_py + ["my_msgs/PsUtil.msg"],
+            genmsg_py + ["--initpy"],
+        ],
+        run_command=[],
     ),
 )
 

--- a/fbrp/examples/09_cpp_ompl/fsetup.py
+++ b/fbrp/examples/09_cpp_ompl/fsetup.py
@@ -1,0 +1,31 @@
+import fbrp
+
+fbrp.process(
+    name="proc",
+    runtime=fbrp.Conda(
+        channels=[
+            "conda-forge",
+            "robostack",
+        ],
+        dependencies=[
+            "python>=3.7",
+            "ros-foxy-ompl",
+        ],
+        setup_commands=[
+            [
+                "g++",
+                "-o",
+                "proc",
+                fbrp.NoEscape("-I${CONDA_PREFIX}/include"),
+                fbrp.NoEscape("-I${CONDA_PREFIX}/include/eigen3"),
+                fbrp.NoEscape("-I${CONDA_PREFIX}/include/ompl-1.5"),
+                "./proc.cpp",
+                fbrp.NoEscape("-L${CONDA_PREFIX}/lib"),
+                "-lompl",
+            ],
+        ],
+        run_command=[fbrp.NoEscape("LD_LIBRARY_PATH=${CONDA_PREFIX}/lib"), "./proc"],
+    ),
+)
+
+fbrp.main()

--- a/fbrp/examples/09_cpp_ompl/proc.cpp
+++ b/fbrp/examples/09_cpp_ompl/proc.cpp
@@ -1,0 +1,58 @@
+#include <ompl/base/ScopedState.h>
+#include <ompl/base/spaces/DubinsStateSpace.h>
+#include <ompl/base/spaces/ReedsSheppStateSpace.h>
+#include <ompl/geometric/SimpleSetup.h>
+
+namespace ob = ompl::base;
+namespace og = ompl::geometric;
+
+int main() {
+  ob::StateSpacePtr space(std::make_shared<ob::DubinsStateSpace>());
+
+  ob::RealVectorBounds bounds(2);
+  bounds.setLow(0);
+  bounds.setHigh(18);
+  space->as<ob::SE2StateSpace>()->setBounds(bounds);
+
+  og::SimpleSetup ss(space);
+
+  const ob::SpaceInformation *si = ss.getSpaceInformation().get();
+  ss.setStateValidityChecker([&](const ob::State *state) {
+    const auto *s = state->as<ob::SE2StateSpace::StateType>();
+    double x = s->getX();
+    double y = s->getY();
+    return si->satisfiesBounds(s) && (x < 5 || x > 13 || (y > 8.5 && y < 9.5));
+  });
+
+  ob::ScopedState<> start(space);
+  start[0] = 1;
+  start[1] = 1;
+  start[2] = 0;
+
+  ob::ScopedState<> goal(space);
+  goal[0] = 17;
+  goal[1] = 17;
+  goal[2] = -0.99 * M_PI;
+
+  ss.setStartAndGoalStates(start, goal);
+
+  ss.getSpaceInformation()->setStateValidityCheckingResolution(0.005);
+  ss.setup();
+  ss.print();
+
+  ob::PlannerStatus solved = ss.solve(30.0);
+
+  if (solved) {
+    std::vector<double> reals;
+
+    std::cout << "Found solution:" << std::endl;
+    ss.simplifySolution();
+    og::PathGeometric path = ss.getSolutionPath();
+    path.interpolate(1000);
+    path.printAsMatrix(std::cout);
+  } else {
+    std::cout << "No solution found" << std::endl;
+  }
+
+  return 0;
+}

--- a/fbrp/src/fbrp/__init__.py
+++ b/fbrp/src/fbrp/__init__.py
@@ -2,6 +2,7 @@ from fbrp import registrar
 from fbrp.process import process
 from fbrp.runtime.conda import Conda
 from fbrp.runtime.docker import Docker
+from fbrp.util import NoEscape
 import argparse
 
 
@@ -29,4 +30,4 @@ def main():
     args.func(args)
 
 
-__all__ = ["main", "process", "Docker", "Conda"]
+__all__ = ["main", "process", "NoEscape", "Docker", "Conda"]

--- a/fbrp/src/fbrp/runtime/conda.py
+++ b/fbrp/src/fbrp/runtime/conda.py
@@ -99,12 +99,8 @@ class Launcher(BaseLauncher):
         return conda_env
 
     async def run_cmd_in_env(self, conda_env):
-        cmd = self.run_command
-        if type(self.run_command) == list:
-            cmd = shlex.join(self.run_command)
-
         self.proc = await asyncio.create_subprocess_shell(
-            cmd,
+            util.shell_join(self.run_command),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             executable="/bin/bash",
@@ -232,7 +228,9 @@ class Conda(BaseRuntime):
 
         if self.setup_commands:
             print(f"setting up conda env for {name}")
-            setup_command = "\n".join([shlex.join(cmd) for cmd in self.setup_commands])
+            setup_command = "\n".join(
+                [util.shell_join(cmd) for cmd in self.setup_commands]
+            )
             result = subprocess.run(
                 f"""
                     eval "$(conda shell.bash hook)"

--- a/fbrp/src/fbrp/util.py
+++ b/fbrp/src/fbrp/util.py
@@ -1,13 +1,14 @@
 import a0
+import collections.abc
 import contextlib
 import glob
 import os
 import pwd
+import random
+import shlex
+import string
 import subprocess
 import sys
-import string
-import random
-import collections.abc
 
 
 def fail(msg):
@@ -90,3 +91,15 @@ def nested_dict_update(d, u):
         else:
             d[k] = v
     return d
+
+
+class NoEscape:
+    def __init__(self, val):
+        self.value = val
+
+
+def shell_join(items):
+    """Modified version of shlex.join that allows for non-escaped segments."""
+    return " ".join(
+        item.value if type(item) == NoEscape else shlex.quote(item) for item in items
+    )

--- a/fbrp/tests/fbrp/runtime/test_conda.py
+++ b/fbrp/tests/fbrp/runtime/test_conda.py
@@ -1,4 +1,3 @@
-import asyncio
 import os
 import unittest
 
@@ -8,55 +7,79 @@ from fbrp.runtime.conda import CondaEnv, Launcher
 
 from unittest import IsolatedAsyncioTestCase
 from unittest import mock
-from unittest.mock import AsyncMock, call, patch, mock_open
+from unittest.mock import call, patch, mock_open
 
 
 class TestCondaEnv(unittest.TestCase):
     def test_merge_and_fix_pip_1(self):
-        a = CondaEnv(channels=["conda-forge", "robostack", "pytorch"], dependencies=["ros-noetic-genpy"])
-        b = CondaEnv(channels=["pytorch", "nvidia"], dependencies=["pytorch", "numpy", "dataclasses"])
+        a = CondaEnv(
+            channels=["conda-forge", "robostack", "pytorch"],
+            dependencies=["ros-noetic-genpy"],
+        )
+        b = CondaEnv(
+            channels=["pytorch", "nvidia"],
+            dependencies=["pytorch", "numpy", "dataclasses"],
+        )
         c = CondaEnv.merge(a, b)
-        self.assertTrue(len(c.channels) == 4)
-        self.assertListEqual(c.channels, sorted(["conda-forge", "robostack", "pytorch", "nvidia"]))
-        self.assertTrue(len(c.dependencies) == 4)
-        self.assertListEqual(c.dependencies, sorted(["pytorch", "ros-noetic-genpy", "numpy", "dataclasses"]))
-        self.assertFalse("pip" in c.dependencies)
+        assert len(c.channels) == 4
+        assert c.channels == sorted(["conda-forge", "robostack", "pytorch", "nvidia"])
+        assert len(c.dependencies) == 4
+        assert c.dependencies == sorted(["pytorch", "ros-noetic-genpy", "numpy", "dataclasses"])
+        assert "pip" not in c.dependencies
         c.fix_pip()
-        self.assertFalse("pip" in c.dependencies)
+        assert "pip" not in c.dependencies
 
     def test_merge_and_fix_pip_2(self):
-        a = CondaEnv(channels=["conda-forge", "robostack", "pytorch"], 
-                     dependencies=["ros-noetic-genpy", {"pip" : ["scipy", "cuda110", "pytorch"]}])
-        b = CondaEnv(channels=["pytorch", "nvidia"], dependencies=["pytorch", "numpy", "dataclasses"])
+        a = CondaEnv(
+            channels=["conda-forge", "robostack", "pytorch"],
+            dependencies=["ros-noetic-genpy", {"pip": ["scipy", "cuda110", "pytorch"]}],
+        )
+        b = CondaEnv(
+            channels=["pytorch", "nvidia"],
+            dependencies=["pytorch", "numpy", "dataclasses"],
+        )
         c = CondaEnv.merge(a, b)
-        self.assertTrue(len(c.channels) == 4)
-        self.assertListEqual(c.channels, sorted(["conda-forge", "robostack", "pytorch", "nvidia"]))
-        self.assertTrue(len(c.dependencies) == 5)
+        assert len(c.channels) == 4
+        assert c.channels == sorted(["conda-forge", "robostack", "pytorch", "nvidia"])
+        assert len(c.dependencies) == 5
         ref_deps = sorted(["pytorch", "ros-noetic-genpy", "numpy", "dataclasses"])
         list_deps = []
         for dep in c.dependencies:
             if type(dep) == dict:
-                self.assertListEqual(sorted(dep["pip"]), sorted(["scipy", "cuda110", "pytorch"]))
+                assert sorted(dep["pip"]) == sorted(["scipy", "cuda110", "pytorch"])
             else:
-                self.assertTrue(dep in ref_deps)
+                assert dep in ref_deps
                 list_deps.append(dep)
-        self.assertFalse("pip" in c.dependencies)
+        assert "pip" not in c.dependencies
         c.fix_pip()
-        self.assertTrue("pip" in c.dependencies)
+        assert "pip" in c.dependencies
 
 
 class TestLauncher(IsolatedAsyncioTestCase):
     @patch("builtins.open", new_callable=mock_open, read_data="env_var=data" + "\0")
     @patch("argparse.Namespace")
     async def test_activate_conda_env(self, mock_namespace, mock_file):
-        proc_def = ProcDef(name="test_conda", root=None, rule_file=None, runtime="BaseRuntime", cfg={}, deps=[], env={})
-        launcher = Launcher(name="test_conda", run_command=["python3", "alice.py"], proc_def=proc_def, args=mock_namespace)
+        proc_def = ProcDef(
+            name="test_conda",
+            root=None,
+            rule_file=None,
+            runtime="BaseRuntime",
+            cfg={},
+            deps=[],
+            env={},
+        )
+        launcher = Launcher(
+            name="test_conda",
+            run_command=["python3", "alice.py"],
+            proc_def=proc_def,
+            args=mock_namespace,
+        )
         os_env_patch = mock.patch.dict(os.environ, {"my_path": "path"})
         os_env_patch.start()
         conda_env = await launcher.activate_conda_env()
         mock_file.assert_called_with(f"/tmp/fbrp_conda_test_conda.env")
-        self.assertTrue(len(conda_env) == 1)
-        self.assertDictEqual(conda_env, {"env_var" : "data"})
+        assert len(conda_env) == 1
+        self.assertDictEqual(conda_env, {"env_var": "data"})
         os_env_patch.stop()
 
     @patch("fbrp.life_cycle.set_state")
@@ -64,28 +87,66 @@ class TestLauncher(IsolatedAsyncioTestCase):
     @patch("fbrp.runtime.conda.Launcher.run_cmd_in_env")
     @patch("fbrp.runtime.conda.Launcher.activate_conda_env")
     @patch("argparse.Namespace")
-    async def test_run(self, mock_namespace, mock_activate_conda_env, mock_run_cmd_in_env, mock_gather_cmd_outputs, mock_set_state):
-        proc_def = ProcDef(name="test_conda", root=None, rule_file=None, runtime="BaseRuntime", cfg={}, deps=[], env={})
-        launcher = Launcher(name="test_conda", run_command=["python3", "alice.py"], proc_def=proc_def, args=mock_namespace)
+    async def test_run(
+        self,
+        mock_namespace,
+        mock_activate_conda_env,
+        mock_run_cmd_in_env,
+        mock_gather_cmd_outputs,
+        mock_set_state,
+    ):
+        proc_def = ProcDef(
+            name="test_conda",
+            root=None,
+            rule_file=None,
+            runtime="BaseRuntime",
+            cfg={},
+            deps=[],
+            env={},
+        )
+        launcher = Launcher(
+            name="test_conda",
+            run_command=["python3", "alice.py"],
+            proc_def=proc_def,
+            args=mock_namespace,
+        )
         await launcher.run()
         mock_activate_conda_env.assert_called_once()
         mock_run_cmd_in_env.assert_called_once()
         mock_gather_cmd_outputs.assert_called_once()
-        self.assertTrue(mock_set_state.call_count == 2)
-        mock_set_state.assert_has_calls([call("test_conda", State.STARTING), call("test_conda", State.STARTED)])
+        assert mock_set_state.call_count == 2
+        mock_set_state.assert_has_calls(
+            [call("test_conda", State.STARTING), call("test_conda", State.STARTED)]
+        )
 
-    
     @patch("fbrp.life_cycle.set_state")
     @patch("fbrp.runtime.conda.Launcher.exit_cmd_in_env")
     @patch("argparse.Namespace")
-    async def test_death_handler(self, mock_namespace, mock_exit_cmd_in_env, mock_set_state):
+    async def test_death_handler(
+        self, mock_namespace, mock_exit_cmd_in_env, mock_set_state
+    ):
         mock_exit_cmd_in_env.return_value = 0
-        proc_def = ProcDef(name="test_conda", root=None, rule_file=None, runtime="BaseRuntime", cfg={}, deps=[], env={})
-        launcher = Launcher(name="test_conda", run_command=["python3", "alice.py"], proc_def=proc_def, args=mock_namespace)  
+        proc_def = ProcDef(
+            name="test_conda",
+            root=None,
+            rule_file=None,
+            runtime="BaseRuntime",
+            cfg={},
+            deps=[],
+            env={},
+        )
+        launcher = Launcher(
+            name="test_conda",
+            run_command=["python3", "alice.py"],
+            proc_def=proc_def,
+            args=mock_namespace,
+        )
         await launcher.death_handler()
         mock_exit_cmd_in_env.assert_called_once()
-        mock_set_state.assert_called_once_with("test_conda", State.STOPPED, return_code=0)
+        mock_set_state.assert_called_once_with(
+            "test_conda", State.STOPPED, return_code=0
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/fbrp/tests/fbrp/test_util.py
+++ b/fbrp/tests/fbrp/test_util.py
@@ -1,0 +1,15 @@
+from fbrp import util
+import unittest
+
+class TestShellJoin(unittest.TestCase):
+    def test_empty(self):
+        assert util.shell_join([]) == ""
+
+    def test_basic(self):
+        assert util.shell_join(["a", "b", "c"]) == "a b c"
+
+    def test_escape(self):
+        assert util.shell_join(["a", ";b", "c"]) == "a ';b' c"
+
+    def test_noescape(self):
+        assert util.shell_join(["a", util.NoEscape(";b"), "c"]) == "a ;b c"


### PR DESCRIPTION
# Description

Add `fbrp.NoEscape` to disable shell quoting for sub commands.

TODO: maybe rename it `LateBinding`, or something like that....
TODO: get it working with env keys

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

See `fbrp/examples/07_rosmsg/fsetup.py`

# Testing

`fbrp/examples/07_rosmsg/fsetup.py` + `fbrp/examples/09_cpp_ompl/fsetup.py` + unit test

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [x] I have added tests that show that the PR is functional.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I have verified that all scripts in `tests/scripts` runs on hardware.
