### PR TITLE
Craftassist perception debug

### DIFF
--- a/agents/argument_parser.py
+++ b/agents/argument_parser.py
@@ -37,13 +37,13 @@ class ArgumentParser:
         )
         self.parser.add_argument(
             "--log_timeline",
-            action="store_true", 
+            action="store_true",
             default=False,
             help="enables timeline logging for dashboard",
         )
         self.parser.add_argument(
             "--enable_timeline",
-            action="store_true", 
+            action="store_true",
             default=False,
             help="enables the dashboard timeline to display events",
         )
@@ -62,9 +62,9 @@ class ArgumentParser:
             help="path to semantic parsing models",
         )
         nsp_parser.add_argument(
-            "--nsp_data_dir", 
-            default="../../droidlet/artifacts/datasets/annotated_data/", 
-            help="path to annotated data"
+            "--nsp_data_dir",
+            default="../../droidlet/artifacts/datasets/annotated_data/",
+            help="path to annotated data",
         )
         nsp_parser.add_argument(
             "--ground_truth_data_dir",
@@ -92,6 +92,12 @@ class ArgumentParser:
         mc_parser.add_argument(
             "--geoscorer_model_path", default="", help="path to geoscorer model"
         )
+        mc_parser.add_argument(
+            "--mark_airtouching_blocks",
+            action="store_true",
+            default=False,
+            help="run thenearby_airtouching_blocks heuristic?",
+        )
         mc_parser.add_argument("--port", type=int, default=25565)
 
     def add_loco_parser(self):
@@ -116,15 +122,9 @@ class ArgumentParser:
             help="sanity checks the robot's movement, camera, arm.",
         )
         loco_parser.add_argument(
-            "--data_store_path",
-            default='',
-            help="path for storing data collected by the robot",
+            "--data_store_path", default="", help="path for storing data collected by the robot"
         )
-        loco_parser.add_argument(
-            "--reexplore_json",
-            default='',
-            help="json for reexplore task",
-        )
+        loco_parser.add_argument("--reexplore_json", default="", help="json for reexplore task")
 
     def fix_path(self, opts):
         if opts.model_base_path == "#relative":

--- a/agents/craftassist/craftassist_agent.py
+++ b/agents/craftassist/craftassist_agent.py
@@ -89,8 +89,8 @@ class CraftAssistAgent(DroidletAgent):
             "fill_idmeta": fill_idmeta,
             "color_bid_map": COLOR_BID_MAP,
         }
-        super(CraftAssistAgent, self).__init__(opts)
         self.mark_airtouching_blocks = opts.mark_airtouching_blocks
+        super(CraftAssistAgent, self).__init__(opts)
         self.no_default_behavior = opts.no_default_behavior
         self.agent_type = "craftassist"
         self.point_targets = []

--- a/agents/craftassist/craftassist_agent.py
+++ b/agents/craftassist/craftassist_agent.py
@@ -90,6 +90,7 @@ class CraftAssistAgent(DroidletAgent):
             "color_bid_map": COLOR_BID_MAP,
         }
         super(CraftAssistAgent, self).__init__(opts)
+        self.mark_airtouching_blocks = opts.mark_airtouching_blocks
         self.no_default_behavior = opts.no_default_behavior
         self.agent_type = "craftassist"
         self.point_targets = []
@@ -215,7 +216,9 @@ class CraftAssistAgent(DroidletAgent):
         self.perception_modules["language_understanding"] = NSPQuerier(self.opts, self)
         self.perception_modules["low_level"] = LowLevelMCPerception(self)
         self.perception_modules["heuristic"] = heuristic_perception.PerceptionWrapper(
-            self, low_level_data=self.low_level_data
+            self,
+            low_level_data=self.low_level_data,
+            mark_airtouching_blocks=self.mark_airtouching_blocks,
         )
         # set up the SubComponentClassifier model
         if os.path.isfile(self.opts.semseg_model_path):
