### PR TITLE
[fbrp] pull docker if image not found locally

### DIFF
--- a/fbrp/src/fbrp/runtime/docker.py
+++ b/fbrp/src/fbrp/runtime/docker.py
@@ -171,6 +171,18 @@ class Docker(BaseRuntime):
                 elif "errorDetail" in lineinfo:
                     util.fail(json.dumps(lineinfo["errorDetail"], indent=2))
 
+        try:
+            docker_api.images.get(self.image)
+        except docker.errors.ImageNotFound:
+            try:
+                for line in docker_api.lowlevel.pull(self.image, stream=True):
+                    lineinfo = json.loads(line.decode())
+                    if args.verbose and "status" in lineinfo:
+                        print(lineinfo["status"].strip())
+            except docker.errors.NotFound as e:
+                util.fail(e)
+
+
         uses_ldap = util.is_ldap_user()
 
         mount_map = {}

--- a/fbrp/src/fbrp/runtime/docker.py
+++ b/fbrp/src/fbrp/runtime/docker.py
@@ -173,17 +173,9 @@ class Docker(BaseRuntime):
                 elif "errorDetail" in lineinfo:
                     util.fail(json.dumps(lineinfo["errorDetail"], indent=2))
         else:
-            # If the image is marked ":latest", we always pull.
-            # No tag implies latest.
-            should_pull = self.image.endswith(":latest") or ":" not in self.image
-            # If not latest, we pull if the named image is not pre-downloaded.
-            if not should_pull:
-                try:
-                    docker_api.images.get(self.image)
-                except docker.errors.ImageNotFound:
-                    should_pull = True
-            # Download the image, if needed.
-            if should_pull:
+            try:
+                docker_api.images.get(self.image)
+            except docker.errors.ImageNotFound:
                 try:
                     for line in docker_api.lowlevel.pull(self.image, stream=True):
                         lineinfo = json.loads(line.decode())

--- a/fbrp/src/fbrp/runtime/docker.py
+++ b/fbrp/src/fbrp/runtime/docker.py
@@ -174,7 +174,8 @@ class Docker(BaseRuntime):
                     util.fail(json.dumps(lineinfo["errorDetail"], indent=2))
         else:
             # If the image is marked ":latest", we always pull.
-            should_pull = self.image.endswith(":latest")
+            # No tag implies latest.
+            should_pull = self.image.endswith(":latest") or ":" not in self.image
             # If not latest, we pull if the named image is not pre-downloaded.
             if not should_pull:
                 try:


### PR DESCRIPTION
# Description

FBRP should pull docker images, if they are not already in the host's registry.

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

# Testing

Add the following to `fsetup.py`:
```py
fbrp.process(
    name="killer",
    runtime=fbrp.Docker(image="alpine:3.15"),
)
```
And run
```sh
docker rmi alpine:3.15 ; python3 fsetup.py -v up killer --norun
```

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I have verified that all scripts in `tests/scripts` runs on hardware.
