### PR TITLE
[fbrp] catch bad docker image

### DIFF
--- a/fbrp/Dockerfile
+++ b/fbrp/Dockerfile
@@ -1,7 +1,5 @@
 FROM nvidia/cuda:11.4.1-cudnn8-devel-ubuntu20.04
 
-ENV version=0.0.0
-
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt install -y \
     git \

--- a/fbrp/setup.py
+++ b/fbrp/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="fbrp",
-    version="0.0.5",
+    version="0.0.7",
     author="Leonid Shamis",
     package_dir={"": "src"},
     packages=find_packages(
@@ -14,7 +14,7 @@ setup(
     python_requires=">=3.7",
     install_requires=[
         "aiodocker>=0.21.0",
-        "alephzero>=0.3.8",
+        "alephzero>=0.3.11",
         "docker>=5.0.0",
         "psutil>=5.8.0",
         "pyyaml>=6.0",

--- a/fbrp/src/fbrp/runtime/docker.py
+++ b/fbrp/src/fbrp/runtime/docker.py
@@ -91,7 +91,13 @@ class Launcher(BaseLauncher):
         }
         util.nested_dict_update(run_kwargs, self.kwargs)
 
-        self.proc = await docker.containers.create_or_replace(container, run_kwargs)
+        try:
+            self.proc = await docker.containers.create_or_replace(container, run_kwargs)
+        except Exception as e:
+            life_cycle.set_state(self.name, life_cycle.State.STOPPED, return_code=-1)
+            await docker.close()
+            util.fail(f"Failed to start docker process: name={self.name} reason={e}")
+
         await self.proc.start()
 
         proc_info = await self.proc.show()


### PR DESCRIPTION
# Description

Catch invalid docker images and prevents inconsistent life-cycle state.

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

For the case of
```py
fbrp.process(
    name="killer",
    runtime=fbrp.Docker(image="notreal"),
)
```

Previously, the error would be hidden and the life-cycle would show `killer` as running, with no way for the cli tool to reset state.
Now, the error is caught. The following is printed:
```
Failed to start docker process: name='killer' reason=DockerError(404, 'No such image: notreal:latest')
```
And `ps` correctly shows the process as down.

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I have verified that all scripts in `tests/scripts` runs on hardware.
