### PR TITLE
Using ImageTag instead of ImageDigest when tagging ecr images

### DIFF
--- a/droidlet/tools/hitl/nsp_retrain/README.md
+++ b/droidlet/tools/hitl/nsp_retrain/README.md
@@ -29,8 +29,8 @@ For Interaction Job, we are serving a specific version of dashboard on ECS insta
 
 Here, you should:
 
-1. First find the DIGEST of that commit (it should look like 'sha256:9db893....')
-2. Tag that digest with a spcific TAG_NAME by running: `./tools/docker/promote.sh <DIGEST> <TAG_NAME>`
+1. First find the SHA1 of that commit (in CI you should see something like: docker push ECR_image_URI:<COMMIT SHA1>)
+2. Tag that digest with a spcific TAG_NAME by running: `./tools/docker/promote.sh <COMMIT SHA1> <TAG_NAME>`
 
 
 ### Step 3: run the pipeline with one click

--- a/tools/docker/promote.sh
+++ b/tools/docker/promote.sh
@@ -6,18 +6,18 @@ set -e
 
 
 if [ $# == 2 ]; then
-    IMAGE_SHA=$1
+    COMMIT_SHA=$1
     IMAGE_TAG=$2
 
 else
-    echo "Usage: $0 <img sha1> <tag>"
+    echo "Usage: $0 <commit sha1> <tag>"
     exit 1
 fi
 
 MANIFEST=$(aws ecr batch-get-image \
     --repository-name craftassist \
     --region us-west-1 \
-    --image-ids imageDigest=$IMAGE_SHA \
+    --image-ids imageTag=$COMMIT_SHA \
     --query "images[].imageManifest" \
     --output text)
 
@@ -31,4 +31,4 @@ aws ecr put-image \
 
 echo
 echo Success!
-echo "Tagged Image <$IMAGE_SHA> as <$IMAGE_TAG>"
+echo "Tagged Image <$COMMIT_SHA> as <$IMAGE_TAG>"

--- a/tools/servermgr/README.md
+++ b/tools/servermgr/README.md
@@ -29,18 +29,18 @@
 1. Verify that the commit passed CI successfully. If all is green, you should see under the "Push versioned docker containers" step a line like
 
 ```
-<Commit SHA1>: digest: <DIGEST>: size: xxxx
+docker push ECR_image_URI:TAG
 ```
 
-Notice that tag is the SHA1 of the latest master commit
+Notice that TAG is the SHA1 of the latest commit
 
 2. Run [tools/docker/promote.sh](https://github.com/facebookresearch/fairo/blob/main/tools/docker/promote.sh) using the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY credentials like this:
 
 ```
-AWS_ACCESS_KEY_ID="key id here" AWS_SECRET_ACCESS_KEY="secret access key here" ./tools/docker/promote.sh <DIGEST from above>
+AWS_ACCESS_KEY_ID="key id here" AWS_SECRET_ACCESS_KEY="secret access key here" ./tools/docker/promote.sh <TAG from above>
 ```
 
-Replacing the <DIGEST from above> with whatever digest you'd like to promote
+Replacing the <TAG from above> with whatever TAG you'd like to promote from step 1.
 
 
 ## How to deploy a new servermgr


### PR DESCRIPTION
# Description

Recently it was reported that wrong image was tagged using `./tools/docker/promote.sh` even if we provided correct ImageDigest. So use ImageTag to search instead of ImageDigest.

This issue needs to be investigated after this fix: #842 


## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.


# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I have verified that all scripts in `tests/scripts` runs on hardware.
