### PR TITLE
Circular examine detection

### DIFF
--- a/droidlet/interpreter/robot/tasks.py
+++ b/droidlet/interpreter/robot/tasks.py
@@ -541,7 +541,8 @@ class ExamineDetectionCircle(TrajectorySaverTask):
         self.finished = False
         logger = logging.getLogger('curious')
         base_pos = self.agent.mover.get_base_pos_in_canonical_coords()
-        self.robot_poses.append(base_pos)
+        if self.steps > 0: # without any steps, the robot isn't on the circle of inspection
+            self.robot_poses.append(base_pos)
         pts = get_circular_path(self.frontier_center, base_pos, radius=0.7, num_points=20)
         dist = np.linalg.norm(base_pos[:2]-np.asarray([self.frontier_center[0], self.frontier_center[2]]))
         logger.info(f"Deciding examination, dist = {dist}")

--- a/droidlet/lowlevel/robot_mover_utils.py
+++ b/droidlet/lowlevel/robot_mover_utils.py
@@ -279,12 +279,11 @@ def visualize_examine(agent, robot_poses, object_xyz, label, obstacle_map, gt_pt
         plt.text(object_xyz[0], object_xyz[2], label)
     
     # visualize robot pose
-    robot_state = robot_poses[-1]
+    if len(robot_poses) > 0:
+        robot_poses = np.asarray(robot_poses)
+        plt.plot(robot_poses[:,0], robot_poses[:,1], 'r--')
 
-    robot_poses = np.asarray(robot_poses)
-    plt.plot(robot_poses[:,0], robot_poses[:,1], 'r--')
-
-    if gt_pts:
+    if len(gt_pts) > 0:
         pts = np.asarray(gt_pts)
         plt.plot(pts[:,0], pts[:,1], 'y--')
     


### PR DESCRIPTION
This commit adds the Circular Examination task. The yellow circle is the circular path generated for the robot to travel along, and the red marks the part of the circle the robot actually travels. Note again that the visualization does not have the robot poses where the robot was randomly exploring.

![circle](https://user-images.githubusercontent.com/57542204/144992930-2873ce83-6184-43c4-9589-cebd4af56b18.gif)

This is a sample of the examine of the first "chair" from the gif above
![chair](https://user-images.githubusercontent.com/57542204/144993937-891c1114-dcde-41da-9dd8-41ab1987a551.gif)

Follow-up:
1. There's a couple of things we can tune here to increase trajectory length - how many points are generated on the circle, and also saving the trajectory where the robot moves to the edge of the circle.
2. Habitat tests.

Stack from [ghstack](https://github.com/ezyang/ghstack):
* #911
* #909
* #900
* __->__ #861
* #860
* #859
* #858
* #857
* #856
* #855
* #854

