### PR TITLE
[fbrp] Conda add env_nosandbox

### DIFF
--- a/fbrp/setup.py
+++ b/fbrp/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="fbrp",
-    version="0.0.8",
+    version="0.0.9",
     author="Leonid Shamis",
     package_dir={"": "src"},
     packages=find_packages(

--- a/fbrp/src/fbrp/runtime/conda.py
+++ b/fbrp/src/fbrp/runtime/conda.py
@@ -193,6 +193,22 @@ class Conda(BaseRuntime):
             use_mamba if use_mamba is not None else bool(shutil.which("mamba"))
         )
 
+        if env_nosandbox:
+            self._validate_env_nosandbox()
+
+    def _validate_env_nosandbox(self):
+        result = subprocess.run(
+            f"""
+                eval "$(conda shell.bash hook)"
+                conda activate {self.env_nosandbox}
+            """,
+            shell=True,
+            executable="/bin/bash",
+            stderr=subprocess.PIPE,
+        )
+        if result.returncode:
+            util.fail(f"'env_nosandbox' not valid: {result.stderr}")
+
     def _env_name(self, name):
         return self.env_nosandbox or f"fbrp_{name}"
 

--- a/fbrp/src/fbrp/runtime/conda.py
+++ b/fbrp/src/fbrp/runtime/conda.py
@@ -68,24 +68,27 @@ class Launcher(BaseLauncher):
         self,
         run_command: typing.List[str],
         name: str,
+        env_name: str,
         proc_def: ProcDef,
         args: argparse.Namespace,
     ):
         self.run_command = run_command
         self.name = name
+        self.env_name = env_name
         self.proc_def = proc_def
         self.args = args
 
-    async def activate_conda_env(self) -> dict:
+    async def activate_conda_envvar(self) -> dict:
         # We grab the conda env variables separate from executing the run
         # command to simplify detecting pid and removing some race conditions.
         subprocess_env = os.environ.copy()
         subprocess_env.update(self.proc_def.env)
-        envinfo = await asyncio.create_subprocess_shell(
+        envvar_file = f"/tmp/fbrp_conda_{self.name}.env"
+        envvar_info = await asyncio.create_subprocess_shell(
             f"""
                 eval "$(conda shell.bash hook)"
-                conda activate fbrp_{self.name}
-                cp -f /proc/self/environ /tmp/fbrp_conda_{self.name}.env
+                conda activate {self.env_name}
+                cp -f /proc/self/environ {envvar_file}
             """,
             stdout=asyncio.subprocess.PIPE,
             executable="/bin/bash",
@@ -93,12 +96,11 @@ class Launcher(BaseLauncher):
             env=subprocess_env,
         )
 
-        await envinfo.wait()
-        lines = open(f"/tmp/fbrp_conda_{self.name}.env").read().split("\0")
-        conda_env = dict(line.split("=", 1) for line in lines if "=" in line)
-        return conda_env
+        await envvar_info.wait()
+        lines = open(envvar_file).read().split("\0")
+        return dict(line.split("=", 1) for line in lines if "=" in line)
 
-    async def run_cmd_in_env(self, conda_env):
+    async def run_cmd_with_envvar(self, conda_env):
         self.proc = await asyncio.create_subprocess_shell(
             util.shell_join(self.run_command),
             stdout=asyncio.subprocess.PIPE,
@@ -127,8 +129,8 @@ class Launcher(BaseLauncher):
 
     async def run(self):
         life_cycle.set_state(self.name, life_cycle.State.STARTING)
-        conda_env = await self.activate_conda_env()
-        await self.run_cmd_in_env(conda_env)
+        conda_env = await self.activate_conda_envvar()
+        await self.run_cmd_with_envvar(conda_env)
         life_cycle.set_state(self.name, life_cycle.State.STARTED)
         await self.gather_cmd_outputs()
 
@@ -170,13 +172,20 @@ class Conda(BaseRuntime):
         run_command,
         yaml=None,
         env=None,
+        env_nosandbox=None,
         channels=[],
         dependencies=[],
         setup_commands=[],
         use_mamba=None,
     ):
+        if env_nosandbox and any([yaml, env, channels, dependencies]):
+            util.fail(
+                f"'env_nosandbox' cannot be mixed with other Conda environment commands."
+            )
+
         self.yaml = yaml
         self.env = env
+        self.env_nosandbox = env_nosandbox
         self.run_command = run_command
         self.conda_env = CondaEnv(channels[:], dependencies[:])
         self.setup_commands = setup_commands
@@ -184,7 +193,10 @@ class Conda(BaseRuntime):
             use_mamba if use_mamba is not None else bool(shutil.which("mamba"))
         )
 
