### PR TITLE
[HiTL] Fixed annotation tool bug: only one line is processed

### DIFF
--- a/tools/annotation_tools/turk_with_s3/create_jobs.py
+++ b/tools/annotation_tools/turk_with_s3/create_jobs.py
@@ -43,6 +43,7 @@ def create_turk_job(xml_file_path: str, tool_num: int, input_csv: str, job_spec_
         headers = next(turk_inputs, None)
         # Construct the URL query params
         count = 0
+        all_new_hits = []
         for row in turk_inputs:
             count += 1
             query_params = ""
@@ -122,10 +123,15 @@ def create_turk_job(xml_file_path: str, tool_num: int, input_csv: str, job_spec_
                 # to avoid sorting all column names by default
                 turk_jobs_df = pd.DataFrame(columns=all_columns)
             turk_jobs_df = turk_jobs_df.append(job_spec, ignore_index=True)
-            break
+
+            # don't break here, consume all inputs and create HITs for them
+            # break
+            all_new_hits.append(new_hit)
 
     turk_jobs_df.to_csv(job_spec_csv, index=False)
-    return new_hit["HIT"]["HITId"]
+
+    hit_ids = [new_hit["HIT"]["HITId"] for new_hit in all_new_hits]
+    return hit_ids
     # Remember to modify the URL above when publishing
     # HITs to the live marketplace.
     # Use: https://worker.mturk.com/mturk/preview?groupId=

--- a/tools/annotation_tools/turk_with_s3/run_tool_1A.py
+++ b/tools/annotation_tools/turk_with_s3/run_tool_1A.py
@@ -6,7 +6,7 @@ import os
 import boto3
 
 from create_jobs import create_turk_job
-from get_results import get_hit_result
+from get_results import get_hits_result
 
 """
 Kicks off a pipeline that schedules Turk jobs for tool 1A,
@@ -66,7 +66,7 @@ mturk = boto3.client(
     endpoint_url=MTURK_URL,
 )
 
-get_hit_result(mturk, hit_id, f"{default_write_dir}/A/turk_output.csv", True if dev_flag else False, timeout)
+get_hits_result(mturk, hit_id, f"{default_write_dir}/A/turk_output.csv", True if dev_flag else False, timeout)
 
 # Collate datasets
 print("*"*50)

--- a/tools/annotation_tools/turk_with_s3/run_tool_1B.py
+++ b/tools/annotation_tools/turk_with_s3/run_tool_1B.py
@@ -6,7 +6,7 @@ import os
 import boto3
 
 from create_jobs import create_turk_job
-from get_results import get_hit_result
+from get_results import get_hits_result
 
 """
 Kicks off a pipeline that schedules Turk jobs for tool 1B,
@@ -63,7 +63,7 @@ mturk = boto3.client(
     endpoint_url=MTURK_URL,
 )
 
-get_hit_result(mturk, hit_id, f"{default_write_dir}/B/turk_output.csv", True if dev_flag else False, timeout)
+get_hits_result(mturk, hit_id, f"{default_write_dir}/B/turk_output.csv", True if dev_flag else False, timeout)
 
 # Collate datasets
 print("*"*50)

--- a/tools/annotation_tools/turk_with_s3/run_tool_1C.py
+++ b/tools/annotation_tools/turk_with_s3/run_tool_1C.py
@@ -6,7 +6,7 @@ import os
 import boto3
 
 from create_jobs import create_turk_job
-from get_results import get_hit_result
+from get_results import get_hits_result
 
 """
 Kicks off a pipeline that schedules Turk jobs for tool 1B,
@@ -63,7 +63,7 @@ mturk = boto3.client(
     endpoint_url=MTURK_URL,
 )
 
-get_hit_result(mturk, hit_id, f"{default_write_dir}/C/turk_output.csv", True if dev_flag else False, timeout)
+get_hits_result(mturk, hit_id, f"{default_write_dir}/C/turk_output.csv", True if dev_flag else False, timeout)
 
 # Collate datasets
 print("*"*50)

--- a/tools/annotation_tools/turk_with_s3/run_tool_1D.py
+++ b/tools/annotation_tools/turk_with_s3/run_tool_1D.py
@@ -6,7 +6,7 @@ import os
 import boto3
 
 from create_jobs import create_turk_job
-from get_results import get_hit_result
+from get_results import get_hits_result
 
 """
 Kicks off a pipeline that schedules Turk jobs for tool 1D,
@@ -64,7 +64,7 @@ mturk = boto3.client(
     endpoint_url=MTURK_URL,
 )
 
-get_hit_result(mturk, hit_id, f"{default_write_dir}/D/turk_output.csv", True if dev_flag else False, timeout)
+get_hits_result(mturk, hit_id, f"{default_write_dir}/D/turk_output.csv", True if dev_flag else False, timeout)
 
 # Collate datasets
 print("*"*50)


### PR DESCRIPTION
# Description

In HiTL annotation pipeline, only the first line of input.txt will be processed and used to create HIT jobs. It's not a problem for tool A because in HiTL annotation job always consists of one single command, but for tool B it's a bug because sometimes more than one line needs to be annotated. For example, output of tool A (also the input of tool B) could be a schematic plus a location.

This PR fixed this bug so that all lines of the input are processed and HITs are created from those lines.


## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

**Before**

LF are partially annotated, some fields are missing.

**After**

All the parts of LF are annotated, the combined LF is legit.

# Testing

Tested with '--dev' flag in sandbox and passed.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I have verified that all scripts in `tests/scripts` runs on hardware.
