### PR TITLE
Add ignore_self to memory creation

### DIFF
--- a/droidlet/memory/craftassist/mc_memory.py
+++ b/droidlet/memory/craftassist/mc_memory.py
@@ -63,6 +63,7 @@ class MCAgentMemory(AgentMemory):
         agent_time=None,
         coordinate_transforms=None,
         agent_low_level_data={},
+        ignore_self=False,
     ):
         super(MCAgentMemory, self).__init__(
             db_file=db_file,
@@ -71,6 +72,7 @@ class MCAgentMemory(AgentMemory):
             nodelist=NODELIST,
             agent_time=agent_time,
             coordinate_transforms=coordinate_transforms,
+            ignore_self=ignore_self,
         )
         self.low_level_block_data = agent_low_level_data.get("block_data", {})
         self.banned_default_behaviors = []  # FIXME: move into triple store?

--- a/droidlet/memory/memory_filters.py
+++ b/droidlet/memory/memory_filters.py
@@ -492,7 +492,6 @@ class MemorySearcher:
             except:
                 pass
             # TODO/FIXME switch output format to dicts
-
         return memids, self.handle_output(agent_memory, query, memids)
 
 

--- a/droidlet/memory/memory_filters.py
+++ b/droidlet/memory/memory_filters.py
@@ -494,6 +494,7 @@ class MemorySearcher:
             # TODO/FIXME switch output format to dicts
         return memids, self.handle_output(agent_memory, query, memids)
 
+    
 # TODO subclass for filters that return at most one memory,value?
 # TODO base_query instead of table
 class MemoryFilter:

--- a/droidlet/memory/memory_filters.py
+++ b/droidlet/memory/memory_filters.py
@@ -492,7 +492,9 @@ class MemorySearcher:
             except:
                 pass
             # TODO/FIXME switch output format to dicts
+
         return memids, self.handle_output(agent_memory, query, memids)
+
 
 
 # TODO subclass for filters that return at most one memory,value?

--- a/droidlet/memory/memory_filters.py
+++ b/droidlet/memory/memory_filters.py
@@ -494,8 +494,6 @@ class MemorySearcher:
             # TODO/FIXME switch output format to dicts
         return memids, self.handle_output(agent_memory, query, memids)
 
-
-
 # TODO subclass for filters that return at most one memory,value?
 # TODO base_query instead of table
 class MemoryFilter:

--- a/droidlet/memory/sql_memory.py
+++ b/droidlet/memory/sql_memory.py
@@ -86,6 +86,7 @@ class AgentMemory:
         nodelist=NODELIST,
         agent_time=None,
         on_delete_callback=None,
+        ignore_self=False,
     ):
         if db_log_path:
             self._db_log_file = gzip.open(db_log_path + ".gz", "w")
@@ -135,7 +136,7 @@ class AgentMemory:
         self.tag(self.self_memid, "AGENT")
         self.tag(self.self_memid, "SELF")
 
-        self.searcher = MemorySearcher()
+        self.searcher = MemorySearcher(ignore_self=ignore_self)
 
     def __del__(self):
         """Close the database file"""


### PR DESCRIPTION
# Description

When searching the memory, we sometimes want to ignore the self reference object. Previously, we had an option in the forward pass, which was deprecated. This change adds the ignore_self option as an argument to the memory searcher where the default option is False.


## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

If this PR introduces a change or fixes a bug, please add before and after screenshots (if this is causes a UX change) or before and after examples(this could be plain text, videos etc ) to demonstrate the change.

If this PR introduces a new feature, please also add examples or screenshots demonstrating the feature.

# Testing

I ran the build_memory_eqa_data.py script for the neural memory repo.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I have verified that all scripts in `tests/scripts` runs on hardware.
