### PR TITLE
CuriousExplore + ExamineDetectionStraightline

### DIFF
--- a/droidlet/interpreter/robot/default_behaviors.py
+++ b/droidlet/interpreter/robot/default_behaviors.py
@@ -35,8 +35,7 @@ def start_explore(agent, goal):
 
         if os.getenv('HEURISTIC') == 'straightline':
             logging.info('Default behavior: Curious Exploration')
-            # do curious exploration
-            # agent.memory.task_stack_push(tasks.CuriousExplore(agent, task_data))
+            agent.memory.task_stack_push(tasks.CuriousExplore(agent, task_data))
         else:
             logging.info('Default behavior: Default Exploration')
             agent.memory.task_stack_push(tasks.Explore(agent, task_data))

--- a/droidlet/interpreter/robot/tasks.py
+++ b/droidlet/interpreter/robot/tasks.py
@@ -7,7 +7,7 @@ import logging
 import numpy as np
 import os
 import math
-from droidlet.memory.robot.loco_memory import DetectedObjectNode
+from droidlet.memory.robot.loco_memory_nodes import DetectedObjectNode
 from droidlet.task.task import Task, BaseMovementTask
 from droidlet.memory.memory_nodes import TaskNode
 
@@ -526,7 +526,7 @@ class Explore(TrajectorySaverTask):
         super().__init__(agent, task_data)
         self.command_sent = False
         self.agent = agent
-        self.goal = task_data.get("goal", (19,19,0))
+        self.goal = task_data.get("goal")
         TaskNode(agent.memory, self.memid).update_task(task=self)
 
     @Task.step_wrapper

--- a/droidlet/lowlevel/locobot/remote/remote_locobot.py
+++ b/droidlet/lowlevel/locobot/remote/remote_locobot.py
@@ -426,7 +426,7 @@ if __name__ == "__main__":
         help="Optional config argument to be passed to the backend."
         "Currently mainly used to pass Habitat environment path",
         type=str,
-        default='/Replica-Dataset/apartment_0/habitat/mesh_semantic.ply',
+        default='/scratch/apratik/replica/apartment_0/habitat/mesh_semantic.ply',
     )
     parser.add_argument(
          "--noisy",

--- a/droidlet/lowlevel/robot_mover_utils.py
+++ b/droidlet/lowlevel/robot_mover_utils.py
@@ -221,7 +221,7 @@ class TrajectoryDataSaver:
 
 
 vis_count = 0
-def visualize_examine(agent, robot_poses, object_xyz, label, obstacle_map, pts):
+def visualize_examine(agent, robot_poses, object_xyz, label, obstacle_map, gt_pts=None):
     global vis_count
     # plt.figure()
     plt.title("Examine Visual")
@@ -242,10 +242,72 @@ def visualize_examine(agent, robot_poses, object_xyz, label, obstacle_map, pts):
     robot_poses = np.asarray(robot_poses)
     plt.plot(robot_poses[:,0], robot_poses[:,1], 'r--')
 
-    pts = np.asarray(pts)
-    plt.plot(pts[:,0], pts[:,1], 'y--')
+    if gt_pts:
+        pts = np.asarray(gt_pts)
+        plt.plot(pts[:,0], pts[:,1], 'y--')
     
     # TODO: visualize robot heading 
     
     plt.savefig("{:04d}.jpg".format(vis_count))
     vis_count += 1
+
+class ExaminedMap:
+    """A helper static class to maintain the state representations needed to track active exploration.
+    droidlet.interpreter.robot.tasks.CuriousExplore uses this to decide which objects to explore next.
+    The core of this class is the ExaminedMap.can_examine method. This is a heuristic.
+    Long term, this information should live in memory (#FIXME @anuragprat1k). 
+    
+    It works as follows -
+    1. for each new candidate coordinate, it fetches the closest examined coordinate.
+    2. if this closest coordinate is within a certain threshold (1 meter) of the current coordinate, 
+    or if that region has been explored upto a certain number of times (2, for redundancy),
+    it is not explored, since a 'close-enough' region in space has already been explored. 
+    """
+    examined = {}
+    examined_id = set()
+    last = None
+
+    @classmethod
+    def l1(cls, xyz, k):
+        """ returns the l1 distance between two standard coordinates"""
+        return np.linalg.norm(np.asarray([xyz[0], xyz[2]]) - np.asarray([k[0], k[2]]), ord=1)
+
+    @classmethod
+    def get_closest(cls, xyz):
+        """returns closest examined point to xyz"""
+        c = None
+        dist = 1.5
+        for k, v in cls.examined.items():
+            if cls.l1(k, xyz) < dist:
+                dist = cls.l1(k, xyz)
+                c = k
+        if c is None:
+            cls.examined[xyz] = 0
+            return xyz
+        return c
+
+    @classmethod
+    def update(cls, target):
+        """called each time a region is examined. Updates relevant states."""
+        cls.last = cls.get_closest(target['xyz'])
+        cls.examined_id.add(target['eid'])
+        cls.examined[cls.last] += 1
+
+    @classmethod
+    def clear(cls):
+        cls.examined = {}
+        cls.examined_id = set()
+        cls.last = None
+
+    @classmethod
+    def can_examine(cls, x):
+        """decides whether to examine x or not."""
+        loc = x['xyz']
+        k = cls.get_closest(x['xyz'])
+        val = True
+        if cls.last is not None and cls.l1(cls.last, k) < 1:
+            val = False
+        val = cls.examined[k] < 2
+        print(f"can_examine {x['eid'], x['label'], x['xyz'][:2]}, closest {k[:2]}, can_examine {val}")
+        print(f"examined[k] = {cls.examined[k]}")
+        return val

--- a/droidlet/memory/robot/loco_memory.py
+++ b/droidlet/memory/robot/loco_memory.py
@@ -94,3 +94,8 @@ class LocoAgentMemory(AgentMemory):
     def add_dance(self, dance_fn, name=None, tags=[]):
         # a dance is movement determined as a sequence of steps, rather than by its destination
         return DanceNode.create(self, dance_fn, name=name, tags=tags)
+
+    def clear(self, objects):
+        for o in objects:
+            if o['memid'] != self.self_memid:
+                self.forget(o['memid'])

--- a/droidlet/memory/robot/loco_memory_nodes.py
+++ b/droidlet/memory/robot/loco_memory_nodes.py
@@ -150,7 +150,8 @@ class DetectedObjectNode(ReferenceObjectNode):
             "feature_repr": feature_repr,
             "bounds": (minx, miny, minz, maxx, maxy, maxz),
             "bbox": bbox,
-            "mask": mask
+            "mask": mask,
+            "memid": node[0],
         }
 
     def get_pos(self) -> XYZ:


### PR DESCRIPTION
# Description

* Implements `CuriousExplore` and `ExamineDetectionStraightline` as a subclass of `TrajectorySaverTask`.

The following visualization shows all the straightline explorations. Note that it does not visualizes the robot poses where the robot was exploring randomly.

![straightline](https://user-images.githubusercontent.com/57542204/144962798-dd21d4ba-dc3f-435a-acaa-62b728422c3b.gif)


Follow-ups
* The static class ExaminedMap needs to be in memory. Will spec this out.
* Add a habitat test.


Stack from [ghstack](https://github.com/ezyang/ghstack):
* #911
* #909
* #900
* #861
* #860
* __->__ #859
* #858
* #857
* #856
* #855
* #854

