### PR TITLE
reset explore changes

### DIFF
--- a/droidlet/lowlevel/locobot/remote/navigation_service.py
+++ b/droidlet/lowlevel/locobot/remote/navigation_service.py
@@ -55,6 +55,7 @@ class Navigation(object):
         self.robot = robot
         self.trackback = Trackback(planner)
         self._busy = False
+        self._done_exploring = False
 
     def go_to_relative(self, goal):
         robot_loc = self.robot.get_base_state()
@@ -128,6 +129,12 @@ class Navigation(object):
 
     def is_busy(self):
         return self._busy
+
+    def is_done_exploring(self):
+        return self._done_exploring
+
+    def reset_explore(self):
+        self._done_exploring = False
 
 robot_ip = os.getenv('LOCOBOT_IP')
 ip = os.getenv('LOCAL_IP')

--- a/droidlet/lowlevel/locobot/remote/slam_service.py
+++ b/droidlet/lowlevel/locobot/remote/slam_service.py
@@ -31,6 +31,7 @@ class SLAM(object):
             agent_min_z=agent_min_z,
             agent_max_z=agent_max_z,
         )
+        self.map_size = map_size
         # if the map is a previous map loaded from disk, and
         # if the robot looks around and registers itself at a
         # non-origin location in the map just as it is coming up,
@@ -111,6 +112,9 @@ class SLAM(object):
             for indice in zip(indices[0], indices[1])
         ]
         return real_world_locations
+    
+    def reset_map(self):
+        self.map_builder.reset_map(self.map_size)
 
 
 robot_ip = os.getenv('LOCOBOT_IP')


### PR DESCRIPTION
Changes to reset exploration - we want to reset the map builder and reset the `_is_done_exploring` flag in slam.

Stack from [ghstack](https://github.com/ezyang/ghstack):
* #911
* #909
* #900
* #861
* #860
* #859
* __->__ #858
* #857
* #856
* #855
* #854

