### PR TITLE
get recent entities to pass to dashboard; also update recent entities when interpreting reference objects

### DIFF
--- a/agents/droidlet_agent.py
+++ b/agents/droidlet_agent.py
@@ -286,10 +286,6 @@ class DroidletAgent(BaseAgent):
         if self.count == 0:
             logging.debug("First top-level step()")
         super().step()
-        if self.count > 200:
-            import ipdb
-
-            ipdb.set_trace()
         self.maybe_dump_memory_to_dashboard()
 
     def task_step(self, sleep_time=0.25):

--- a/agents/droidlet_agent.py
+++ b/agents/droidlet_agent.py
@@ -156,26 +156,29 @@ class DroidletAgent(BaseAgent):
                 )
                 if logical_form_triples:
                     logical_form_mem = self.memory.get_mem_by_id(logical_form_triples[0][2])
+                    logical_form = logical_form_mem.logical_form
                 if logical_form:
                     logical_form = self.dialogue_manager.dialogue_object_mapper.postprocess_logical_form(
                         speaker="dashboard", chat=chat, logical_form=logical_form_mem.logical_form
                     )
-                    # FIXME should be able to get this from the memory node
-                    _, create_times = self.memory.basic_search(
-                        "SELECT create_time FROM ProgramNode WHERE uuid={}".format(
-                            logical_form_mem.memid
-                        )
+                    where = "WHERE <<?, attended_while_interpreting, #{}>>".format(
+                        logical_form_mem.memid
                     )
-                    create_time = create_times[0]
-                    query = "SELECT MEMORY FROM ReferenceObject WHERE attended_time>{}".format(
-                        create_time
+                    _, refobjs = self.memory.basic_search(
+                        "SELECT MEMORY FROM ReferenceObject " + where
                     )
-                    _, refobjs = self.memory.basic_search(query)
-                    point_targets = [r.get_point_target() for r in refobjs]
+                    ref_obj_data = [
+                        {
+                            "point_target": r.get_point_at_target(),
+                            "node_type": r.NODE_TYPE,
+                            "tags": r.get_tags(),
+                        }
+                        for r in refobjs
+                    ]
             except Exception as e:
                 logging.debug(f"Failed to find any action dict for command [{chat}] in memory")
 
-            payload = {"action_dict": logical_form, "recent_refobj_point_targets": point_targets}
+            payload = {"action_dict": logical_form, "lf_refobj_data": ref_obj_data}
             sio.emit("setLastChatActionDict", payload)
 
         @sio.on("terminateAgent")

--- a/droidlet/interpreter/interpret_location.py
+++ b/droidlet/interpreter/interpret_location.py
@@ -4,7 +4,7 @@ Copyright (c) Facebook, Inc. and its affiliates.
 
 import math
 from droidlet.shared_data_structs import ErrorWithResponse
-from .interpreter_utils import SPEAKERLOOK, backoff_where
+from .interpreter_utils import SPEAKERLOOK, backoff_where, update_attended_and_link_lf
 
 
 def interpret_relative_direction(interpreter, location_d):
@@ -56,7 +56,7 @@ class ReferenceLocationInterpreter:
                 if mem1 is None or mem2 is None:
                     raise ErrorWithResponse("I don't know what you're referring to")
                 mems = [mem1, mem2]
-                interpreter.memory.update_recent_entities(mems)
+                update_attended_and_link_lf(interpreter, mems)
                 return mems
 
         default_loc = getattr(interpreter, "default_loc", SPEAKERLOOK)
@@ -82,6 +82,6 @@ class ReferenceLocationInterpreter:
 
         # FIXME:
         mems = mems[:expected_num]
-        interpreter.memory.update_recent_entities(mems)
+        update_attended_and_link_lf(interpreter, mems)
 
         return mems

--- a/droidlet/interpreter/interpret_reference_objects.py
+++ b/droidlet/interpreter/interpret_reference_objects.py
@@ -7,7 +7,7 @@ import numpy as np
 from copy import deepcopy
 from typing import cast, List, Tuple, Dict
 
-from .interpreter_utils import SPEAKERLOOK
+from .interpreter_utils import SPEAKERLOOK, update_attended_and_link_lf
 from droidlet.dialog.dialogue_task import ConfirmReferenceObject
 from .interpret_location import interpret_relative_direction
 from droidlet.base_util import euclid_dist, number_from_span, T, XYZ
@@ -129,7 +129,7 @@ def interpret_reference_object(
     if filters_d.get("contains_coreference", "NULL") != "NULL":
         mem = filters_d["contains_coreference"]
         if isinstance(mem, ReferenceObjectNode):
-            interpreter.memory.update_recent_entities([mem])
+            update_attended_and_link_lf(interpreter, [mem])
             return [mem]
         elif mem == "resolved":
             pass
@@ -170,7 +170,7 @@ def interpret_reference_object(
                 loose=loose_speakerlook,
                 all_proximity=all_proximity,
             )
-            interpreter.memory.update_recent_entities(mems)
+            update_attended_and_link_lf(interpreter, mems)
             return mems
 
         elif allow_clarification:
@@ -206,7 +206,7 @@ def interpret_reference_object(
                 self.memid
             )
             _, ref_obj_mems = interpreter.memory.basic_search(query)
-            interpreter.memory.update_recent_entities(ref_obj_mems)
+            update_attended_and_link_lf(interpreter, ref_obj_mems)
             return ref_obj_mems
         else:
             raise ErrorWithResponse("I don't know what you're referring to")

--- a/droidlet/interpreter/interpret_reference_objects.py
+++ b/droidlet/interpreter/interpret_reference_objects.py
@@ -129,6 +129,7 @@ def interpret_reference_object(
     if filters_d.get("contains_coreference", "NULL") != "NULL":
         mem = filters_d["contains_coreference"]
         if isinstance(mem, ReferenceObjectNode):
+            interpreter.memory.update_recent_entities([mem])
             return [mem]
         elif mem == "resolved":
             pass
@@ -161,7 +162,7 @@ def interpret_reference_object(
         #        filters_no_select.pop("location", None)
         candidate_mems = apply_memory_filters(interpreter, speaker, filters_no_select)
         if len(candidate_mems) > 0:
-            return filter_by_sublocation(
+            mems = filter_by_sublocation(
                 interpreter,
                 speaker,
                 candidate_mems,
@@ -169,6 +170,8 @@ def interpret_reference_object(
                 loose=loose_speakerlook,
                 all_proximity=all_proximity,
             )
+            interpreter.memory.update_recent_entities(mems)
+            return mems
 
         elif allow_clarification:
             # no candidates found; ask Clarification
@@ -203,6 +206,7 @@ def interpret_reference_object(
                 self.memid
             )
             _, ref_obj_mems = interpreter.memory.basic_search(query)
+            interpreter.memory.update_recent_entities(ref_obj_mems)
             return ref_obj_mems
         else:
             raise ErrorWithResponse("I don't know what you're referring to")

--- a/droidlet/interpreter/interpreter.py
+++ b/droidlet/interpreter/interpreter.py
@@ -48,10 +48,10 @@ class InterpreterBase:
                 raise Exception("multiple logical forms associated to single interpreter memory")
             logical_form_memid = logical_form_memids[0]
 
-        if (
-            logical_form_memid != "NULL"
-        ):  # if it were "NULL", this is a dummy interpreter of some sort...
-            logical_form_mem = agent_memory.get_mem_by_id(logical_form_memid)
+        if logical_form_memid != "NULL":
+            # if it were "NULL", this is a dummy interpreter of some sort...
+            self.logical_form_memid = logical_form_memid
+            logical_form_mem = agent_memory.get_mem_by_id(self.logical_form_memid)
             self.logical_form = logical_form_mem.logical_form
 
     def step(self, agent):

--- a/droidlet/interpreter/interpreter.py
+++ b/droidlet/interpreter/interpreter.py
@@ -49,7 +49,7 @@ class InterpreterBase:
             logical_form_memid = logical_form_memids[0]
 
         if logical_form_memid != "NULL":
-            # if it were "NULL", this is a dummy interpreter of some sort...
+            # if it were "NULL", this is a dummy interpreter of some sort... probably from a unit test
             self.logical_form_memid = logical_form_memid
             logical_form_mem = agent_memory.get_mem_by_id(self.logical_form_memid)
             self.logical_form = logical_form_mem.logical_form

--- a/droidlet/interpreter/interpreter_utils.py
+++ b/droidlet/interpreter/interpreter_utils.py
@@ -40,12 +40,13 @@ def update_attended_and_link_lf(interpreter, mems):
     and links it to the interpreters logical form (if it has one).
     """
     interpreter.memory.update_recent_entities(mems)
-    for m in mems:
-        interpreter.memory.add_triple(
-            subj=m.memid,
-            pred_text="attended_while_interpreting",
-            obj=interpreter.logical_form_memid,
-        )
+    lf_memid = getattr(interpreter, "logical_form_memid", None)
+    # a dummy interpreter may have no logical form memid associated to it...
+    if lf_memid:
+        for m in mems:
+            interpreter.memory.add_triple(
+                subj=m.memid, pred_text="attended_while_interpreting", obj=lf_memid
+            )
 
 
 # FIXME... be more careful with OR and NOT

--- a/droidlet/interpreter/interpreter_utils.py
+++ b/droidlet/interpreter/interpreter_utils.py
@@ -32,6 +32,22 @@ def strip_prefix(s, pre):
     return s
 
 
+# TODO: do this more carefully so that the mems are associated to
+# their exact place in the logical form
+def update_attended_and_link_lf(interpreter, mems):
+    """
+    for each mem in mems (a list of MemoryNodes), updates its attended time to now, 
+    and links it to the interpreters logical form (if it has one).
+    """
+    interpreter.memory.update_recent_entities(mems)
+    for m in mems:
+        interpreter.memory.add_triple(
+            subj=m.memid,
+            pred_text="attended_while_interpreting",
+            obj=interpreter.logical_form_memid,
+        )
+
+
 # FIXME... be more careful with OR and NOT
 def backoff_where(where_clause, triples_to_tags=True, canonicalize=True, lower=False):
     """


### PR DESCRIPTION
# Description

reference object interpreter updates recently attended on output memories, and the point targets of these are passed to dashboard when asking for a logical form from a chat
Fixes # (issue)

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

