### PR TITLE
[polymetis] Better logging, fix flaky tests

### DIFF
--- a/polymetis/polymetis/include/polymetis/polymetis_server.hpp
+++ b/polymetis/polymetis/include/polymetis/polymetis_server.hpp
@@ -37,6 +37,7 @@ using grpc::ServerReader;
 using grpc::ServerReaderWriter;
 using grpc::ServerWriter;
 using grpc::Status;
+using grpc::StatusCode;
 
 /**
 TODO

--- a/polymetis/polymetis/src/polymetis_server.cpp
+++ b/polymetis/polymetis/src/polymetis_server.cpp
@@ -178,10 +178,9 @@ PolymetisControllerServerImpl::ControlUpdate(ServerContext *context,
   } else {
     controller = robot_client_context_.default_controller;
   }
-
+  std::vector<float> desired_torque;
   try {
-    std::vector<float> desired_torque =
-        controller->forward(*torch_robot_state_);
+    desired_torque = controller->forward(*torch_robot_state_);
   } catch (const std::exception &e) {
     custom_controller_context_.controller_mtx.unlock();
     std::string error_msg =

--- a/polymetis/tests/scripts/3_timestamps.py
+++ b/polymetis/tests/scripts/3_timestamps.py
@@ -35,7 +35,7 @@ class TimestampCheckController(toco.PolicyModule):
         # Check timestamp
         if self.i > self.warmup_steps:
             t_diff = toco.utils.timestamp_diff_seconds(ts, self.ts_prev)
-            assert torch.allclose(t_diff, self.dt, atol=1e-3)  # millisecond accuracy
+            assert torch.allclose(t_diff, self.dt, atol=2e-3)  # 2ms accuracy
 
         # Update
         self.i += 1

--- a/polymetis/tests/test_empty_statistics_client.sh
+++ b/polymetis/tests/test_empty_statistics_client.sh
@@ -14,15 +14,15 @@ export HYDRA_FULL_ERROR=1
 # Test empty statistics client
 ######################
 # Start server & robot client
-echo "=== Starting server and testing empty statistics client... ==="
+echo "========= Starting server and testing empty statistics client... ========="
 launch_robot.py robot_client=empty_statistics_client use_real_time=false num_requests=5000 &
 server_pid=$!
-echo "=== Server PID: $server_pid ==="
+echo "========= Server PID: $server_pid ========="
 
 # Wait
 sleep 8
 
-echo "=== Success. ==="
+echo "========= Success. ========="
 
 # Kill server
 pkill -9 run_server || true

--- a/polymetis/tests/test_mocked_hardware_client.sh
+++ b/polymetis/tests/test_mocked_hardware_client.sh
@@ -16,23 +16,23 @@ PROJECT_ROOT_DIR=$(git rev-parse --show-toplevel)
 # Test mocked hardware client
 ######################
 # Start server & robot client
-echo "=== Starting server and mocked franka hardware client... ==="
+echo "========= Starting server and mocked franka hardware client... ========="
 launch_robot.py robot_client=franka_hardware use_real_time=false robot_client.executable_cfg.mock=true &
 server_pid=$!
-echo "=== Server PID: $server_pid ==="
+echo "========= Server PID: $server_pid ========="
 
 sleep 4
 
 # Run examples
-echo "=== Running controllers in examples/ ... ==="
+echo "========= Running controllers in examples/ ... ========="
 for entry in "$PROJECT_ROOT_DIR/polymetis/examples"/*; do
     if [ ${entry: -3} == ".py" ]; then
-        echo "Running `python $entry`"
+        echo "====== Running 'python $entry' ======"
         python $entry
     fi
 done
 
-echo "=== Success. ==="
+echo "========= Success. ========="
 
 # Kill server
 pkill -9 run_server || true

--- a/polymetis/tests/test_simulation.sh
+++ b/polymetis/tests/test_simulation.sh
@@ -16,35 +16,32 @@ PROJECT_ROOT_DIR=$(git rev-parse --show-toplevel)
 # Test simulation client
 ######################
 # Start server & robot client
-echo "=== Starting server and franka simulation...==="
+echo "========= Starting server and franka simulation... ========="
 launch_robot.py robot_client=franka_sim gui=false use_real_time=false &
 server_pid=$!
-echo "=== Server PID: $server_pid ==="
+echo "========= Server PID: $server_pid ========="
 
 sleep 4
 
 # Run RobotInterface tests (previous agent.py tests)
-echo "=== Running controller tests in simulation to check tracking... ==="
+echo "========= Running controller tests in simulation to check tracking... ========="
 for entry in "$PROJECT_ROOT_DIR/polymetis/tests/scripts"/*; do
     if [[ ${entry: -3} == ".py" && ${entry: -6} != "_hw.py" ]]; then
-        echo "Running `python $entry`"
+        echo "====== Running 'python $entry' ======"
         python $entry
     fi
-    sleep 4
 done
-echo "=== Success. ==="
+echo "========= Success. ========="
 
 # Run examples
-echo "=== Running controllers in examples/ ... ==="
-echo "here $PROJECT_ROOT_DIR/polymetis/examples"
+echo "========= Running controllers in examples/ ... ========="
 for entry in "$PROJECT_ROOT_DIR/polymetis/examples"/*; do
     if [ ${entry: -3} == ".py" ]; then
-        echo "Running `python $entry`"
+        echo "====== Running 'python $entry' ======"
         python $entry
     fi
-    sleep 4
 done
-echo "=== Success. ==="
+echo "========= Success. ========="
 
 # Kill server
 pkill -9 run_server || true


### PR DESCRIPTION
# Description

In the process of fixing occasionally flaky tests, I added:

- Exception logging on server sent as gRPC status code message to client
  - On server, catch and return runtime exceptions on controller forward
- Use `logging` module for RobotInterface
- Nicer print statements for integration test shell scripts (especially printing the actual test being run)

And then the fix for the flaky test, which is due to `3_timestamps.py` test enforcing a strict 1ms turnaround time for the simulation output. I just loosened the constraint slightly, since IMO still a good idea to make sure it's outputting something close to dt.

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

See [this test run](https://app.circleci.com/pipelines/github/facebookresearch/fairo/4313/workflows/bff844f0-6472-4c5f-b5e7-0c29964693bc/jobs/19340) for the logging output which let us catch the flaky test issue.

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) that all scripts in `tests/scripts`, (2) asv benchmarks.
