### PR TITLE
[HiTL] Show agent command processing state in dashboard and force error labeling

### DIFF
--- a/agents/droidlet_agent.py
+++ b/agents/droidlet_agent.py
@@ -188,6 +188,15 @@ class DroidletAgent(BaseAgent):
                     json.dump(job_metadata, f)
             os._exit(0)
 
+        @sio.on("taskStackPoll")
+        def poll_task_stack(sid):
+            logging.info("Poll to see if task stack is empty")
+            task = True if self.memory.task_stack_peek() else False
+            res = {
+                "task": task,
+            }
+            sio.emit("taskStackPollResponse", res)
+
     def init_physical_interfaces(self):
         """
         should define or otherwise set up

--- a/droidlet/dashboard/web/src/StateManager.js
+++ b/droidlet/dashboard/web/src/StateManager.js
@@ -19,6 +19,7 @@ import Retrainer from "./components/Retrainer";
 import Navigator from "./components/Navigator";
 import { isMobile } from "react-device-detect";
 import MainPane from "./MainPane";
+import AgentThinking from "./components/Interact/AgentThinking";
 
 /**
  * The main state manager for the dashboard.
@@ -69,6 +70,8 @@ class StateManager {
     timelineFilters: ["Perceive", "Dialogue", "Interpreter", "Memory"],
     timelineSearchPattern: "",
     agentType: "locobot",
+    commandState: "idle",
+    commandPollTime: 500,
   };
   session_id = null;
 
@@ -310,7 +313,16 @@ class StateManager {
     }
     this.memory.chats = res.allChats;
 
-    // once confirm that this chat has been sent, clear last chat action dict
+    // Set the commandState to display 'received' for one poll cycle and then switch
+    this.memory.commandState = "received";
+    setTimeout(() => {
+      if (this.memory.commandState === "received") {
+        // May have moved on already, in which case leave it
+        this.memory.commandState = "thinking";
+      }
+    }, this.memory.commandPollTime - 1); // avoid race condition
+
+    // once confirm that this chat has been sent, clear last action dict
     this.memory.lastChatActionDict = null;
 
     this.refs.forEach((ref) => {
@@ -332,7 +344,7 @@ class StateManager {
   updateVoxelWorld(res) {
     this.refs.forEach((ref) => {
       if (ref instanceof VoxelWorld) {
-        console.log("update Voxel World with " + res.world_state);
+        //console.log("update Voxel World with " + res.world_state);
         ref.setState({
           world_state: res.world_state,
           status: res.status,
@@ -375,6 +387,22 @@ class StateManager {
     this.memory.timelineEventHistory.push(res);
     this.memory.timelineEvent = res;
     this.updateTimeline();
+
+    // If the agent has finished processing the command
+    // notify the user to look for an empty task stack
+    if (JSON.parse(res).name === "perceive") {
+      this.memory.commandState = "done_thinking";
+      this.refs.forEach((ref) => {
+        if (ref instanceof AgentThinking) {
+          ref.sendTaskStackPoll(); // Do this once from here
+        }
+      });
+    }
+    // If there's an action to take in the world,
+    // notify the user that it's executing
+    if (JSON.parse(res).name === "interpreter") {
+      this.memory.commandState = "executing";
+    }
   }
 
   updateTimelineResults() {

--- a/droidlet/dashboard/web/src/StateManager.js
+++ b/droidlet/dashboard/web/src/StateManager.js
@@ -72,6 +72,7 @@ class StateManager {
     agentType: "locobot",
     commandState: "idle",
     commandPollTime: 500,
+    isTurk: false,
   };
   session_id = null;
 
@@ -81,6 +82,7 @@ class StateManager {
     this.setLastChatActionDict = this.setLastChatActionDict.bind(this);
     this.setConnected = this.setConnected.bind(this);
     this.updateAgentType = this.updateAgentType.bind(this);
+    this.checkIsTurk = this.checkIsTurk.bind(this);
     this.updateStateManagerMemory = this.updateStateManagerMemory.bind(this);
     this.keyHandler = this.keyHandler.bind(this);
     this.updateVoxelWorld = this.updateVoxelWorld.bind(this);
@@ -290,6 +292,20 @@ class StateManager {
     this.refs.forEach((ref) => {
       if (ref instanceof MainPane) {
         ref.setState({ agentType: this.memory.agentType });
+      }
+      if (ref instanceof InteractApp) {
+        ref.setState({ agentType: this.memory.agentType });
+      }
+    });
+  }
+
+  checkIsTurk(status) {
+    // If TurkInfo successfully mounts, this is a HIT
+    // Used to turn on forced error labeling
+    this.memory.isTurk = status;
+    this.refs.forEach((ref) => {
+      if (ref instanceof InteractApp) {
+        ref.setState({ isTurk: this.memory.isTurk });
       }
     });
   }

--- a/droidlet/dashboard/web/src/StateManager.js
+++ b/droidlet/dashboard/web/src/StateManager.js
@@ -82,7 +82,7 @@ class StateManager {
     this.setLastChatActionDict = this.setLastChatActionDict.bind(this);
     this.setConnected = this.setConnected.bind(this);
     this.updateAgentType = this.updateAgentType.bind(this);
-    this.checkIsTurk = this.checkIsTurk.bind(this);
+    this.forceErrorLabeling = this.forceErrorLabeling.bind(this);
     this.updateStateManagerMemory = this.updateStateManagerMemory.bind(this);
     this.keyHandler = this.keyHandler.bind(this);
     this.updateVoxelWorld = this.updateVoxelWorld.bind(this);
@@ -299,9 +299,8 @@ class StateManager {
     });
   }
 
-  checkIsTurk(status) {
-    // If TurkInfo successfully mounts, this is a HIT
-    // Used to turn on forced error labeling
+  forceErrorLabeling(status) {
+    // If TurkInfo successfully mounts, this is a HIT and forced labeling should be on
     this.memory.isTurk = status;
     this.refs.forEach((ref) => {
       if (ref instanceof InteractApp) {
@@ -360,7 +359,6 @@ class StateManager {
   updateVoxelWorld(res) {
     this.refs.forEach((ref) => {
       if (ref instanceof VoxelWorld) {
-        //console.log("update Voxel World with " + res.world_state);
         ref.setState({
           world_state: res.world_state,
           status: res.status,

--- a/droidlet/dashboard/web/src/components/Interact/AgentThinking.js
+++ b/droidlet/dashboard/web/src/components/Interact/AgentThinking.js
@@ -1,0 +1,188 @@
+/*
+   Copyright (c) Facebook, Inc. and its affiliates.
+
+ * AgentThinking.js displays the animation that shows in between when a command is issued
+   and when a response is received from the back end
+ */
+
+import React, { Component } from "react";
+import Button from "@material-ui/core/Button";
+
+class AgentThinking extends Component {
+  allowedStates = [
+    "sent",
+    "received",
+    "thinking",
+    "done_thinking",
+    "executing",
+  ];
+  constructor(props) {
+    super(props);
+    this.state = {
+      ellipsis: "",
+      ellipsisInterval: null,
+      commandState: "idle",
+      now: null,
+    };
+
+    this.sendTaskStackPoll = this.sendTaskStackPoll.bind(this);
+    this.receiveTaskStackPoll = this.receiveTaskStackPoll.bind(this);
+    this.issueStopCommand = this.issueStopCommand.bind(this);
+    this.elementRef = React.createRef();
+  }
+
+  isMounted() {
+    //check if this element is being displayed on the screen
+    return this.elementRef.current != null;
+  }
+
+  sendTaskStackPoll() {
+    console.log("Sending task stack poll");
+    this.props.stateManager.socket.emit("taskStackPoll");
+  }
+
+  receiveTaskStackPoll(res) {
+    var response = JSON.stringify(res);
+    console.log("Received task stack poll response:" + response);
+    // If we get a response of any kind, reset the timeout clock
+    if (res) {
+      this.setState({
+        now: Date.now(),
+      });
+      if (!res.task) {
+        console.log("no task on stack");
+        // If there's no task, leave this pane and go to error labeling
+        this.props.goToQuestion(this.props.chats.length - 1);
+      } else {
+        // Otherwise send out a new task stack poll after a delay
+        setTimeout(() => {
+          this.sendTaskStackPoll();
+        }, 1000);
+      }
+    }
+  }
+
+  componentDidMount() {
+    this.props.stateManager.connect(this); // Add to refs
+
+    if (this.props.stateManager) {
+      this.props.stateManager.socket.on(
+        "taskStackPollResponse",
+        this.receiveTaskStackPoll
+      );
+    }
+
+    // Ellipsis animation and update command status
+    let intervalId = setInterval(() => {
+      let commandState = null;
+      if (this.props.stateManager) {
+        commandState = this.props.stateManager.memory.commandState;
+        console.log("Command State from agent thinking: " + commandState);
+      }
+
+      // Check that we're in an allowed state and haven't timed out
+      if (this.safetyCheck()) {
+        this.setState((prevState) => {
+          if (prevState.commandState !== commandState) {
+            // Log changes in command state to mephisto for analytics
+            window.parent.postMessage(
+              JSON.stringify({ msg: commandState }),
+              "*"
+            );
+          }
+          if (prevState.ellipsis.length > 6) {
+            return {
+              ellipsis: "",
+              commandState: commandState,
+            };
+          } else {
+            return {
+              ellipsis: prevState.ellipsis + ".",
+              commandState: commandState,
+            };
+          }
+        });
+      }
+    }, this.props.stateManager.memory.commandPollTime);
+
+    this.setState({
+      ellipsisInterval: intervalId,
+      commandState: this.props.stateManager.memory.commandState,
+      now: Date.now(),
+    });
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.state.ellipsisInterval);
+    if (this.props.stateManager) {
+      this.props.stateManager.disconnect(this);
+      this.props.stateManager.socket.off(
+        "taskStackPollResponse",
+        this.receiveTaskStackPoll
+      );
+    }
+  }
+
+  safetyCheck() {
+    // If we've gotten here during idle somehow, or timed out, escape to safety
+    if (
+      !this.allowedStates.includes(this.state.commandState) ||
+      Date.now() - this.state.now > 50000
+    ) {
+      console.log("Safety check failed, exiting to Message pane.");
+      this.props.goToMessage();
+    } else return true;
+  }
+
+  issueStopCommand() {
+    console.log("Stop command issued");
+    const chatmsg = "stop";
+    //add to chat history box of parent
+    this.props.setInteractState({ msg: chatmsg, timestamp: Date.now() });
+    //log message to flask
+    this.props.stateManager.logInteractiondata("text command", chatmsg);
+    //socket connection
+    this.props.stateManager.socket.emit("sendCommandToAgent", chatmsg);
+    //update StateManager command state
+    this.props.stateManager.memory.commandState = "sent";
+  }
+
+  renderPerformingTask() {
+    return (
+      <div>
+        <h2>Assistant is doing the task</h2>
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={this.issueStopCommand.bind(this)}
+        >
+          Stop
+        </Button>
+      </div>
+    );
+  }
+
+  render() {
+    return (
+      <div className="container">
+        {this.state.commandState === "sent" ? (
+          <h2>Sending command{this.state.ellipsis}</h2>
+        ) : null}
+        {this.state.commandState === "received" ? (
+          <h2>Command received</h2>
+        ) : null}
+        {this.state.commandState === "thinking" ? (
+          <h2>Assistant is thinking{this.state.ellipsis}</h2>
+        ) : null}
+        {this.state.commandState === "done_thinking"
+          ? this.renderPerformingTask()
+          : null}
+        {this.state.commandState === "executing"
+          ? this.renderPerformingTask()
+          : null}
+      </div>
+    );
+  }
+}
+
+export default AgentThinking;

--- a/droidlet/dashboard/web/src/components/Interact/AgentThinking.js
+++ b/droidlet/dashboard/web/src/components/Interact/AgentThinking.js
@@ -51,8 +51,13 @@ class AgentThinking extends Component {
       });
       if (!res.task) {
         console.log("no task on stack");
-        // If there's no task, leave this pane and go to error labeling
-        this.props.goToQuestion(this.props.chats.length - 1);
+        // If there's no task, leave this pane
+        // If it's a HIT go to error labeling, else back to Message
+        if (this.props.isTurk) {
+          this.props.goToQuestion(this.props.chats.length - 1);
+        } else {
+          this.props.goToMessage();
+        }
       } else {
         // Otherwise send out a new task stack poll after a delay
         setTimeout(() => {

--- a/droidlet/dashboard/web/src/components/Interact/InteractApp.js
+++ b/droidlet/dashboard/web/src/components/Interact/InteractApp.js
@@ -19,6 +19,8 @@ class InteractApp extends Component {
       chats: [{ msg: "", failed: false }],
       failidx: -1,
       agent_reply: "",
+      agentType: null,
+      isTurk: false,
     };
     this.state = this.initialState;
     this.setAssistantReply = this.setAssistantReply.bind(this);
@@ -130,6 +132,7 @@ class InteractApp extends Component {
               isMobile={this.props.isMobile}
               ref={this.MessageRef}
               chats={this.state.chats}
+              agentType={this.state.agentType}
               enableVoice={false}
               agent_reply={this.state.agent_reply}
               goToQuestion={this.goToQuestion.bind(this)}
@@ -151,6 +154,7 @@ class InteractApp extends Component {
             <AgentThinking
               stateManager={this.props.stateManager}
               chats={this.state.chats}
+              isTurk={this.state.isTurk}
               goToMessage={this.goToMessage.bind(this)}
               goToQuestion={this.goToQuestion.bind(this)}
               setInteractState={this.setInteractState.bind(this)}

--- a/droidlet/dashboard/web/src/components/Interact/InteractApp.js
+++ b/droidlet/dashboard/web/src/components/Interact/InteractApp.js
@@ -50,6 +50,7 @@ class InteractApp extends Component {
         "showAssistantReply",
         this.setAssistantReply
       );
+      this.setState({ isTurk: this.props.stateManager.memory.isTurk });
     }
   }
 
@@ -64,7 +65,7 @@ class InteractApp extends Component {
 
   goToMessage() {
     // Send a message to the parent iframe for analytics logging
-    window.parent.postMessage(JSON.stringify({ msg: "goToMessaage" }), "*");
+    window.parent.postMessage(JSON.stringify({ msg: "goToMessage" }), "*");
 
     //change the state to switch the view to show Message and save the user input necessary for socket connection
     var newchats = this.state.chats;

--- a/droidlet/dashboard/web/src/components/Interact/InteractApp.js
+++ b/droidlet/dashboard/web/src/components/Interact/InteractApp.js
@@ -7,6 +7,7 @@ import React, { Component } from "react";
 import "./InteractApp.css";
 import Message from "./Message";
 import Question from "./Question";
+import AgentThinking from "./AgentThinking";
 
 class InteractApp extends Component {
   constructor(props) {
@@ -59,6 +60,9 @@ class InteractApp extends Component {
   }
 
   goToMessage() {
+    // Send a message to the parent iframe for analytics logging
+    window.parent.postMessage(JSON.stringify({ msg: "goToMessaage" }), "*");
+
     //change the state to switch the view to show Message and save the user input necessary for socket connection
     var newchats = this.state.chats;
     if (this.state.failidx !== -1) {
@@ -70,21 +74,48 @@ class InteractApp extends Component {
     });
   }
 
+  goToAgentThinking() {
+    // Send a message to the parent iframe for analytics logging
+    window.parent.postMessage(
+      JSON.stringify({ msg: "goToAgentThinking" }),
+      "*"
+    );
+
+    //change the state to switch the view to show AgentThinking window
+    this.setState({
+      currentView: 3,
+    });
+  }
+
   goToQuestion(idx) {
-    // first send request to retrieve the logic form of last sent command before showing NSP Error annotation page to users
+    // Wait for the logical form of last chat and show the Fail page
+    this.props.stateManager.socket.on(
+      "setLastChatActionDict",
+      this.goToQuestionWindow
+    );
+
+    // Send request to retrieve the logic form of last sent command
     this.props.stateManager.socket.emit(
       "getChatActionDict",
       this.state.chats[idx]["msg"]
     );
+  }
 
-    // then wait 3 seconds for the logical form of last chat and show the Fail page (by setting currentView)
-    setTimeout(() => {
-      this.setState({
-        currentView: 2,
-        chats: this.state.chats,
-        failidx: idx,
-      });
-    }, 3000);
+  goToQuestionWindow() {
+    // Send a message to the parent iframe for analytics logging
+    window.parent.postMessage(JSON.stringify({ msg: "goToQuestion" }), "*");
+    // Don't proliferate sio listeners
+    this.props.stateManager.socket.off(
+      "setLastChatActionDict",
+      this.goToQuestionWindow
+    );
+    const replies_len = this.props.stateManager.memory.agent_replies.length;
+    const chats_len = this.state.chats.length;
+    this.setState({
+      currentView: 2,
+      chats: this.state.chats,
+      failidx: chats_len - 1,
+    });
   }
 
   render() {
@@ -100,6 +131,7 @@ class InteractApp extends Component {
               chats={this.state.chats}
               agent_reply={this.state.agent_reply}
               goToQuestion={this.goToQuestion.bind(this)}
+              goToAgentThinking={this.goToAgentThinking.bind(this)}
               setInteractState={this.setInteractState.bind(this)}
             />
           ) : null}
@@ -110,6 +142,16 @@ class InteractApp extends Component {
               failidx={this.state.failidx}
               goToMessage={this.goToMessage.bind(this)}
               failmsg={this.state.chats[this.state.failidx].msg}
+              agent_reply={this.state.last_reply}
+            />
+          ) : null}
+          {this.state.currentView === 3 ? (
+            <AgentThinking
+              stateManager={this.props.stateManager}
+              chats={this.state.chats}
+              goToMessage={this.goToMessage.bind(this)}
+              goToQuestion={this.goToQuestion.bind(this)}
+              setInteractState={this.setInteractState.bind(this)}
             />
           ) : null}
         </div>

--- a/droidlet/dashboard/web/src/components/Interact/InteractApp.js
+++ b/droidlet/dashboard/web/src/components/Interact/InteractApp.js
@@ -22,6 +22,7 @@ class InteractApp extends Component {
     };
     this.state = this.initialState;
     this.setAssistantReply = this.setAssistantReply.bind(this);
+    this.goToQuestionWindow = this.goToQuestionWindow.bind(this);
     this.MessageRef = React.createRef();
   }
 
@@ -109,18 +110,18 @@ class InteractApp extends Component {
       "setLastChatActionDict",
       this.goToQuestionWindow
     );
-    const replies_len = this.props.stateManager.memory.agent_replies.length;
-    const chats_len = this.state.chats.length;
+
     this.setState({
+      agent_reply: this.props.stateManager.memory.agent_reply,
       currentView: 2,
       chats: this.state.chats,
-      failidx: chats_len - 1,
+      failidx: 0,
     });
   }
 
   render() {
     return (
-      <div className="App">
+      <div className="App" style={{ padding: 0 }}>
         <div className="content">
           {this.state.currentView === 1 ? (
             <Message
@@ -129,6 +130,7 @@ class InteractApp extends Component {
               isMobile={this.props.isMobile}
               ref={this.MessageRef}
               chats={this.state.chats}
+              enableVoice={false}
               agent_reply={this.state.agent_reply}
               goToQuestion={this.goToQuestion.bind(this)}
               goToAgentThinking={this.goToAgentThinking.bind(this)}

--- a/droidlet/dashboard/web/src/components/Interact/Message.css
+++ b/droidlet/dashboard/web/src/components/Interact/Message.css
@@ -23,10 +23,15 @@ Copyright (c) Facebook, Inc. and its affiliates.
 }
 
 .Chat {
-  margin-top: 2px auto;
+  margin: 20px auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
 }
 
 #msg {
+  width: 90%;
   border-color: white;
 }
 

--- a/droidlet/dashboard/web/src/components/Interact/Message.js
+++ b/droidlet/dashboard/web/src/components/Interact/Message.js
@@ -76,7 +76,7 @@ class Message extends Component {
 
   componentDidMount() {
     document.addEventListener("keypress", this.bindKeyPress);
-    window.parent.postMessage(JSON.stringify({ msg: "goToMessaage" }), "*");
+    window.parent.postMessage(JSON.stringify({ msg: "goToMessage" }), "*");
   }
 
   componentWillUnmount() {

--- a/droidlet/dashboard/web/src/components/Interact/Message.js
+++ b/droidlet/dashboard/web/src/components/Interact/Message.js
@@ -130,8 +130,10 @@ class Message extends Component {
       document.getElementById("msg").innerHTML = "";
       //clear the agent reply that will be shown in the question pane
       this.props.stateManager.memory.agent_reply = "";
-      //change to the AgentThinking view pane
-      this.props.goToAgentThinking();
+      //change to the AgentThinking view pane if it makes sense
+      if (this.props.agentType === "craftassist") {
+        this.props.goToAgentThinking();
+      }
     }
   }
 

--- a/droidlet/dashboard/web/src/components/Interact/Message.js
+++ b/droidlet/dashboard/web/src/components/Interact/Message.js
@@ -10,9 +10,6 @@ import List from "@material-ui/core/List";
 import ListItem from "@material-ui/core/ListItem";
 import ListItemSecondaryAction from "@material-ui/core/ListItemSecondaryAction";
 import ListItemText from "@material-ui/core/ListItemText";
-import FailIcon from "@material-ui/icons/Cancel";
-
-import IconButton from "@material-ui/core/IconButton";
 import KeyboardVoiceIcon from "@material-ui/icons/KeyboardVoice";
 
 import "./Message.css";
@@ -25,6 +22,7 @@ class Message extends Component {
     super(props);
     this.state = {
       recognizing: false,
+      enableVoice: this.props.enableVoice,
     };
 
     this.toggleListen = this.toggleListen.bind(this);
@@ -78,6 +76,7 @@ class Message extends Component {
 
   componentDidMount() {
     document.addEventListener("keypress", this.bindKeyPress);
+    window.parent.postMessage(JSON.stringify({ msg: "goToMessaage" }), "*");
   }
 
   componentWillUnmount() {
@@ -125,8 +124,14 @@ class Message extends Component {
       this.props.stateManager.logInteractiondata("text command", chatmsg);
       //socket connection
       this.props.stateManager.socket.emit("sendCommandToAgent", chatmsg);
+      //update StateManager command state
+      this.props.stateManager.memory.commandState = "sent";
       //clear the textbox
       document.getElementById("msg").innerHTML = "";
+      //clear the agent reply that will be shown in the question pane
+      this.props.stateManager.memory.agent_reply = "";
+      //change to the AgentThinking view pane
+      this.props.goToAgentThinking();
     }
   }
 
@@ -136,33 +141,41 @@ class Message extends Component {
         {/* FIXME Save for dashboard in turk */}
         {/* <p>Press spacebar to start/stop recording.</p> */}
         {/* <p>Enter the command to the bot in the input box below</p>
-        <List>{this.renderChatHistory()}</List>
-        <div
-          contentEditable="true"
-          className="Msg single-line"
-          id="msg"
-          suppressContentEditableWarning={true}
-        >
-          {" "}
-        </div> */}
-        <p>
-          Enter the command to the bot in the input box below, or click the mic
-          button to start/stop voice input.
-        </p>
-        <p>
-          Click the x next to the message if the outcome wasn't as expected.
-        </p>
-        <KeyboardVoiceIcon
-          className="ASRButton"
-          variant="contained"
-          color={this.state.recognizing ? "default" : "secondary"}
-          fontSize="large"
-          onClick={this.toggleListen.bind(this)}
-        ></KeyboardVoiceIcon>
+           <List>{this.renderChatHistory()}</List>
+           <div
+             contentEditable="true"
+             className="Msg single-line"
+             id="msg"
+             suppressContentEditableWarning={true}
+           >
+             {" "}
+           </div> */}
+        {this.state.enableVoice ? (
+          <div>
+            <p>
+              Enter the command to the assistant in the input box below, or
+              click the mic button to start/stop voice input.
+            </p>
+            <p>
+              Click "Mark Error" next to the message if the outcome wasn't as
+              expected.
+            </p>
+            <KeyboardVoiceIcon
+              className="ASRButton"
+              variant="contained"
+              color={this.state.recognizing ? "default" : "secondary"}
+              fontSize="large"
+              onClick={this.toggleListen.bind(this)}
+            ></KeyboardVoiceIcon>
+            <p> {this.state.recognizing ? "Listening..." : ""} </p>
+          </div>
+        ) : (
+          <div>
+            <p>Enter the command to the assistant in the input box below.</p>
+          </div>
+        )}
 
-        <p> {this.state.recognizing ? "Listening..." : ""} </p>
-
-        <List>{this.renderChatHistory(this.props.status)}</List>
+        {/*<List>{this.renderChatHistory(this.props.status)}</List>*/}
         {this.props.isMobile === true ? (
           <div
             style={{ outline: " solid 1px black" }}
@@ -195,9 +208,9 @@ class Message extends Component {
 
         {/* FIXME save for dashboard in turk */}
         {/* <p id="callbackMsg">{this.props.status}</p>
-        <p id="assistantReply">[Reply] {this.props.agent_reply} </p>
-        <br />
-        <br /> */}
+           <p id="assistantReply">[Reply] {this.props.agent_reply} </p>
+           <br />
+           <br /> */}
         <p id="assistantReply">{this.props.agent_reply} </p>
       </div>
     );

--- a/droidlet/dashboard/web/src/components/Interact/Question.css
+++ b/droidlet/dashboard/web/src/components/Interact/Question.css
@@ -10,6 +10,16 @@ Copyright (c) Facebook, Inc. and its affiliates.
   min-width: 90px;
   white-space: nowrap;
   text-align: center;
+  color: white;
+}
+
+.MuiInputBase-root {
+  background-color: black;
+  outline: white;
+}
+
+.listButton {
+  text-decoration: underline;
 }
 
 .inputtext {

--- a/droidlet/dashboard/web/src/components/Interact/Question.js
+++ b/droidlet/dashboard/web/src/components/Interact/Question.js
@@ -19,13 +19,14 @@ class Question extends Component {
 
     this.state = {
       view: 0,
+      parsing_error: false,
+      task_error: false,
+      action_dict: {},
+      feedback: "",
       // asr: false,
       // adtt: false,
       // adtt_text: "",
-      parsing_error: false,
-      action_dict: {},
       // new_action_dict: {},
-      feedback: "",
     };
   }
 
@@ -37,17 +38,20 @@ class Question extends Component {
      */
     var data = {
       action_dict: this.state.action_dict,
+      parsing_error: this.state.parsing_error,
+      task_error: this.state.task_error,
+      msg: this.props.chats[this.props.failidx].msg,
+      feedback: this.state.feedback,
       // new_action_dict: this.state.new_action_dict,
       // asr: this.state.asr,
       // adtt: this.state.adtt,
-      parsing_error: this.state.parsing_error,
       // adtt_text: this.state.adtt_text,
-      msg: this.props.chats[this.props.failidx].msg,
-      feedback: this.state.feedback,
     };
 
-    // Emit socket.io event to save data to error logs
+    // Emit socket.io event to save data to error logs and Mephisto
     this.props.stateManager.socket.emit("saveErrorDetailsToCSV", data);
+    // Parsed: data.msg.data = data
+    window.parent.postMessage(JSON.stringify({ msg: data }), "*");
 
     // go back to message page after writing to database
     this.props.goToMessage();
@@ -65,13 +69,14 @@ class Question extends Component {
           {" "}
           Thanks for letting me know that I didn't understand the command right.{" "}
         </h3>
-        <Button
-          variant="contained"
-          color="primary"
-          onClick={this.finishQuestions.bind(this)}
-        >
-          Done
-        </Button>
+        <List className="answers" component="nav">
+          <ListItem button onClick={this.finishQuestions.bind(this)}>
+            <ListItemText className="listButton" primary="Done" />
+          </ListItem>
+          <ListItem button onClick={() => this.setState({ view: 0 })}>
+            <ListItemText className="listButton" primary="Go Back" />
+          </ListItem>
+        </List>
       </div>
     );
   }
@@ -81,53 +86,71 @@ class Question extends Component {
       <div>
         <h3>
           {" "}
-          Okay, looks like I understood your command but couldn't follow it all
-          the way through. Tell me more about what I did wrong :{" "}
+          Okay, it seems like I understood your command. Did I successfully do
+          the task you asked me to complete?{" "}
+        </h3>
+        <List className="answers" component="nav">
+          <ListItem button onClick={() => this.answerAction(1)}>
+            <ListItemText className="listButton" primary="Yes" />
+          </ListItem>
+          <ListItem button onClick={() => this.answerAction(2)}>
+            <ListItemText className="listButton" primary="No" />
+          </ListItem>
+          <ListItem button onClick={() => this.setState({ view: 0 })}>
+            <ListItemText className="listButton" primary="Go Back" />
+          </ListItem>
+        </List>
+      </div>
+    );
+  }
+
+  renderActionFail() {
+    return (
+      <div>
+        <h3>
+          {" "}
+          Okay, looks like I understood your command but didn't complete it.
+          Please tell me more about what I did wrong:{" "}
         </h3>
         <TextField
-          style={{
-            backgroundColor: "white",
-          }}
           id="outlined-uncontrolled"
           label=""
           margin="normal"
           variant="outlined"
           onChange={(event) => this.saveFeedback(event)}
         />
-        <div></div>
-        <Button
-          variant="contained"
-          color="primary"
-          onClick={this.finishQuestions.bind(this)}
-        >
-          Done
-        </Button>
+        <List className="answers" component="nav">
+          <ListItem button onClick={this.finishQuestions.bind(this)}>
+            <ListItemText className="listButton" primary="Done" />
+          </ListItem>
+          <ListItem button onClick={() => this.setState({ view: 2 })}>
+            <ListItemText className="listButton" primary="Go Back" />
+          </ListItem>
+        </List>
       </div>
     );
   }
+
   renderEnd() {
     //end screen, user can put any additional feedback
     return (
       <div>
-        <h3> Thanks! Submit any other feedback here: </h3>
+        <h3> Thanks! Submit any other feedback here (optional): </h3>
         <TextField
-          style={{
-            backgroundColor: "white",
-          }}
           id="outlined-uncontrolled"
           label=""
           margin="normal"
           variant="outlined"
           onChange={(event) => this.saveFeedback(event)}
         />
-        <div></div>
-        <Button
-          variant="contained"
-          color="primary"
-          onClick={this.finishQuestions.bind(this)}
-        >
-          Done
-        </Button>
+        <List className="answers" component="nav">
+          <ListItem button onClick={this.finishQuestions.bind(this)}>
+            <ListItemText className="listButton" primary="Done" />
+          </ListItem>
+          <ListItem button onClick={() => this.setState({ view: 2 })}>
+            <ListItemText className="listButton" primary="Go Back" />
+          </ListItem>
+        </List>
       </div>
     );
   }
@@ -177,10 +200,7 @@ class Question extends Component {
   // }
 
   renderSemanticParserErrorQuestion() {
-    /* check if the parser was right.
-    Yes -> correct, go to any feedback page
-    No -> mark as aprsing error.
-    */
+    /* check if the parser was right.*/
 
     if (this.state.action_dict) {
       if ("dialogue_type" in this.state.action_dict) {
@@ -189,51 +209,124 @@ class Question extends Component {
         if (dialogue_type === "HUMAN_GIVE_COMMAND") {
           // handle composite action
 
+          let cmd = this.props.chats[this.props.failidx].msg.split(" ");
           // get the action type
           var action_dict = this.state.action_dict.action_sequence[0];
           var action_type = action_dict.action_type.toLowerCase();
           question_word = "to " + action_type + " ";
-          // action is build
+          // action is build or dig
           if (["build", "dig"].indexOf(action_type) >= 0) {
             if ("schematic" in action_dict) {
-              question_word =
-                question_word + "'" + action_dict.schematic.text_span + "'";
+              if ("text_span" in action_dict.schematic) {
+                question_word =
+                  question_word + "'" + action_dict.schematic.text_span + "'";
+              }
+              // If we don't have a convenient text_span, find the words referenced by index
+              else if ("where_clause" in action_dict.schematic.filters) {
+                let qty = "";
+                if ("selector" in action_dict.schematic.filters) {
+                  qty = action_dict.schematic.filters.selector.ordinal;
+                }
+                let antecedent = [qty, "", "", "", ""]; // qty then size then colour then block type then name. Ignore everything else.
+                action_dict.schematic.filters.where_clause.AND.forEach(
+                  (clause) => {
+                    if (clause.pred_text === "has_size")
+                      antecedent[1] = clause.obj_text;
+                    else if (clause.pred_text === "has_colour")
+                      antecedent[2] = clause.obj_text;
+                    else if (clause.pred_text === "has_block_type")
+                      antecedent[3] = clause.obj_text;
+                    else if (clause.pred_text === "has_name")
+                      antecedent[4] = clause.obj_text;
+                  }
+                );
+                question_word =
+                  question_word +
+                  "'" +
+                  antecedent.join(" ").replace(/  +/g, " ").trim() +
+                  "'";
+              }
             }
             if ("location" in action_dict) {
-              question_word =
-                question_word +
-                " at location '" +
-                action_dict.location.text_span +
-                "'";
+              if ("text_span" in action_dict.location) {
+                question_word =
+                  question_word +
+                  " at location '" +
+                  action_dict.location.text_span +
+                  "'";
+              } else {
+                question_word = question_word + " at this location "; // Not worth it to handle all of the potential references?
+              }
             }
             question_word = question_word + " ?";
           } else if (
-            ["destroy", "fill", "spawn", "copy", "get", "scout"].indexOf(
-              action_type
-            ) >= 0
+            [
+              "destroy",
+              "fill",
+              "spawn",
+              "copy",
+              "get",
+              "scout",
+              "freebuild",
+            ].indexOf(action_type) >= 0
           ) {
             if ("reference_object" in action_dict) {
-              question_word =
-                question_word +
-                "'" +
-                action_dict.reference_object.text_span +
-                "'";
+              if ("text_span" in action_dict.reference_object) {
+                question_word =
+                  question_word +
+                  "'" +
+                  action_dict.reference_object.text_span +
+                  "'";
+              }
+              // If we don't have a convenient text_span, find the words referenced by index
+              else if ("where_clause" in action_dict.reference_object.filters) {
+                let qty = "";
+                if ("selector" in action_dict.reference_object.filters) {
+                  qty = action_dict.reference_object.filters.selector.ordinal;
+                }
+                let antecedent = [qty, "", "", "", ""]; // qty then size then colour then block type then name. Ignore everything else.
+                action_dict.reference_object.filters.where_clause.AND.forEach(
+                  (clause) => {
+                    if (clause.pred_text === "has_size")
+                      antecedent[1] = clause.obj_text;
+                    else if (clause.pred_text === "has_colour")
+                      antecedent[2] = clause.obj_text;
+                    else if (clause.pred_text === "has_block_type")
+                      antecedent[3] = clause.obj_text;
+                    else if (clause.pred_text === "has_name")
+                      antecedent[4] = clause.obj_text;
+                  }
+                );
+                question_word =
+                  question_word +
+                  "'" +
+                  antecedent.join(" ").replace(/  +/g, " ").trim() +
+                  "'";
+              }
             }
             if ("location" in action_dict) {
-              question_word =
-                question_word +
-                " at location '" +
-                action_dict.location.text_span +
-                "'";
+              if ("text_span" in action_dict.location) {
+                question_word =
+                  question_word +
+                  " at location '" +
+                  action_dict.location.text_span +
+                  "'";
+              } else {
+                question_word = question_word + " at this location ";
+              }
             }
             question_word = question_word + " ?";
           } else if (["move"].indexOf(action_type) >= 0) {
             if ("location" in action_dict) {
-              question_word =
-                question_word +
-                " at location '" +
-                action_dict.location.text_span +
-                "'";
+              if ("text_span" in action_dict.location) {
+                question_word =
+                  question_word +
+                  " to location '" +
+                  action_dict.location.text_span +
+                  "'";
+              } else {
+                question_word = question_word + " to here";
+              }
             }
             question_word = question_word + " ?";
           } else if (["stop", "resume", "undo"].indexOf(action_type) >= 0) {
@@ -245,6 +338,9 @@ class Question extends Component {
                 "'";
             }
             question_word = question_word + " ?";
+          } else if (["otheraction"].indexOf(action_type) >= 0) {
+            question_word =
+              "to perform an action not in assistant capabilities ?";
           }
         } else if (dialogue_type === "GET_MEMORY") {
           // you asked the bot a question
@@ -255,17 +351,17 @@ class Question extends Component {
           question_word = "to remember or learn something you taught it ?";
         } else if (dialogue_type === "NOOP") {
           // no operation was requested.
-          question_word = "to do nothing ?";
+          question_word = "to just respond verbally with no action ?";
         }
       } else {
         // NOTE: This should never happen ...
-        question_word = "did you want me to do nothing ?";
+        question_word = "to do nothing ?";
       }
     } else {
       //end screen, user can put any additional feedback
       return (
         <div>
-          <h3> Thanks for marking this error! </h3>
+          <h3> Thanks! Press to continue.</h3>
           <Button
             variant="contained"
             color="primary"
@@ -278,13 +374,13 @@ class Question extends Component {
     }
     return (
       <div className="question">
-        <h5>Did you want the assistant {question_word}</h5>
+        <h3>Did you want the assistant {question_word}</h3>
         <List className="answers" component="nav">
           <ListItem button onClick={() => this.answerParsing(1)}>
-            <ListItemText primary="Yes" />
+            <ListItemText className="listButton" primary="Yes" />
           </ListItem>
           <ListItem button onClick={() => this.answerParsing(2)}>
-            <ListItemText primary="No" />
+            <ListItemText className="listButton" primary="No" />
           </ListItem>
         </List>
       </div>
@@ -292,36 +388,59 @@ class Question extends Component {
   }
 
   answerParsing(index) {
-    //handles after the user submits the answer (y/n) to if asr errored or not
-    // if (index === 1) { //no of adtt, ask to annotate the tree, set Labeling tool view.
-    //   this.setState({ adtt: true, view: 2 });
-    // } else
+    //handles after the user submits the answer (y/n) to if NSP errored or not
     if (index === 1) {
       // yes, so not a parsing error
-      this.setState({ view: 2 });
+      this.setState({ parsing_error: false, view: 2 });
     } else if (index === 2) {
       // no, so parsing error
       this.setState({ parsing_error: true, view: 1 });
     }
   }
 
+  answerAction(index) {
+    //handles after the user submits the answer (y/n) to if the agent task was correct
+    if (index === 1) {
+      // yes, so not a task error
+      this.setState({ view: 4 });
+    } else if (index === 2) {
+      // no, so yes a task error
+      this.setState({ task_error: true, view: 3 });
+    }
+  }
+
   goToEnd(new_action_dict) {
     //go to the last feedback page and save the new dict from labeling
-    this.setState({ view: 3, new_action_dict: new_action_dict });
+    this.setState({ view: 4, new_action_dict: new_action_dict });
   }
 
   componentDidMount() {
+    this.props.stateManager.memory.commandState = "idle";
     var lastChatActionDict = this.props.stateManager.memory.lastChatActionDict;
-    var chatMsg = this.props.chats[this.props.failidx].msg;
-    this.setState({ action_dict: lastChatActionDict });
+    this.setState({
+      action_dict: lastChatActionDict,
+      agent_reply: this.props.agent_reply, // In case the agent chat updates while this pane is displayed
+    });
+    let command_and_lf = {
+      command:
+        this.props.chats[this.props.failidx].msg +
+        "|" +
+        JSON.stringify(this.state.action_dict),
+    };
+    // Parsed: data.msg.command = "command|logical_form"
+    window.parent.postMessage(JSON.stringify({ msg: command_and_lf }), "*");
   }
 
   render() {
     return (
       <div>
         <div className="msg-header">
-          Message you sent to the bot: <br></br>
-          {this.props.chats[this.props.failidx].msg}
+          Message you sent to the assistant: <br></br>
+          <strong>{this.props.chats[this.props.failidx].msg}</strong>
+        </div>
+        <div className="msg-header">
+          The assistant responded:<br></br>
+          <strong>{this.state.agent_reply}</strong>
         </div>
         {/* {this.state.view === 0 ?  this.renderASRQuestion() : null} */}
         {this.state.view === 0
@@ -329,9 +448,10 @@ class Question extends Component {
           : null}
         {this.state.view === 1 ? this.renderParsingFail() : null}
         {this.state.view === 2 ? this.renderParsingSuccess() : null}
+        {this.state.view === 3 ? this.renderActionFail() : null}
         {/* {this.state.view === 1 ? this.renderADTTQuestion() : null} */}
         {/* {this.state.view === 2 ? <Labeling action_dict={this.state.action_dict} message={(this.props.chats[this.props.failidx]).msg} goToEnd={this.goToEnd.bind(this)} /> : null} */}
-        {this.state.view === 3 ? this.renderEnd() : null}
+        {this.state.view === 4 ? this.renderEnd() : null}
       </div>
     );
   }

--- a/droidlet/dashboard/web/src/components/Timeline/Timeline.js
+++ b/droidlet/dashboard/web/src/components/Timeline/Timeline.js
@@ -168,7 +168,7 @@ class DashboardTimeline extends React.Component {
     const filters = this.props.stateManager.memory.timelineFilters;
     // checks if filters have been changed
     if (filters && filters !== this.searchFilters) {
-      console.log(filters);
+      //console.log(filters);
       this.searchFilters = [...filters];
       let items = timelineEvents.get();
       // loop through all items and check if the filter applies

--- a/droidlet/dashboard/web/src/components/Turk/TurkInfo.js
+++ b/droidlet/dashboard/web/src/components/Turk/TurkInfo.js
@@ -19,7 +19,7 @@ class TurkInfo extends Component {
   }
 
   componentDidMount() {
-    this.props.stateManager.checkIsTurk(true);
+    this.props.stateManager.forceErrorLabeling(true);
   }
 
   handleClick = () => {

--- a/droidlet/dashboard/web/src/components/Turk/TurkInfo.js
+++ b/droidlet/dashboard/web/src/components/Turk/TurkInfo.js
@@ -18,6 +18,10 @@ class TurkInfo extends Component {
     };
   }
 
+  componentDidMount() {
+    this.props.stateManager.checkIsTurk(true);
+  }
+
   handleClick = () => {
     if (this.state.isTimerOn) {
       this.setState({

--- a/droidlet/tools/crowdsourcing/servermgr/run.withagent.sh
+++ b/droidlet/tools/crowdsourcing/servermgr/run.withagent.sh
@@ -6,7 +6,7 @@ S3_DEST=s3://craftassist/turk_interactions_with_agent
 function background_agent() (
     echo "Running craftassist agent"
     python3 /fairo/droidlet/lowlevel/minecraft/craftassist_cuberite_utils/wait_for_cuberite.py --host localhost --port 25565
-    python3 /fairo/agents/craftassist/craftassist_agent.py --no_default_behavior --agent_debug_mode --log_level debug --dev 1>agent.log 2>agent.log
+    python3 /fairo/agents/craftassist/craftassist_agent.py --no_default_behavior --agent_debug_mode --enable_timeline --log_level debug --dev 1>agent.log 2>agent.log
 )
 
 echo "Installing Droidlet as a module"

--- a/droidlet/tools/hitl/utils/run.withagent.sh
+++ b/droidlet/tools/hitl/utils/run.withagent.sh
@@ -6,7 +6,7 @@ S3_DEST=s3://droidlet-hitl
 function background_agent() (
     echo "Running craftassist agent"
     python3 /fairo/droidlet/lowlevel/minecraft/craftassist_cuberite_utils/wait_for_cuberite.py --host localhost --port 25565
-    python3 /fairo/agents/craftassist/craftassist_agent.py --no_default_behavior --agent_debug_mode --log_level debug --dev 1>agent.log 2>agent.log
+    python3 /fairo/agents/craftassist/craftassist_agent.py --no_default_behavior --agent_debug_mode --enable_timeline --log_level debug --dev 1>agent.log 2>agent.log
 )
 
 echo "Installing Droidlet as a module"

--- a/tools/servermgr/run.withagent.sh
+++ b/tools/servermgr/run.withagent.sh
@@ -8,7 +8,7 @@ S3_DEST=s3://craftassist/turk_interactions_with_agent
 function background_agent() (
     echo "Running craftassist agent"
     python3 /fairo/droidlet/lowlevel/minecraft/craftassist_cuberite_utils/wait_for_cuberite.py --host localhost --port 25565
-    python3 /fairo/agents/craftassist/craftassist_agent.py --no_default_behavior --agent_debug_mode --log_level debug --dev 1>agent.log 2>agent.log
+    python3 /fairo/agents/craftassist/craftassist_agent.py --no_default_behavior --agent_debug_mode --enable_timeline --log_level debug --dev 1>agent.log 2>agent.log
 )
 
 echo "Installing Droidlet as a module"


### PR DESCRIPTION
# Description

This PR contains three major changes:
- The first is the display of agent state in a new AgentThinking dashboard pane, making it clear to the user what's happening at any given time.  This helps prevent confusion and can allay suspicion that the agent has crashed.
- The second change is to force error labeling.  After each command issued through the dashboard the user must label whether it was carried out successfully, there was an error of understanding, or an error of execution.
- The final change is a relatively minor update to the way action_dict is parsed in the error labeling process.  When text_span isn't available, it retrieves the relevant obj_text from elsewhere in the dictionary.

The interface is unchanged for agents other than craftassist, and forced error labeling is turned on only for turkers (by proxy whether the TurkInfo pane is mounted).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [X] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [X] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Previously the user flow after issuing a command was as follows:
- The user sends a command and the command is displayed above the message box with a red 'x' next to it
- When the command is successfully received by the agent, the red 'x' turns into a green checkmark
- The agent executes the command in VoxelWorld
- Depending on the action, the agent may issue a chat reply which is displayed in a pane below the message box
- At the user's discretion, they can push a "mark error" button to the right of the last issued command to mark an error of understanding

The new user flow is:
- The user sends a command and the view of the InteractApp changes to display the AgentThinking pane
- The text within the AgentThinking pane updates based on the state of command processing (sending command -> command received -> assistant thinking -> done thinking -> executing command).  An ellipsis animation is displayed after the command processing state to indicate that the dashboard is still active.
- When the agent has finished executing the command and/or replying, the InteractApp view shifts to immediately show the error labeling pane
- The user must answer whether or not the task was performed correctly.  If so the command is labeled as not having an error and the user returns to the message pane.
- If the task was not performed correctly, the user is shown a sentence containing the action the agent understood it was supposed to take and asked if the agent understood correctly.  If the agent did, then the task is labeled as an execution error, and if not an nsp error.  The user has the opportunity to submit additional feedback and then returns to the message pane.

A gif showing the change can be seen [here](https://docs.google.com/document/d/1JB6igdT6mMuCfRDvocmwp0Tt5WVkIuvzx1oeFCdpkkE/edit?pli=1#heading=h.4bq2awem43nb).

# Testing

Run the dashboard locally with a craftassist back end to see the changes.

# Checklist:

- [X] I have performed manual end-to-end testing of the feature in my environment.
- [X] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [X] New and existing unit tests pass locally with my changes.
- [X] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I have verified that all scripts in `tests/scripts` runs on hardware.
