### PR TITLE
[Droidlet CI] Move artifact download from unittest script to docker build stage

### DIFF
--- a/.circleci/craftassist_tests.sh
+++ b/.circleci/craftassist_tests.sh
@@ -4,11 +4,6 @@ set -ex
 script_dir=$(dirname $0)
 SHARED_PATH=/shared
 
-echo "Downloading datasets, models ..."
-yes | python3 droidlet/tools/artifact_scripts/try_download.py --agent_name craftassist &
-wait
-echo "Done!"
-
 pushd $script_dir/../
 
 pytest --cov-report=xml:$SHARED_PATH/test_full_craftassist_agent.xml --cov=agents --cov=droidlet agents/craftassist/tests/ --disable-pytest-warnings

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -31,6 +31,11 @@ RUN ((curl http://craftassist.s3-us-west-2.amazonaws.com/pubr/client_ccache.tar.
     ccache -s && \
     rm -rf client_ccache.tar.gz /cache/.ccache /client_ccache.tar.gz
 
+RUN cd /fairo && \
+    python setup.py develop && \
+    yes | python3 droidlet/tools/artifact_scripts/try_download.py --agent_name craftassist
+
+
 RUN npm install -g yarn
 RUN cd /fairo/droidlet/dashboard/web && yarn install
 

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -32,7 +32,7 @@ RUN ((curl http://craftassist.s3-us-west-2.amazonaws.com/pubr/client_ccache.tar.
     rm -rf client_ccache.tar.gz /cache/.ccache /client_ccache.tar.gz
 
 RUN cd /fairo && \
-    python setup.py develop && \
+    python3 setup.py develop && \
     yes | python3 droidlet/tools/artifact_scripts/try_download.py --agent_name craftassist
 
 


### PR DESCRIPTION
# Description

In recent artifact refactor #773, the artifact downloading part is pushed back from docker build stage to unittest stage (the main reason is the updated version requires droidlet module to be installed, which happens after docker build stage). 

One side effect of this change is in the docker image there're no pre-downloaded artifacts, causing agent in ECS hosting dashboard to fail because it failed to load any language/vision model. 

This PR is bringing artifact downloading logic back to docker build stage so that artifacts will be pre-downloaded into the docker image which will be promoted to ECR.


## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

**Before**

if you spin up an ECS instance and visit the dashboard via that IP address, you will observe agent failures due to missing artifacts

**After**

Dashboard agent works as expected.

# Testing

Tested with ECS route

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I have verified that all scripts in `tests/scripts` runs on hardware.
