### PR TITLE
[droidlet][CI] Improve stability and coverage of end-to-end agent tests

### DIFF
--- a/.circleci/locobot_tests.sh
+++ b/.circleci/locobot_tests.sh
@@ -8,8 +8,7 @@ pip install -r agents/locobot/requirements.txt
 python setup.py develop
 
 echo "Downloading datasets, models ..."
-yes | python droidlet/tools/artifact_scripts/try_download.py --agent_name locobot --test_mode &
-wait
+yes | python droidlet/tools/artifact_scripts/try_download.py --agent_name locobot --test_mode
 echo "Done!"
 
 
@@ -58,3 +57,4 @@ conda activate habitat_env
 droidlet/lowlevel/locobot/remote/launch_pyro_habitat.sh
 conda activate droidlet_env
 ./agents/locobot/tests/test_agent.sh
+droidlet/lowlevel/locobot/remote/kill_pyro_habitat.sh

--- a/agents/locobot/locobot_agent.py
+++ b/agents/locobot/locobot_agent.py
@@ -134,6 +134,10 @@ class LocobotAgent(DroidletAgent):
         def _shutdown(sid, data):
             self.shutdown()
 
+        @sio.on("get_count")
+        def _return_count(sid, data):
+            sio.emit("currentCount", self.count)
+
         @sio.on("get_memory_objects")
         def objects_in_memory(sid):
             objects = DetectedObjectNode.get_all(self.memory)
@@ -316,16 +320,8 @@ class LocobotAgent(DroidletAgent):
 
     def shutdown(self):
         self._shutdown = True
-        try:
-            self.perception_modules["vision"].vprocess_shutdown.set()
-        except:
-            """
-            the try/except is there in the event that
-            self.perception_modules["vision"] has either:
-            1. not been fully started yet
-            2. already crashed / shutdown due to other effects
-            """
-            pass
+        time.sleep(5)  # let current step to finish
+        self.perception_modules["vision"].vprocess.stop()
         time.sleep(5)  # let the other threads die
         os._exit(0)  # TODO: remove and figure out why multiprocess sometimes hangs on exit
 

--- a/agents/locobot/tests/test_agent.py
+++ b/agents/locobot/tests/test_agent.py
@@ -5,9 +5,43 @@ import os
 # standard Python
 sio = socketio.Client()
 
-sio.connect("http://localhost:8000")
+connect_count = 0
+connect_max_tries = 10
+connect_delay = 5 # seconds
+while True:
+    try:
+        sio.connect("http://localhost:8000")
+        print("Connected to agent")
+        break
+    except socketio.exceptions.ConnectionError:
+        connect_count = connect_count + 1
+        if connect_count >= connect_max_tries:
+            raise
+        print("Failed connecting for the {} / {} time. "
+              "Retrying in {} seconds".format(connect_count, connect_max_tries, connect_delay))
+        sio.sleep(connect_delay)
 
-print("Connected to agent")
+agent_running = False
+
+@sio.on("currentCount")
+def currentCount(data):
+    global agent_running
+    if data > 1:
+        agent_running = True
+
+timeout = 60 # seconds
+delay = 1 # second
+# wait for agent loop to actually start executing
+for i in range(timeout):
+    print("Waiting for agent to step once {} / {}".format(i, timeout))
+    sio.emit("get_count", i)
+    sio.sleep(delay)
+    if agent_running:
+        break
+if not agent_running:
+    print("agent never started executing "
+          "even after {} seconds".format(timeout))
+    os._exit(1)
 
 commands = [
     "move forward",
@@ -18,8 +52,27 @@ for command in commands:
     print("sending command to agent: ", command)
     sio.emit('sendCommandToAgent', command)
 
-time.sleep(5)
-# wait for commands to be processed and maybe emit an error
+agent_objects = False
+
+@sio.on("objects")
+def objects(data):
+    global agent_objects
+    if data["image"] != -1:
+        agent_objects = True
+        print("Got object detection output from agent")
+    else:
+        print("Waiting for object detection output", data)
+
+for i in range(timeout):
+    print("Waiting for objects from agent {} / {}".format(i, timeout))
+    if agent_objects:
+        break
+    sio.sleep(delay)
+
+if not agent_objects:
+    print("agent not processing object detection "
+          "even after {} seconds".format(timeout))
+    os._exit(1)
 
 try:
     print("Shutting down the agent")

--- a/agents/locobot/tests/test_agent.sh
+++ b/agents/locobot/tests/test_agent.sh
@@ -5,16 +5,27 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 pushd $SCRIPT_DIR
 
+TEST_TIMEOUT=120s
+
 pushd ..
-python locobot_agent.py 2>&1 >/dev/null &
+timeout -k $TEST_TIMEOUT $TEST_TIMEOUT \
+	python locobot_agent.py &
 BGPID=$!
 popd
 
-sleep 45 # wait for the agent to fully start (including downloading of models)
-
 python test_agent.py
+STATUS1=$?
+if [[ $STATUS1 -gt 0 ]]; then
+    echo "test_agent.py returned with non-zero error code."
+    kill -9 $BGPID
+    exit STATUS1
+else
+    wait $BGPID
+    STATUS2=$?
+    if [[ $STATUS2 -gt 0 ]]; then
+	echo "Failed to shutdown locobot_agent.py cleanly."
+	exit $STATUS2
+    fi
+fi
 
-wait $BGPID
-STATUS=$?
 
-exit $STATUS


### PR DESCRIPTION
# Description

Earlier today, I had to issue https://github.com/facebookresearch/fairo/pull/828 because `main` was all green, but locally the locobot_agent.py was broken.

Upon further investigation, it looked like the end-to-end agent test was running, and even on failure, was exiting Green.
For example, a recent commit on main: https://app.circleci.com/pipelines/github/facebookresearch/fairo/3670/workflows/740bcfff-af2b-4c26-9bd4-9aa588a754ff/jobs/14115?invite=true#step-104-2698 where the end-to-end agent test failed.

On investigating, I found and issued miscellaneous fixes, and increased test coverage to wait for the agent's `step` to start, and the slow-running processes (SlowPerception) to start.

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

If this PR introduces a change or fixes a bug, please add before and after screenshots (if this is causes a UX change) or before and after examples(this could be plain text, videos etc ) to demonstrate the change.

If this PR introduces a new feature, please also add examples or screenshots demonstrating the feature.

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I have verified that all scripts in `tests/scripts` runs on hardware.
