### PR TITLE
Fix relative directory path

### DIFF
--- a/agents/argument_parser.py
+++ b/agents/argument_parser.py
@@ -58,15 +58,17 @@ class ArgumentParser:
         )
         nsp_parser.add_argument(
             "--nsp_models_dir",
-            default="droidlet/artifacts/models/nlu/",
+            default="../../droidlet/artifacts/models/nlu/",
             help="path to semantic parsing models",
         )
         nsp_parser.add_argument(
-            "--nsp_data_dir", default="droidlet/artifacts/datasets/annotated_data/", help="path to annotated data"
+            "--nsp_data_dir", 
+            default="../../droidlet/artifacts/datasets/annotated_data/", 
+            help="path to annotated data"
         )
         nsp_parser.add_argument(
             "--ground_truth_data_dir",
-            default="droidlet/artifacts/datasets/ground_truth/",
+            default="../../droidlet/artifacts/datasets/ground_truth/",
             help="path to folder of common short and templated commands",
         )
         nsp_parser.add_argument(


### PR DESCRIPTION
# Description

This is a fix for relative model and dataset directory path when running the agents.

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

# Testing

Tested on devfair by running the agent and cuberite on devfair and Minecraft client on local machine.

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I have verified that all scripts in `tests/scripts` runs on hardware.
