### PR TITLE
properly handle FROM clause when searching on main memory table columns

### DIFF
--- a/droidlet/memory/tests/test_low_level_memory.py
+++ b/droidlet/memory/tests/test_low_level_memory.py
@@ -216,11 +216,20 @@ class BasicTest(unittest.TestCase):
         assert abs(vals[0][0] + 2.0) < 0.01
         assert abs(vals[0][1]) < 0.01
 
-        TripleNode.create(self.memory, subj=sam_memid, pred_text="mother_of", obj=robert_memid)
+        triple_memid = TripleNode.create(
+            self.memory, subj=sam_memid, pred_text="mother_of", obj=robert_memid
+        )
         query = "SELECT MEMORY FROM ReferenceObject WHERE <<#{}, mother_of, ?>>".format(sam_memid)
         memids, _ = m.search(self.memory, query=query)
         assert robert_memid in memids
         assert len(memids) == 1
+
+        # test FROM works
+        query = "SELECT MEMORY FROM Triple WHERE create_time > -100"
+        memids, _ = m.search(self.memory, query=query)
+        assert all([type(self.memory.get_mem_by_id(m)) is TripleNode for m in memids])
+        assert triple_memid in memids
+        assert robert_memid not in memids
 
     def test_chat_apis_memory(self):
         self.memory = AgentMemory()


### PR DESCRIPTION
# Description

There was a bug in basic search where FROM clauses were ignored when the WHERE clause used a column from the main memory table.  This is fixed and a test added. 

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [x] I have added tests that show that the PR is functional.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I have verified that all scripts in `tests/scripts` runs on hardware.