-    def _build(self, name: str, proc_def: ProcDef, args: argparse.Namespace):
+    def _env_name(self, name):
+        return self.env_nosandbox or f"fbrp_{name}"
+
+    def _create_env(self, name: str, proc_def: ProcDef, args: argparse.Namespace):
         if self.yaml:
             yaml_path = os.path.join(proc_def.root, self.yaml)
             self.conda_env = CondaEnv.merge(
@@ -196,13 +208,12 @@ class Conda(BaseRuntime):
 
         self.conda_env.fix_pip()
 
-        env_name = f"fbrp_{name}"
         env_path = f"/tmp/fbrp_conda_{name}.yml"
 
         with open(env_path, "w") as env_fp:
             json.dump(
                 {
-                    "name": env_name,
+                    "name": self._env_name(name),
                     "channels": self.conda_env.channels,
                     "dependencies": self.conda_env.dependencies,
                 },
@@ -216,7 +227,7 @@ class Conda(BaseRuntime):
         # https://github.com/conda/conda/issues/7279
         # Updating an existing environment does not remove old packages, even with --prune.
         subprocess.run(
-            [update_bin, "env", "remove", "-n", env_name],
+            [update_bin, "env", "remove", "-n", self._env_name(name)],
             capture_output=not args.verbose,
         )
         result = subprocess.run(
@@ -226,6 +237,10 @@ class Conda(BaseRuntime):
         if result.returncode:
             util.fail(f"Failed to set up conda env: {result.stderr}")
 
+    def _build(self, name: str, proc_def: ProcDef, args: argparse.Namespace):
+        if not self.env_nosandbox:
+            self._create_env(name, proc_def, args)
+
         if self.setup_commands:
             print(f"setting up conda env for {name}")
             setup_command = "\n".join(
@@ -234,7 +249,7 @@ class Conda(BaseRuntime):
             result = subprocess.run(
                 f"""
                     eval "$(conda shell.bash hook)"
-                    conda activate {env_name}
+                    conda activate {self._env_name(name)}
                     cd {proc_def.root}
                     {setup_command}
                 """,
@@ -246,7 +261,7 @@ class Conda(BaseRuntime):
                 util.fail(f"Failed to set up conda env: {result.stderr}")
 
     def _launcher(self, name: str, proc_def: ProcDef, args: argparse.Namespace):
-        return Launcher(self.run_command, name, proc_def, args)
+        return Launcher(self.run_command, name, self._env_name(name), proc_def, args)
 
 
 __all__ = ["Conda"]

--- a/fbrp/tests/fbrp/runtime/test_conda.py
+++ b/fbrp/tests/fbrp/runtime/test_conda.py
@@ -70,13 +70,14 @@ class TestLauncher(IsolatedAsyncioTestCase):
         )
         launcher = Launcher(
             name="test_conda",
+            env_name="fbrp_test_conda",
             run_command=["python3", "alice.py"],
             proc_def=proc_def,
             args=mock_namespace,
         )
         os_env_patch = mock.patch.dict(os.environ, {"my_path": "path"})
         os_env_patch.start()
-        conda_env = await launcher.activate_conda_env()
+        conda_env = await launcher.activate_conda_envvar()
         mock_file.assert_called_with(f"/tmp/fbrp_conda_test_conda.env")
         assert len(conda_env) == 1
         self.assertDictEqual(conda_env, {"env_var": "data"})
@@ -84,14 +85,14 @@ class TestLauncher(IsolatedAsyncioTestCase):
 
     @patch("fbrp.life_cycle.set_state")
     @patch("fbrp.runtime.conda.Launcher.gather_cmd_outputs")
-    @patch("fbrp.runtime.conda.Launcher.run_cmd_in_env")
-    @patch("fbrp.runtime.conda.Launcher.activate_conda_env")
+    @patch("fbrp.runtime.conda.Launcher.run_cmd_with_envvar")
+    @patch("fbrp.runtime.conda.Launcher.activate_conda_envvar")
     @patch("argparse.Namespace")
     async def test_run(
         self,
         mock_namespace,
         mock_activate_conda_env,
-        mock_run_cmd_in_env,
+        mock_run_cmd_with_envvar,
         mock_gather_cmd_outputs,
         mock_set_state,
     ):
@@ -106,13 +107,14 @@ class TestLauncher(IsolatedAsyncioTestCase):
         )
         launcher = Launcher(
             name="test_conda",
+            env_name="fbrp_test_conda",
             run_command=["python3", "alice.py"],
             proc_def=proc_def,
             args=mock_namespace,
         )
         await launcher.run()
         mock_activate_conda_env.assert_called_once()
-        mock_run_cmd_in_env.assert_called_once()
+        mock_run_cmd_with_envvar.assert_called_once()
         mock_gather_cmd_outputs.assert_called_once()
         assert mock_set_state.call_count == 2
         mock_set_state.assert_has_calls(
@@ -137,6 +139,7 @@ class TestLauncher(IsolatedAsyncioTestCase):
         )
         launcher = Launcher(
             name="test_conda",
+            env_name="fbrp_test_conda",
             run_command=["python3", "alice.py"],
             proc_def=proc_def,
             args=mock_namespace,


### PR DESCRIPTION
# Description

Adds a Conda runtime flag, `env_nosandbox`, which, like `env`, uses an existing conda environment, but does not make a clone.
This is fast to load and can point to directories:

```py
fbrp.process(
    name="proc",
    runtime=fbrp.Conda(
        env_nosandbox="~/anaconda3/envs/fbrp_alice/",
        run_command=["python3", "proc.py"],
    ),
)
```

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

# Testing

With proc.py:
```py
import time
import platform

i = 0
while True:
    print(platform.python_version(), f"i={i}")
    i += 1
    time.sleep(1)
```

Ran `python3 fsetup.py -v up -f && python3 fsetup.py logs`

Changed the `env_nosandbox` to point to another conda env that had a different version of python and reran the command.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I have verified that all scripts in `tests/scripts` runs on hardware.
