### PR TITLE
refactor robot's perception test assets to datasets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,6 @@ tools/annotation_tools/turk/turk_base_app/node_modules/
 tools/annotation_tools/turk/turk_base_app/package-lock.json
 chat.lock
 incoming_chat.txt
-locobot/test/test_assets/perception_handlers/
 locobot/agent/dashboard_data.db*
 nsp_outputs.csv
 agents/locobot/*.json
@@ -51,7 +50,6 @@ agents/locobot/models
 agents/locobot/datasets
 agents/locobot/dashboard_data.db
 agents/locobot/dashboard_data.db-journal
-droidlet/perception/robot/tests/test_assets/perception_handlers
 .ropeproject
 agents/craftassist/timeline_log*
 annotation_data/rgb/*

--- a/droidlet/perception/robot/tests/test_perception.py
+++ b/droidlet/perception/robot/tests/test_perception.py
@@ -36,15 +36,17 @@ PERCEPTION_MODELS_DIR = os.path.join(
 
 OFFICE_IMG_PATH = os.path.join(
     os.path.abspath(os.path.dirname(__file__)),
-    "test_assets",
+    "../../../../droidlet/artifacts/datasets/robot/perception_test_assets",
     "office_chair.jpg",
 )
 GROUP_IMG_PATH = os.path.join(
     os.path.abspath(os.path.dirname(__file__)),
-    "test_assets",
+    "../../../../droidlet/artifacts/datasets/robot/perception_test_assets",
     "obama_trump.jpg",
 )
-FACES_IDS_DIR = os.path.join(os.path.dirname(__file__), "test_assets/faces")
+FACES_IDS_DIR = os.path.join(
+    os.path.dirname(__file__),
+    "../../../../droidlet/artifacts/datasets/robot/perception_test_assets/faces")
 
 logging.getLogger().setLevel(logging.INFO)
 

--- a/droidlet/tools/artifact_scripts/README.md
+++ b/droidlet/tools/artifact_scripts/README.md
@@ -12,7 +12,7 @@ python try_download.py --agent_name <name of agent> --test_mode
 ```
 where `agent_name` is the name of agent you are downloading the artifacts for. Note that some perception models will be 
 different for different agents like `craftassist` and `locobot`.
-`test_mode` is a binary flag, if passed downloads the `test_assets` for locobot. This will be refactored soon.
+`test_mode` is a binary flag, and if passed, downloads the `perception_test_assets` for robot.
 
 The above script first compares the checksum of your local artifacts folders and compares them against the checksums 
 tracked in main, if they are different it will force download the updated version.

--- a/droidlet/tools/artifact_scripts/fetch_artifacts_from_aws.py
+++ b/droidlet/tools/artifact_scripts/fetch_artifacts_from_aws.py
@@ -31,8 +31,8 @@ def fetch_test_assets_from_aws(agent=None):
 
     download_url("https://locobot-bucket.s3-us-west-2.amazonaws.com/perception_test_assets.tar.gz", final_path)
 
-    test_artifact_path = os.path.join(ROOTDIR, 'droidlet/perception/robot/tests/test_assets/')
-    """Now update the local directory and with untar'd file contents"""
+    test_artifact_path = os.path.join(ROOTDIR, 'droidlet/artifacts/datasets/robot/perception_test_assets/')
+    """Now update the local directory with untar'd file contents"""
     if os.path.isdir(test_artifact_path):
         print("Overwriting the directory: %r" % test_artifact_path)
         shutil.rmtree(test_artifact_path, ignore_errors=True)  # force delete if directory has content in it

--- a/droidlet/tools/artifact_scripts/try_download.py
+++ b/droidlet/tools/artifact_scripts/try_download.py
@@ -30,13 +30,15 @@ def try_download_artifacts(agent=None, test_mode=False):
     artifact_path = artifact_path_original
     # in case directories don't exist, create them
     os.makedirs(os.path.join(artifact_path, 'datasets'), exist_ok=True)
+    os.makedirs(os.path.join(artifact_path, 'datasets/robot'), exist_ok=True)
     os.makedirs(os.path.join(artifact_path, 'models'), exist_ok=True)
     os.makedirs(os.path.join(artifact_path, 'models/nlu'), exist_ok=True)
     os.makedirs(os.path.join(artifact_path, 'models/perception'), exist_ok=True)
     os.makedirs(os.path.join(artifact_path, 'models/perception', agent), exist_ok=True)
     if test_mode:
         # Download test artifacts for Locobot tests
-        os.makedirs(os.path.join(ROOTDIR, 'droidlet/perception/robot/tests/test_assets/'), exist_ok=True)
+        os.makedirs(os.path.join(artifact_path, 'datasets/robot/perception_test_assets'), exist_ok=True)
+        # os.makedirs(os.path.join(ROOTDIR, 'droidlet/perception/robot/tests/test_assets/'), exist_ok=True)
 
     # Remove existing checksum files so that they can be re-calculated
     fileList = [os.path.join(artifact_path, 'models/nlu/nlu_checksum.txt'),
@@ -76,7 +78,7 @@ def try_download_artifacts(agent=None, test_mode=False):
     compare_checksum_try_download(agent, checksum_write_path, "datasets")
 
     if test_mode:
-        print("Now downloading test assets...")
+        print("Now downloading perception test assets for robots ...")
         fetch_test_assets_from_aws(agent=agent)
 
 
@@ -137,7 +139,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--test_mode",
-        help="Is this is given, download locobot test assets",
+        help="Is this is given, download robot test assets",
         action="store_true"
     )
     args = parser.parse_args()

--- a/droidlet/tools/artifact_scripts/try_download.py
+++ b/droidlet/tools/artifact_scripts/try_download.py
@@ -38,7 +38,6 @@ def try_download_artifacts(agent=None, test_mode=False):
     if test_mode:
         # Download test artifacts for Locobot tests
         os.makedirs(os.path.join(artifact_path, 'datasets/robot/perception_test_assets'), exist_ok=True)
-        # os.makedirs(os.path.join(ROOTDIR, 'droidlet/perception/robot/tests/test_assets/'), exist_ok=True)
 
     # Remove existing checksum files so that they can be re-calculated
     fileList = [os.path.join(artifact_path, 'models/nlu/nlu_checksum.txt'),


### PR DESCRIPTION
# Description

As the title says.
Previous location of these assets was:
`droidlet/perception/robot/tests/test_assets/`
current location:
`droidlet/artifacts/datasets/robot/perception_test_assets`

Fixes #807 

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [x] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

# Testing

Tested on devfair, CI and locally on mac.
Currently the robot test: `test_perception` tests for the functionality of this.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I have verified that all scripts in `tests/scripts` runs on hardware.
