### PR TITLE
[fbrp] down sub-sub-processes

### DIFF
--- a/fbrp/src/fbrp/runtime/conda.py
+++ b/fbrp/src/fbrp/runtime/conda.py
@@ -108,7 +108,9 @@ class Launcher(BaseLauncher):
             executable="/bin/bash",
             cwd=self.proc_def.root,
             env=conda_env,
+            preexec_fn=os.setsid,
         )
+        self.proc_pgrp = os.getpgid(self.proc.pid)
 
     async def gather_cmd_outputs(self):
         async def log_pipe(logger, pipe):
@@ -148,20 +150,19 @@ class Launcher(BaseLauncher):
 
     async def handle_down(self):
         try:
-            if self.proc.returncode is not None:
-                return
-            proc_pid = self.get_pid()
+            if self.proc.returncode is None:
+                proc_pid = self.get_pid()
 
-            life_cycle.set_state(self.name, life_cycle.State.STOPPING)
-            os.kill(proc_pid, signal.SIGTERM)
+                life_cycle.set_state(self.name, life_cycle.State.STOPPING)
+                os.kill(proc_pid, signal.SIGTERM)
 
-            for _ in range(100):
-                if not os.kill(proc_pid, 0):
-                    break
-                await asyncio.sleep(0.03)
+                for _ in range(100):
+                    if not os.kill(proc_pid, 0):
+                        break
+                    await asyncio.sleep(0.03)
 
-            if os.kill(proc_pid, 0):
-                os.kill(proc_pid, signal.SIGKILL)
+            # Clean up zombie sub-sub-processes.
+            os.killpg(self.proc_pgrp, signal.SIGKILL)
         except:
             pass
 

--- a/fbrp/src/fbrp/runtime/conda.py
+++ b/fbrp/src/fbrp/runtime/conda.py
@@ -110,6 +110,7 @@ class Launcher(BaseLauncher):
             env=conda_env,
             start_new_session=True,
         )
+        # TODO(lshamis): Handle the case where proc dies before we can query getpgid.
         self.proc_pgrp = os.getpgid(self.proc.pid)
 
     async def gather_cmd_outputs(self):


### PR DESCRIPTION
# Description

Previously, `fbrp down` would not reap forked subprocesses in the Conda runtime.

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

```py
import time
import os

def child():
    for i in range(60):
        time.sleep(0.5)
        print(f"child {i}")

def parent():
    pid = os.fork()
    if not pid:
        child()
        return
    os.waitpid(pid, 0)

parent()
```

Previously, the process above would continue to print after `fsetup.py down`.
Now, both the parent and child are cleaned up.

# Testing

See above.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) that all scripts in `tests/scripts`, (2) asv benchmarks.