@@ -262,7 +265,8 @@ class CraftAssistAgent(DroidletAgent):
         low_level_perception_output = self.perception_modules["low_level"].perceive()
         self.areas_to_perceive = cluster_areas(self.areas_to_perceive)
         self.areas_to_perceive = self.memory.update(
-            low_level_perception_output, self.areas_to_perceive)["areas_to_perceive"]
+            low_level_perception_output, self.areas_to_perceive
+        )["areas_to_perceive"]
         # 3. with the updated areas_to_perceive, perceive from heuristic perception module
         if force or not self.memory.task_stack_peek():
             # perceive from heuristic perception module

--- a/agents/craftassist/tests/fake_agent.py
+++ b/agents/craftassist/tests/fake_agent.py
@@ -54,6 +54,7 @@ class FakeAgent(DroidletAgent):
     coordinate_transforms = CraftAssistAgent.coordinate_transforms
 
     def __init__(self, world, opts=None, do_heuristic_perception=False, prebuilt_perception=None):
+        self.mark_airtouching_blocks = do_heuristic_perception
         self.head_height = HEAD_HEIGHT
         self.world = world
         self.chat_count = 0
@@ -108,7 +109,9 @@ class FakeAgent(DroidletAgent):
             self.perception_modules["language_understanding"] = NSPQuerier(self.opts, self)
         self.perception_modules["low_level"] = LowLevelMCPerception(self, perceive_freq=1)
         self.perception_modules["heuristic"] = PerceptionWrapper(
-            self, low_level_data=self.low_level_data
+            self,
+            low_level_data=self.low_level_data,
+            mark_airtouching_blocks=self.mark_airtouching_blocks,
         )
 
     def init_physical_interfaces(self):

--- a/droidlet/interpreter/get_memory_handler.py
+++ b/droidlet/interpreter/get_memory_handler.py
@@ -1,7 +1,6 @@
 """
 Copyright (c) Facebook, Inc. and its affiliates.
 """
-from copy import deepcopy
 import logging
 from typing import Dict, Tuple, Any, Optional, Sequence
 
@@ -30,7 +29,7 @@ class GetMemoryHandler(InterpreterBase):
         super().__init__(
             speaker, logical_form_memid, agent_memory, memid=memid, interpreter_type="get_memory"
         )
-        self.logical_form_orig = deepcopy(self.logical_form)
+        self.output_type = self.logical_form["filters"].get("output")
         # fill in subclasses
         self.subinterpret = {}  # noqa
         self.task_objects = {}  # noqa
@@ -106,7 +105,7 @@ class GetMemoryHandler(InterpreterBase):
             step_data: Any other data that this step would like to send to the task
         """
         self.finished = True  # noqa
-        output_type = self.logical_form_orig["filters"].get("output")
+        output_type = self.output_type
         try:
             if type(output_type) is str and output_type.lower() == "count":
                 # FIXME will multiple count if getting tags

--- a/droidlet/memory/craftassist/mc_memory.py
+++ b/droidlet/memory/craftassist/mc_memory.py
@@ -257,8 +257,8 @@ class MCAgentMemory(AgentMemory):
                 self.add_holes_to_mem(perception_output.in_perceive_area["holes"])
             # 1.3 Update tags of air-touching blocks
             if "airtouching_blocks" in perception_output.in_perceive_area:
-                shifted_c, tags = perception_output.in_perceive_area["airtouching_blocks"]
-                InstSegNode.create(self, shifted_c, tags=tags)
+                for c, tags in perception_output.in_perceive_area["airtouching_blocks"]:
+                    InstSegNode.create(self, c, tags=tags)
         # 2. Process everything near agent's current position
         if perception_output.near_agent:
             # 2.1 Add colors of all block objects
@@ -273,8 +273,8 @@ class MCAgentMemory(AgentMemory):
                 self.add_holes_to_mem(perception_output.near_agent["holes"])
             # 2.3 Update tags of air-touching blocks
             if "airtouching_blocks" in perception_output.near_agent:
-                shifted_c, tags = perception_output.near_agent["airtouching_blocks"]
-                InstSegNode.create(self, shifted_c, tags=tags)
+                for c, tags in perception_output.near_agent["airtouching_blocks"]:
+                    InstSegNode.create(self, c, tags=tags)
 
         """Update the memory with labeled blocks from SubComponent classifier"""
         if perception_output.labeled_blocks:

--- a/droidlet/perception/craftassist/heuristic_perception.py
+++ b/droidlet/perception/craftassist/heuristic_perception.py
@@ -514,7 +514,8 @@ class PerceptionWrapper:
         perceive_freq (int): if not forced, how many Agent steps between perception
     """
 
