### PR TITLE
extra simple scenes

### DIFF
--- a/droidlet/lowlevel/minecraft/cuberite_process.py
+++ b/droidlet/lowlevel/minecraft/cuberite_process.py
@@ -19,7 +19,10 @@ from droidlet.lowlevel.minecraft.craftassist_cuberite_utils import (
 from droidlet.lowlevel.minecraft.craftassist_cuberite_utils.wait_for_cuberite import (
     wait_for_cuberite,
 )
-from droidlet.lowlevel.minecraft.small_scenes_with_shapes import build_shape_scene
+from droidlet.lowlevel.minecraft.small_scenes_with_shapes import (
+    build_shape_scene,
+    build_extra_simple_shape_scene,
+)
 
 logging.basicConfig(format="%(asctime)s [%(levelname)s]: %(message)s")
 logging.getLogger().setLevel(logging.DEBUG)
@@ -150,6 +153,7 @@ if __name__ == "__main__":
     parser.add_argument("--MAX_NUM_SHAPES", type=int, default=3)
     parser.add_argument("--GROUND_DEPTH", type=int, default=5)
     parser.add_argument("--MAX_NUM_GROUND_HOLES", type=int, default=0)
+    parser.add_argument("--extra_simple", action="store_true", default=False)
     parser.add_argument("--SL", type=int, default=17)
     parser.add_argument("--H", type=int, default=13)
     args = parser.parse_args()
@@ -179,7 +183,10 @@ if __name__ == "__main__":
         args.cuberite_y_offset = 63 - args.GROUND_DEPTH
         args.cuberite_x_offset = -args.SL // 2
         args.cuberite_z_offset = -args.SL // 2
-        schematic = build_shape_scene(args)["schematic_for_cuberite"]
+        if args.extra_simple:
+            schematic = build_extra_simple_shape_scene(args)["schematic_for_cuberite"]
+        else:
+            schematic = build_shape_scene(args)["schematic_for_cuberite"]
 
     p = CuberiteProcess(
         args.config,

--- a/droidlet/lowlevel/minecraft/small_scenes_with_shapes.py
+++ b/droidlet/lowlevel/minecraft/small_scenes_with_shapes.py
@@ -17,8 +17,11 @@ H = 13
 HOLE_NAMES = ["RECTANGULOID", "ELLIPSOID", "SPHERE"]
 
 
-def bid():
-    return (35, np.random.randint(16))
+def bid(nowhite=True):
+    if nowhite:
+        return (35, np.random.randint(15) + 1)
+    else:
+        return (35, np.random.randint(16))
 
 
 def red():
@@ -71,6 +74,44 @@ def shift(blocks, s):
     return blocks
 
 
+def in_box_builder(mx, my, mz, Mx, My, Mz):
+    def f(l):
+        lb = l[0] >= mx and l[1] >= my and l[2] >= mz
+        ub = l[0] < Mx and l[1] < My and l[2] < Mz
+        return lb and ub
+
+    return f
+
+
+def record_shape(S, in_box, offsets, blocks, inst_seg, occupied_by_shapes):
+    for l, idm in S:
+        ln = np.add(l, offsets)
+        if in_box(ln):
+            ln = tuple(ln.tolist())
+            if not occupied_by_shapes.get(ln):
+                blocks[ln] = idm
+                inst_seg.append(ln)
+                occupied_by_shapes[ln] = True
+
+
+def collect_scene(blocks, inst_segs, args):
+    J = {}
+    # FIXME not using the avatar and agent position in cuberite...
+    J["avatarInfo"] = {"pos": avatar_pos(args, blocks), "look": avatar_look(args, blocks)}
+    J["agentInfo"] = {"pos": agent_pos(args, blocks), "look": agent_look(args, blocks)}
+    J["inst_seg_tags"] = inst_segs
+    mapped_blocks = [(l[0], l[1], l[2], IGLU_BLOCK_MAP[idm]) for l, idm in blocks]
+    J["blocks"] = mapped_blocks
+
+    o = (0, args.cuberite_y_offset, 0)
+    blocks = shift(blocks, o)
+    J["schematic_for_cuberite"] = [
+        {"x": l[0], "y": l[1], "z": l[2], "id": idm[0], "meta": idm[1]} for l, idm in blocks
+    ]
+    J["offset"] = (args.cuberite_x_offset, args.cuberite_y_offset, args.cuberite_z_offset)
+    return J
+
+
 def build_shape_scene(args):
     """
     Build a scene using basic shapes,
@@ -94,16 +135,10 @@ def build_shape_scene(args):
         m = np.round(np.mean([l for l, idm in S], axis=0)).astype("int32")
         offsets = np.random.randint((args.SL, args.H, args.SL)) - m
         inst_seg = []
-        for l, idm in S:
-            ln = np.add(l, offsets)
-            if ln[0] >= 0 and ln[1] >= 0 and ln[2] >= 0:
-                if ln[0] < args.SL and ln[1] < args.H and ln[2] < args.SL:
-                    ln = tuple(ln.tolist())
-                    if not occupied_by_shapes.get(ln):
-                        blocks[ln] = idm
-                        inst_seg.append(ln)
-                        occupied_by_shapes[ln] = True
+        in_box = in_box_builder(0, 0, 0, args.SL, args.H, args.SL)
+        record_shape(S, in_box, offsets, blocks, inst_seg, occupied_by_shapes)
         inst_segs.append({"tags": [shape], "locs": inst_seg})
+
     if args.MAX_NUM_GROUND_HOLES == 0:
         num_holes = 0
     else:
@@ -118,6 +153,7 @@ def build_shape_scene(args):
         shape = random.choice(HOLE_NAMES)
         opts = SHAPE_OPTION_FUNCTION_MAP[shape]()
         S = SHAPE_FNS[shape](**opts)
+        S = [(l, (0, 0)) for l, idm in S]
         m = np.round(np.mean([l for l, idm in S], axis=0)).astype("int32")
         miny = min([l[1] for l, idm in S])
         maxy = max([l[1] for l, idm in S])
@@ -127,15 +163,8 @@ def build_shape_scene(args):
         # offset miny to GROUND_DEPTH - radius of shape
         offsets[1] = args.GROUND_DEPTH - maxy // 2 - 1
         inst_seg = []
-        for l, idm in S:
-            ln = np.add(l, offsets)
-            if ln[0] >= mL and ln[1] >= 0 and ln[2] >= mL:
-                if ln[0] < ML and ln[1] < args.GROUND_DEPTH and ln[2] < ML:
-                    ln = tuple(ln.tolist())
-                    if not occupied_by_shapes.get(ln):
-                        blocks[ln] = (0, 0)
-                        inst_seg.append(ln)
-                        occupied_by_shapes[ln] = True
+        in_box = in_box_builder(mL, 0, mL, ML, args.GROUND_DEPTH, ML)
+        record_shape(S, in_box, offsets, blocks, inst_seg, occupied_by_shapes)
         inst_segs.append({"tags": ["hole"], "locs": inst_seg})
     J = {}
     # not shifting y for gridworld
@@ -144,20 +173,63 @@ def build_shape_scene(args):
     blocks = shift(blocks, o)
     for i in inst_segs:
         i["locs"] = shift(i["locs"], o)
-    # FIXME not using the avatar and agent position in cuberite...
-    J["avatarInfo"] = {"pos": avatar_pos(args, blocks), "look": avatar_look(args, blocks)}
-    J["agentInfo"] = {"pos": agent_pos(args, blocks), "look": agent_look(args, blocks)}
-    J["inst_seg_tags"] = inst_segs
-    mapped_blocks = [(l[0], l[1], l[2], IGLU_BLOCK_MAP[idm]) for l, idm in blocks]
-    J["blocks"] = mapped_blocks
 
-    o = (0, args.cuberite_y_offset, 0)
+    return collect_scene(blocks, inst_segs, args)
+
+
+def build_extra_simple_shape_scene(args):
+    """
+    Build a scene with a sphere and a cube, non-overlapping.
+    outputs a json dict with fields
+    "avatarInfo" = {"pos": (x,y,z), "look": (yaw, pitch)}
+    "agentInfo" = {"pos": (x,y,z), "look": (yaw, pitch)}
+    "blocks" = [(x,y,z,bid) ... (x,y,z,bid)]
+    "schematic_for_cuberite" = [{"x": x, "y":y, "z":z, "id":blockid, "meta": meta} ...]
+    where bid is the output of the BLOCK_MAP applied to a minecraft blockid, meta pair.
+    """
+    CUBE_SIZE = 3
+    SPHERE_RADIUS = 2
+    fence = getattr(args, "fence", False)
+    blocks = build_base_world(args.SL, args.H, args.GROUND_DEPTH, fence=fence)
+    inst_segs = []
+    shape_opts = {"SPHERE": {"radius": SPHERE_RADIUS}, "CUBE": {"size": CUBE_SIZE}}
+    shapes = np.random.permutation(["SPHERE", "CUBE"])
+    occupied_by_shapes = {}
+    old_offset = [-100, -100, -100]
+    for shape in shapes:
+        opts = shape_opts[shape]
+        opts["bid"] = bid()
+        S = SHAPE_FNS[shape](**opts)
+        m = np.round(np.mean([l for l, idm in S], axis=0)).astype("int32")
+        offsets = np.random.randint(
+            (0, args.GROUND_DEPTH, 0),
+            (args.SL - CUBE_SIZE, args.H - CUBE_SIZE, args.SL - CUBE_SIZE),
+        )
+        count = 0
+        while (
+            abs(old_offset[0] - offsets[0]) + abs(old_offset[2] - offsets[2])
+            < CUBE_SIZE + SPHERE_RADIUS
+        ):
+            offsets = np.random.randint(
+                (0, args.GROUND_DEPTH, 0),
+                (args.SL - CUBE_SIZE, args.H - CUBE_SIZE, args.SL - CUBE_SIZE),
+            )
+            count += 1
+            assert (count < 100, "Is world too small? can't place shapes")
+        old_offset = offsets
+        inst_seg = []
+        in_box = in_box_builder(0, 0, 0, args.SL, args.H, args.SL)
+        record_shape(S, in_box, offsets, blocks, inst_seg, occupied_by_shapes)
+        inst_segs.append({"tags": [shape], "locs": inst_seg})
+
+    # not shifting y for gridworld
+    o = (args.cuberite_x_offset, 0, args.cuberite_z_offset)
+    blocks = [(l, idm) for l, idm in blocks.items()]
     blocks = shift(blocks, o)
-    J["schematic_for_cuberite"] = [
-        {"x": l[0], "y": l[1], "z": l[2], "id": idm[0], "meta": idm[1]} for l, idm in blocks
-    ]
-    J["offset"] = (args.cuberite_x_offset, args.cuberite_y_offset, args.cuberite_z_offset)
-    return J
+    for i in inst_segs:
+        i["locs"] = shift(i["locs"], o)
+
+    return collect_scene(blocks, inst_segs, args)
 
 
 if __name__ == "__main__":
@@ -176,11 +248,15 @@ if __name__ == "__main__":
     parser.add_argument("--cuberite_y_offset", type=int, default=63 - GROUND_DEPTH)
     parser.add_argument("--cuberite_z_offset", type=int, default=-SL // 2)
     parser.add_argument("--save_data_path", default="")
+    parser.add_argument("--extra_simple", action="store_true", default=False)
     args = parser.parse_args()
 
     scenes = []
     for i in range(args.NUM_SCENES):
-        scenes.append(build_shape_scene(args))
+        if args.extra_simple:
+            scenes.append(build_extra_simple_shape_scene(args))
+        else:
+            scenes.append(build_shape_scene(args))
     if args.save_data_path:
         with open(args.save_data_path, "w") as f:
             json.dump(scenes, f)


### PR DESCRIPTION
# Description
Adds extra simple scenes to scene generations, where there is only a cube and a sphere, and these are separated and in the air.   also makes the default to not generate white blocks except for the ground

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) that all scripts in `tests/scripts`, (2) asv benchmarks.
