### PR TITLE
setting exploration goal in agent, making Explore a TrajectorySaverTask

### DIFF
--- a/droidlet/interpreter/robot/default_behaviors.py
+++ b/droidlet/interpreter/robot/default_behaviors.py
@@ -3,8 +3,47 @@ Copyright (c) Facebook, Inc. and its affiliates.
 """
 import logging
 from droidlet.interpreter.robot import tasks
+import os
+import random
+import numpy as np
 
+random.seed(2021) # fixing a random seed to fix default exploration goal
+first_exploration_done = False
+
+def get_distant_goal(x, y, t, l1_thresh=35):
+    # Get a distant goal for the slam exploration
+    # Pick a random quadrant, get 
+    while True:
+        xt = random.randint(-19, 19)
+        yt = random.randint(-19, 19)
+        d = np.linalg.norm(np.asarray([x,y]) - np.asarray([xt,yt]), ord=1)
+        if d > l1_thresh:
+            return (xt, yt, 0)
+
+def start_explore(agent, goal):
+    global first_exploration_done
+    goal_str = '_'.join(str(g) for g in goal)
+
+    if not first_exploration_done or os.getenv('CONTINUOUS_EXPLORE', 'False') == 'True':
+        agent.mover.slam.reset_map()
+        agent.mover.nav.reset_explore()
+        task_data = { 
+            "goal": goal, 
+            "save_data": os.getenv('SAVE_EXPLORATION', 'False') == 'True',
+            "data_path": f"{os.getenv('HEURISTIC', 'default')}/goal" + goal_str,
+        }
+
+        if os.getenv('HEURISTIC') == 'straightline':
+            logging.info('Default behavior: Curious Exploration')
+            # do curious exploration
+            # agent.memory.task_stack_push(tasks.CuriousExplore(agent, task_data))
+        else:
+            logging.info('Default behavior: Default Exploration')
+            agent.memory.task_stack_push(tasks.Explore(agent, task_data))
+        
+        first_exploration_done = True
 
 def explore(agent):
-    logging.info("Default behavior: Exploration")
-    agent.memory.task_stack_push(tasks.Explore(agent, {}))
+    x,y,t = agent.mover.get_base_pos()
+    goal = get_distant_goal(x,y,t)
+    start_explore(agent, goal)

--- a/droidlet/interpreter/robot/tasks.py
+++ b/droidlet/interpreter/robot/tasks.py
@@ -360,22 +360,24 @@ class TrajectorySaverTask(Task):
         return "<TrajectorySaverTask {}>".format(self.target)
 
 
-class Explore(Task):
+class Explore(TrajectorySaverTask):
     """use slam to explore environemt"""
 
     def __init__(self, agent, task_data):
-        super().__init__(agent)
+        super().__init__(agent, task_data)
         self.command_sent = False
         self.agent = agent
+        self.goal = task_data.get("goal", (19,19,0))
         TaskNode(agent.memory, self.memid).update_task(task=self)
 
     @Task.step_wrapper
     def step(self):
+        super().step()
         self.interrupted = False
         self.finished = False
         if not self.command_sent:
             self.command_sent = True
-            self.agent.mover.explore()
+            self.agent.mover.explore(self.goal)
         else:
             self.finished = self.agent.mover.bot_step()
 

--- a/droidlet/lowlevel/locobot/locobot_mover.py
+++ b/droidlet/lowlevel/locobot/locobot_mover.py
@@ -378,9 +378,9 @@ class LoCoBotMover:
         """
         return self.bot.grasp(bounding_box)
 
-    def explore(self):
+    def explore(self, goal):
         if self.nav_result.ready:
-            self.nav_result = safe_call(self.nav.explore)
+            self.nav_result = safe_call(self.nav.explore, goal)
         else:
             print("navigator executing another call right now")
         return self.nav_result

--- a/droidlet/lowlevel/locobot/remote/navigation_service.py
+++ b/droidlet/lowlevel/locobot/remote/navigation_service.py
@@ -113,12 +113,11 @@ class Navigation(object):
         self._busy = False
         return return_code
 
-    def explore(self):
+    def explore(self, far_away_goal):
         if not hasattr(self, '_done_exploring'):
             self._done_exploring = False
         if not self._done_exploring:
             print("exploring 1 step")
-            far_away_goal = (19, 19, 0)
             success = self.go_to_absolute(far_away_goal, steps=1)       
             if success == False:
                 # couldn't reach far_away_goal


### PR DESCRIPTION
* Moves setting the goal for exploration to the agent. This was previously hard-coded in the navigation service.
* Adds an environment variable `CONTINUOUS_EXPLORE` to continuously keep exploring. This is useful for collecting multiple exploration trajectories.
* Changes `Explore` into a `TrajectorySaverTask`

Stack from [ghstack](https://github.com/ezyang/ghstack):
* #911
* #909
* #900
* #861
* #860
* #859
* #858
* __->__ #857
* #856
* #855
* #854