-    def __init__(self, agent, low_level_data, perceive_freq=20):
+    def __init__(self, agent, low_level_data, perceive_freq=20, mark_airtouching_blocks=False):
+        self.mark_airtouching_blocks = mark_airtouching_blocks
         self.perceive_freq = perceive_freq
         self.agent = agent
         self.radius = 15
@@ -578,19 +579,20 @@ class PerceptionWrapper:
             )
             perceive_info["in_perceive_area"]["holes"] = holes if holes else None
             # 1.3 Get all air-touching blocks in perception area
-            blocktypes, shifted_c, tags = get_nearby_airtouching_blocks(
-                self.agent,
-                pos,
-                self.block_data,
-                self.color_data,
-                self.block_property_data,
-                color_list,
-                radius,
-            )
-            if tags and len(shifted_c) > 0:
-                perceive_info["in_perceive_area"]["airtouching_blocks"] = list(
-                    zip(shifted_c, tags)
+            if self.mark_airtouching_blocks:
+                blocktypes, shifted_c, tags = get_nearby_airtouching_blocks(
+                    self.agent,
+                    pos,
+                    self.block_data,
+                    self.color_data,
+                    self.block_property_data,
+                    color_list,
+                    radius,
                 )
+                if tags and len(shifted_c) > 0:
+                    perceive_info["in_perceive_area"]["airtouching_blocks"] = list(
+                        zip(shifted_c, tags)
+                    )
 
         # 2. perceive blocks and their colors near the agent
         near_obj_tag_list = []
@@ -617,17 +619,18 @@ class PerceptionWrapper:
         )
         perceive_info["near_agent"]["holes"] = holes if holes else None
         # 4. Get all air-touching blocks near agent
-        blocktypes, shifted_c, tags = get_nearby_airtouching_blocks(
-            self.agent,
-            self.agent.pos,
-            self.block_data,
-            self.color_data,
-            self.block_property_data,
-            color_list,
-            radius=self.radius,
-        )
-        if tags and len(shifted_c) > 0:
-            perceive_info["near_agent"]["airtouching_blocks"] = list(zip(shifted_c, tags))
+        if self.mark_airtouching_blocks:
+            blocktypes, shifted_c, tags = get_nearby_airtouching_blocks(
+                self.agent,
+                self.agent.pos,
+                self.block_data,
+                self.color_data,
+                self.block_property_data,
+                color_list,
+                radius=self.radius,
+            )
+            if tags and len(shifted_c) > 0:
+                perceive_info["near_agent"]["airtouching_blocks"] = list(zip(shifted_c, tags))
 
         return CraftAssistPerceptionData(
             in_perceive_area=perceive_info["in_perceive_area"],

--- a/droidlet/perception/craftassist/heuristic_perception.py
+++ b/droidlet/perception/craftassist/heuristic_perception.py
@@ -344,9 +344,9 @@ def get_nearby_airtouching_blocks(
     xyzb = yzxb.transpose([2, 0, 1, 3]).copy()
     components = connected_components(xyzb, unique_idm=True)
     blocktypes = []
-    shifted_c = []
+    all_components = []
+    all_tags = []
     for c in components:
-        tags = None
         for loc in c:
             idm = tuple(xyzb[loc[0], loc[1], loc[2], :])
             for coord in range(3):
@@ -374,7 +374,7 @@ def get_nearby_airtouching_blocks(
                                         idm[0], idm[1]
                                     )
                                 )
-    return blocktypes, shifted_c, tags
+    return blocktypes, all_components, all_tags
 
 
 def get_all_nearby_holes(agent, location, block_data, fill_idmeta, radius=15, store_inst_seg=True):

--- a/droidlet/perception/craftassist/heuristic_perception.py
+++ b/droidlet/perception/craftassist/heuristic_perception.py
@@ -374,6 +374,11 @@ def get_nearby_airtouching_blocks(
                                         idm[0], idm[1]
                                     )
                                 )
