### PR TITLE
Kavya/vision error routing

### DIFF
--- a/droidlet/dashboard/web/src/components/Interact/Question.js
+++ b/droidlet/dashboard/web/src/components/Interact/Question.js
@@ -11,15 +11,15 @@
                                /   \
                              Yes    No -> NSP Error
                               |
-                    Location Ref Exists?
+                    Reference Object Exists?
                             /   \
                           Yes    No -> Other Error
                            |
-             Found Location Ref in Memory?
+             Found Reference Object in Memory?
                          /   \
                        Yes    No -> Perception Error
                         |
-           Is 'This' the Location Ref?
+           Is 'This' the Reference Object? (point at it / flash it)
                      /   \
     Other Error <- Yes    No -> Perception Error
  */
@@ -417,22 +417,6 @@ class Question extends Component {
     this.setState({
       reference_object_description: reference_object_description,
     });
-
-    // else {
-    //   // shouldn't happen
-    //   return (
-    //     <div>
-    //       <h3> Thanks! Press to continue.</h3>
-    //       <Button
-    //         variant="contained"
-    //         color="primary"
-    //         onClick={() => this.props.goToMessage()}
-    //       >
-    //         Done
-    //       </Button>
-    //     </div>
-    //   );
-    // }
   }
 
   renderVisionQuestion() {
@@ -455,8 +439,8 @@ class Question extends Component {
         <div className="question">
           <h3>
             Okay, I was looking for an object of interest called :
-            {reference_object_description}. Here's what I think it is. Does that
-            look right ?
+            {reference_object_description}. I'll make it flash in the world now.
+            Does that object look right ?
           </h3>
           <List className="answers" component="nav">
             <ListItem button onClick={() => this.answerVision(1)}>

--- a/droidlet/dashboard/web/src/components/Interact/Question.js
+++ b/droidlet/dashboard/web/src/components/Interact/Question.js
@@ -410,7 +410,7 @@ class Question extends Component {
           );
         }
       }
-      // If no reference object description found no perception error.
+      // If no reference object description found not a perception error.
     } else {
       console.log("no action dictionary found ..."); // Shouldn't happen....
     }
@@ -445,26 +445,54 @@ class Question extends Component {
       this.setState({ view: 6 });
       return;
     }
-    return (
-      <div className="question">
-        <h3>
-          Okay, looks like I understood your command. I was looking for an
-          object of interest called : {reference_object_description}. Here's
-          what I think it is. Does that look right ?
-        </h3>
-        <List className="answers" component="nav">
-          <ListItem button onClick={() => this.answerVision(1)}>
-            <ListItemText className="listButton" primary="Yes" />
-          </ListItem>
-          <ListItem button onClick={() => this.answerVision(2)}>
-            <ListItemText className="listButton" primary="No" />
-          </ListItem>
-          <ListItem button onClick={() => this.setState({ view: 1 })}>
-            <ListItemText className="listButton" primary="Go Back" />
-          </ListItem>
-        </List>
-      </div>
-    );
+    // Check for this reference object in memory
+    let user_message = null;
+    // NOTE: this should come from the state setter sio event.
+    this.state.memory_entries = null;
+
+    if (this.state.memory_entries) {
+      return (
+        <div className="question">
+          <h3>
+            Okay, I was looking for an object of interest called :
+            {reference_object_description}. Here's what I think it is. Does that
+            look right ?
+          </h3>
+          <List className="answers" component="nav">
+            <ListItem button onClick={() => this.answerVision(1)}>
+              <ListItemText className="listButton" primary="Yes" />
+            </ListItem>
+            <ListItem button onClick={() => this.answerVision(2)}>
+              <ListItemText className="listButton" primary="No" />
+            </ListItem>
+            <ListItem button onClick={() => this.setState({ view: 1 })}>
+              <ListItemText className="listButton" primary="Go Back" />
+            </ListItem>
+          </List>
+        </div>
+      );
+    } else {
+      // No entries found for this reference object in memory
+      return (
+        <div className="question">
+          <h3>
+            I did not find anything called :{reference_object_description} in
+            the world. Does that seem right from your view of the world ?
+          </h3>
+          <List className="answers" component="nav">
+            <ListItem button onClick={() => this.answerVision(1)}>
+              <ListItemText className="listButton" primary="Yes" />
+            </ListItem>
+            <ListItem button onClick={() => this.answerVision(2)}>
+              <ListItemText className="listButton" primary="No" />
+            </ListItem>
+            <ListItem button onClick={() => this.setState({ view: 1 })}>
+              <ListItemText className="listButton" primary="Go Back" />
+            </ListItem>
+          </List>
+        </div>
+      );
+    }
   }
 
   answerVision(index) {


### PR DESCRIPTION
# Description

This PR introduces a new error route on top of parsing error routing. The only missing piece is retrieving the reference object from memory and double checking + adding flashing of the reference object in the renderer.

Here's what the new routing mechanism looks like:
```
"destroy the blue cube"
1. Check if the assistant did it right 
  1. Yes -> Finished take to final page 
  2. No  -> Check if this parser was right:
    1. Yes -> Check if visin model was right (extract description of reference object, check in memory and flash):
      1. Yes -> this is another error type, ask for free form description.  
      2. No -> Mark vision mistake in state
    2. No -> Mark parser mistake in state
```

Current flow:
<img width="526" alt="Screen Shot 2021-12-21 at 3 06 51 PM" src="https://user-images.githubusercontent.com/5814583/147009112-926f34d6-731f-46f9-a363-77c0ef2e432c.png">
<img width="552" alt="Screen Shot 2021-12-21 at 3 07 03 PM" src="https://user-images.githubusercontent.com/5814583/147009123-9ae28104-b218-4aa2-9066-29285b79ab9c.png">

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.


# Testing

To repro the flow test with the command : "destroy the blue cube"
The parser gets it right but agent fails overall.

Note:
1. We still need to check the reference object against memory - this isn't trivial right now.
2. We need to add flashing of reference object to renderer.

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I have verified that all scripts in `tests/scripts` runs on hardware.
