### PR TITLE
M detr in interpreter

### DIFF
--- a/droidlet/interpreter/interpret_reference_objects.py
+++ b/droidlet/interpreter/interpret_reference_objects.py
@@ -156,7 +156,7 @@ def interpret_reference_object(
     # does a clarification task referencing this interpreter exist?
     if not clarification_task_mems:
 
-        mems = maybe_get_text_span_mems(interpeter, speaker, d)
+        mems = maybe_get_text_span_mems(interpreter, speaker, d)
         if mems:
             update_attended_and_link_lf(interpreter, mems)
             # No filter by sublocation etc if a mem matches the text_span exactly...

--- a/droidlet/memory/filters_conversions.py
+++ b/droidlet/memory/filters_conversions.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 import json
+import uuid
 
 FILTERS_KW = ["SELECT", "FROM", "WHERE", "ORDER BY", "LIMIT", "SAME", "CONTAINS_COREFERENCE"]
 LIMITS = {"FIRST": "1", "SECOND": "2", "THIRD": "3"}
@@ -441,11 +442,19 @@ def triple_str_to_dict(clause):
     << #dd2ca5a4c5204fc09c71279f8956a2b1, parent_of, ? >>  -->
           {"pred_text": "parent_of", "subj": "dd2ca5a4c5204fc09c71279f8956a2b1"}
 
+    commmas in obj text or subj text need to be escaped with \
+    "find me a record whose name is bob, the sailor":
+    << ?, has_name, bob >> --> {"pred_text": "has_name", "obj_text": "bob\, the sailor"}
+
     TODO:
     This does not currently handle nested queries.
     This does not currently handle multiple "?"
+    moar escapes?
     """
+    comma = uuid.uuid4().hex
+    clause = clause.replace("\,", comma)
     terms = remove_enclosing_symbol(clause, ("<<", ">>")).split(",")
+    terms = [t.replace(comma, ",") for t in terms]
     terms = [t.strip() for t in terms]
     assert terms[1] and terms[1] != "?"
     out = {"pred_text": terms[1]}


### PR DESCRIPTION
# Description

adds a check for "has_description" exact matches in interpret_reference_object, in order to support just-in-time m-detr style perception.  

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) that all scripts in `tests/scripts`, (2) asv benchmarks.
