### PR TITLE
[HiTL] Force ECS instances to upload agent logs to S3 upon termination

### DIFF
--- a/droidlet/tools/hitl/utils/allocate_instances.py
+++ b/droidlet/tools/hitl/utils/allocate_instances.py
@@ -324,30 +324,26 @@ if __name__ == "__main__":
         "--task_name", type=str, help="Task name of the ecs instance to be requested"
     )
     args = parser.parse_args()
-    instance_ips, instance_ids = request_instance(args.instance_num, args.image_tag, args.task_name, batch_id=11300246)
-    print(f'instance ips: {instance_ips}')
-    import time
-    time.sleep(120)
-    free_ecs_instances(instance_ids)
-    # batch_id = args.batch_id
-    # # register subdomain to proxy instance IP
-    # if os.getenv("CLOUDFLARE_TOKEN") and os.getenv("CLOUDFLARE_ZONE_ID"):
-    #     logging.info("registering subdomains on craftassist.io")
-    #     cloudflare_token = os.getenv("CLOUDFLARE_TOKEN")
-    #     zone_id = os.getenv("CLOUDFLARE_ZONE_ID")
-    #     cf = CloudFlare.CloudFlare(email=args.user, token=cloudflare_token)
-    #     dns_records = cf.zones.dns_records.get(zone_id)
+    instance_ips, instance_ids = request_instance(args.instance_num, args.image_tag, args.task_name, batch_id="0643")
+    batch_id = args.batch_id
+    # register subdomain to proxy instance IP
+    if os.getenv("CLOUDFLARE_TOKEN") and os.getenv("CLOUDFLARE_ZONE_ID"):
+        logging.info("registering subdomains on craftassist.io")
+        cloudflare_token = os.getenv("CLOUDFLARE_TOKEN")
+        zone_id = os.getenv("CLOUDFLARE_ZONE_ID")
+        cf = CloudFlare.CloudFlare(email=args.user, token=cloudflare_token)
+        dns_records = cf.zones.dns_records.get(zone_id)
 
-    #     # Write the subdomains and batch IDs to input CSV for Mephisto
-    #     # CSV file headers
-    #     headers = ["subdomain", "batch"]
-    #     with open("../../../../tools/crowdsourcing/droidlet_static_html_task/data.csv", "w") as fd:
-    #         csv_writer = csv.writer(fd, delimiter=",")
-    #         csv_writer.writerow(headers)
-    #         for x in range(len(instance_ips)):
-    #             ip = instance_ips[x]
-    #             subdomain = "dashboard-{}-{}".format(batch_id, x)
-    #             register_dashboard_subdomain(cf, zone_id, ip, subdomain)
-    #             # Write record to Mephisto task input CSV
-    #             csv_writer.writerow([subdomain, batch_id])
+        # Write the subdomains and batch IDs to input CSV for Mephisto
+        # CSV file headers
+        headers = ["subdomain", "batch"]
+        with open("../../../../tools/crowdsourcing/droidlet_static_html_task/data.csv", "w") as fd:
+            csv_writer = csv.writer(fd, delimiter=",")
+            csv_writer.writerow(headers)
+            for x in range(len(instance_ips)):
+                ip = instance_ips[x]
+                subdomain = "dashboard-{}-{}".format(batch_id, x)
+                register_dashboard_subdomain(cf, zone_id, ip, subdomain)
+                # Write record to Mephisto task input CSV
+                csv_writer.writerow([subdomain, batch_id])
 

--- a/droidlet/tools/hitl/utils/run.withagent.sh
+++ b/droidlet/tools/hitl/utils/run.withagent.sh
@@ -3,6 +3,8 @@
 
 S3_DEST=s3://droidlet-hitl
 
+echo "CHILD PID $$"
+
 function background_agent() (
     echo "Running craftassist agent"
     python3 /fairo/droidlet/lowlevel/minecraft/craftassist_cuberite_utils/wait_for_cuberite.py --host localhost --port 25565

--- a/tools/docker/run.fromenv.sh
+++ b/tools/docker/run.fromenv.sh
@@ -4,7 +4,6 @@
 
 set -u
 
-echo "PID $$"
 echo $RUN_SH_GZ_B64 | base64 --decode | gunzip > /run.sh
 chmod +x /run.sh
 . /run.sh

--- a/tools/docker/run.fromenv.sh
+++ b/tools/docker/run.fromenv.sh
@@ -6,4 +6,4 @@ set -u
 
 echo $RUN_SH_GZ_B64 | base64 --decode | gunzip > /run.sh
 chmod +x /run.sh
-/run.sh
+. /run.sh

--- a/tools/docker/run.fromenv.sh
+++ b/tools/docker/run.fromenv.sh
@@ -4,6 +4,7 @@
 
 set -u
 
+echo "PID $$"
 echo $RUN_SH_GZ_B64 | base64 --decode | gunzip > /run.sh
 chmod +x /run.sh
 . /run.sh


### PR DESCRIPTION
# Description

Currently in turk version dashboard the agent logs are collected and uploaded to S3 only when turkers click on the 'END' button. We've add strict restrictions on HIT page to enforce turkers to click on that button but still only ~40% logs are collected in S and we are not sure why it happens,

This PR added some handlers to ECS instance terminations so that they can terminate gracefully -- meaning that they will always collect and upload agent logs to S3 right before they are shut down by AWS. Specifically, a SIGTERM signal is what AWS will send to the ECS docker container first when we issue a command like `ecs.stop_task()`, so we trapped that signal and added a customized handler to do the cleanup work.


## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

If this PR introduces a change or fixes a bug, please add before and after screenshots (if this is causes a UX change) or before and after examples(this could be plain text, videos etc ) to demonstrate the change.

If this PR introduces a new feature, please also add examples or screenshots demonstrating the feature.

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I have verified that all scripts in `tests/scripts` runs on hardware.
