### PR TITLE
Use current branch instead of main when tagging branch commits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,6 +163,7 @@ jobs:
           name: Get branch env variable
           command: |
             echo 'export DOCKER_BUILD_ARGS="--build-arg current_branch=${CIRCLE_BRANCH} --build-arg AWS_ACCESS_KEY_ID=${AWS_S3_ACCESS_KEY_ID} --build-arg AWS_SECRET_ACCESS_KEY=${AWS_S3_SECRET_ACCESS_KEY}"' >> $BASH_ENV
+            echo 'export CURRENT_BRANCH="${CIRCLE_BRANCH}"' >> $BASH_ENV
 
       - run:
           name: Build docker containers

--- a/tools/docker/Makefile
+++ b/tools/docker/Makefile
@@ -1,5 +1,5 @@
 REMOTE=492338101900.dkr.ecr.us-west-1.amazonaws.com
-COMMIT_SHA:=$(shell git show --name-only origin/main | head -1 | cut -d' ' -f2)
+COMMIT_SHA:=$(shell git show --name-only origin/${CURRENT_BRANCH} | head -1 | cut -d' ' -f2)
 ARGS=${DOCKER_BUILD_ARGS}
 
 all: build


### PR DESCRIPTION
# Description

We were using latest main commit to tag every docker image to pushed to ECR. It it wrong. We should use the corresponding commit in current branch to tag the image.


## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

If this PR introduces a change or fixes a bug, please add before and after screenshots (if this is causes a UX change) or before and after examples(this could be plain text, videos etc ) to demonstrate the change.

If this PR introduces a new feature, please also add examples or screenshots demonstrating the feature.

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I have verified that all scripts in `tests/scripts` runs on hardware.
