### PR TITLE
Updating special reference in put_memory

### DIFF
--- a/tools/annotation_tools/turk_with_s3/parse_tool_C_outputs.py
+++ b/tools/annotation_tools/turk_with_s3/parse_tool_C_outputs.py
@@ -311,9 +311,9 @@ def handle_components(d, child_name):
         x in ["special_reference.SPEAKER", "special_reference.AGENT"] for x in d.values()
     ):
         if "special_reference.SPEAKER" in d.values():
-            output[child_name] = {"special_reference": "SPEAKER"}
+            output[child_name] = {"special_reference": {"fixed_value": "SPEAKER"}}
         elif "special_reference.AGENT" in d.values():
-            output[child_name] = {"special_reference": "AGENT"}
+            output[child_name] = {"special_reference": {"fixed_value":"AGENT"}}
         child_d = process_dict(with_prefix(d, "{}.".format(child_name)))
         output[child_name].update(child_d)
     else:


### PR DESCRIPTION
# Description

This is a quick fix for a sub dict for get and put memory commands to make `special_reference` value consistent with human_give_command commands.

Fixes # (issue)

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Before:
`{"special_reference": "SPEAKER" / "AGENT"}

After:
`{"special_reference": {"fixed_value": "SPEAKER" / "AGENT"}}`


# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I have verified that all scripts in `tests/scripts` runs on hardware.