+        if tags:
+            shifted_c = [(l[0] + x - radius, l[1] + ymin, l[2] + z - radius) for l in c]
+            if len(shifted_c) > 0:
+                all_components.append(shifted_c)
+                all_tags.append(tags)
     return blocktypes, all_components, all_tags
 
 
@@ -546,8 +551,12 @@ class PerceptionWrapper:
             - airtouching_blocks(list) - List of [shifted_coordinates, list of tags]
         """
         perceive_info = {}
-        perceive_info["in_perceive_area"] = {} # dictionary with children: block objects and holes in perception area
-        perceive_info["near_agent"] = {} # dictionary with children: block objects and holes near the agent
+        perceive_info[
+            "in_perceive_area"
+        ] = {}  # dictionary with children: block objects and holes in perception area
+        perceive_info[
+            "near_agent"
+        ] = {}  # dictionary with children: block objects and holes near the agent
         # 1. perceive blocks in marked areas to perceive
         for pos, radius in self.agent.areas_to_perceive:
             # 1.1 Get block objects and their colors
@@ -579,7 +588,9 @@ class PerceptionWrapper:
                 radius,
             )
             if tags and len(shifted_c) > 0:
-                perceive_info["in_perceive_area"]["airtouching_blocks"] = [shifted_c, tags]
+                perceive_info["in_perceive_area"]["airtouching_blocks"] = list(
+                    zip(shifted_c, tags)
+                )
 
         # 2. perceive blocks and their colors near the agent
         near_obj_tag_list = []
@@ -616,7 +627,7 @@ class PerceptionWrapper:
             radius=self.radius,
         )
         if tags and len(shifted_c) > 0:
-            perceive_info["near_agent"]["airtouching_blocks"] = [shifted_c, tags]
+            perceive_info["near_agent"]["airtouching_blocks"] = list(zip(shifted_c, tags))
 
         return CraftAssistPerceptionData(
             in_perceive_area=perceive_info["in_perceive_area"],

--- a/droidlet/shared_data_structs.py
+++ b/droidlet/shared_data_structs.py
@@ -1,7 +1,8 @@
 import heapq
 import numpy as np
 import time
-#rename for now, FIXME!
+
+# rename for now, FIXME!
 from droidlet.lowlevel.robot_coordinate_utils import xyz_pyrobot_to_canonical_coords
 
 
@@ -32,7 +33,8 @@ class ErrorWithResponse(Exception):
 class NextDialogueStep(Exception):
     pass
 
-#FIXME!  why is this here?
+
+# FIXME!  why is this here?
 class RGBDepth:
     """Class for the current RGB, depth and point cloud fetched from the robot.
 
@@ -54,10 +56,12 @@ class RGBDepth:
 
     def get_pillow_image(self):
         from PIL import Image
+
         return Image.fromarray(self.rgb, "RGB")
 
     def get_bounds_for_mask(self, mask):
         import open3d as o3d
+
         """for all points in the mask, returns the bounds as an axis-aligned bounding box.
         """
         if mask is None:
@@ -114,6 +118,7 @@ class MockOpt:
         self.ground_truth_data_dir = ""
         self.semseg_model_path = ""
         self.no_ground_truth = True
+        self.mark_airtouching_blocks = False
         # test does not instantiate cpp client
         self.port = -1
         self.no_default_behavior = False


### PR DESCRIPTION
# Description

Fixes some bugs with heuristic perception in craftassist, and an unrelated bug in get_memory

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After
Previously previously, heuristic perception would run a check on components of interesting blocks that touched air, and tag them with their color and material name.  In some recent commits, this was accidentally knocked out of commission.  This PR 1: fixes the bug; but also 2: sets the default to _not_ run this heuristic (and so keep current behavior)

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) that all scripts in `tests/scripts`, (2) asv benchmarks.
