### PR TITLE
Update to model viewer to allow cycling through scenes

### DIFF
--- a/droidlet/perception/craftassist/voxel_models/instance_segmentation/mask_output_viewer/blockMap.mjs
+++ b/droidlet/perception/craftassist/voxel_models/instance_segmentation/mask_output_viewer/blockMap.mjs
@@ -3,6 +3,52 @@
 // LICENSE file in the root directory of this source tree.
 
 const BLOCK_MAP = {
+    1: 0xbcbcbc,  // Stone
+    2: 0xbcbcbc,  // Granite
+    3: 0xbcbcbc,  // Polished Granite
+    4: 0xbcbcbc,  // Diorite
+    5: 0xbcbcbc,  // Polished Diorite
+    6: 0xbcbcbc,  // Andesite
+    7: 0xbcbcbc,  // Polished Andesite
+    8: 0x8fce00,  // Grass
+    9: 0xdd992c,  // Dirt
+    10: 0xdd992c,  // Coarse Dirt
+    11: 0xbcbcbc,  // Podzol
+    12: 0xbcbcbc,  // Cobblestone
+    13: 0xdd992c,  // Oak Wood Plank
+    14: 0xdd992c,  // Spruce Wood Plank
+    15: 0xdd992c,  // Birch Wood Plank
+    16: 0xdd992c,  // Jungle Wood Plank
+    17: 0xdd992c,  // Acacia Wood Plank
+    18: 0xdd992c,  // Dark Oak Wood Plank
+    19: 0xdd992c,  // Oak Sapling
+    20: 0xdd992c,  // Spruce Sapling
+    21: 0xdd992c,  // Birch Sapling
+    22: 0xdd992c,  // Jungle Sapling
+    23: 0xdd992c,  // Acacia Sapling
+    24: 0xdd992c,  // Dark Oak Sapling
+    25: 0xbcbcbc,  // Bedrock
+    26: 0x75bdff,  // Flowing Water
+    27: 0x75bdff,  // Still Water
+    28: 0xffa500,  // Sand
+    29: 0xff0000,  // Red Sand
+    30: 0xdd992c,  // Gravel
+    31: 0xdd992c,  // Oak Wood
+    32: 0xdd992c,  // Spruce Wood
+    33: 0xdd992c,  // Birch Wood
+    34: 0xdd992c,  // Jungle Wood
+    35: 0x8fce00,  // Oak Leaves
+    36: 0x8fce00,  // Spruce Leaves
+    37: 0x8fce00,  // Birch Leaves
+    38: 0x8fce00,  // Jungle Leaves
+    39: 0xdd992c,  // Sandstone
+    40: 0xdd992c,  // Chiseled Sandstone
+    41: 0xdd992c,  // Smooth Sandstone
+    42: 0xdd992c,  // Dead Shrub
+    43: 0x8fce00,  // Grass
+    44: 0x8fce00,  // Fern
+    45: 0xdd992c,  // Dead Bush
+
     46: 0xffffff, // White Wool
     47: 0xffa500, // Orange Wool
     48: 0xff00ff, // Magenta Wool
@@ -19,6 +65,11 @@ const BLOCK_MAP = {
     59: 0x8fce00, // Green Wool
     60: 0xff0000, // Red Wool
     61: 0x1a1a1a, // Black Wool
+
+    62: 0x8fce00,  // Dandelion
+    63: 0x8fce00,  // Poppy
+    64: 0xdd992c,  // Brown Mushroom
+    65: 0xff0000,  // Red Mushroom
 
     67: 0xffa500, // Orange Hole
     68: 0xff00ff, // Magenta Hole

--- a/droidlet/perception/craftassist/voxel_models/instance_segmentation/mask_output_viewer/index.html
+++ b/droidlet/perception/craftassist/voxel_models/instance_segmentation/mask_output_viewer/index.html
@@ -34,7 +34,7 @@
                 </div>
                 <div class="instructions-section">
                     <h4 class="instruction-headings">Block Colors:</h4>
-                    The "ground" in the scene is made up of white blocks.
+                    The "ground" in the scene is made up of translucent white blocks outlined in black.
                     The "air" in the scene is transparent.
                     The instance segment masks are shown in colored blocks with darker edges.  The labels for each mask are below the windows.
                 </div>
@@ -75,16 +75,29 @@
                 if (typeof(event.data) === "string") {
                 data = JSON.parse(event.data);
                 } else data = event.data;
-                console.log(data);
                 if (data.msg) populateLegend(data.msg);
             }, false);
 
             function populateLegend(msg) {
+                if (msg === "clear") { 
+                    clearLegend();
+                    return;
+                }
+
                 let li = document.createElement("li");
                 li.appendChild(document.createTextNode(msg.label.tags[0]));
                 li.style.color = "#" + msg.color.toString(16);
                 let eleID = "legend" + msg.idx
                 document.getElementById(eleID).appendChild(li);
+            }
+
+            function clearLegend() {
+                legends = document.getElementsByClassName("legend");
+                Array.from(legends).forEach((leg) => {
+                    while (leg.firstChild) {
+                        leg.removeChild(leg.firstChild);
+                    }
+                });
             }
         </script>
     </body>

--- a/droidlet/perception/craftassist/voxel_models/instance_segmentation/mask_output_viewer/voxel_viewer.mjs
+++ b/droidlet/perception/craftassist/voxel_models/instance_segmentation/mask_output_viewer/voxel_viewer.mjs
@@ -126,6 +126,9 @@ function loadScene(scene, idx) {
                 // Holes need their own number so they don't get texture later
                 match_block_idx = scene.blocks.findIndex((block) => block[0] == loc[0] && block[1] == loc[1] && block[2] == loc[2] && (block[3] == 0 || block[3] == 46) );
                 if (match_block_idx != -1) scene.blocks[match_block_idx][3] = color_idx + 20;
+                // If the block doesn't exist, they marked the air
+                match_block_idx = scene.blocks.findIndex((block) => block[0] == loc[0] && block[1] == loc[1] && block[2] == loc[2]);
+                if (match_block_idx == -1) scene.blocks.push([loc[0], loc[1], loc[2], (color_idx + 20)]);
             });
             let obj = {msg: {idx: idx, label: tag, color: BLOCK_MAP[color_idx++]}};
             window.parent.postMessage(JSON.stringify(obj), "*");

--- a/droidlet/perception/craftassist/voxel_models/instance_segmentation/mask_output_viewer/voxel_viewer.mjs
+++ b/droidlet/perception/craftassist/voxel_models/instance_segmentation/mask_output_viewer/voxel_viewer.mjs
@@ -112,8 +112,13 @@ function loadScene(scene, idx) {
 
     // Populate legend and mask colors
     let color_idx = 47;  // Increment mask color coding with each tag
+    let blockColorList = [];
+    scene.blocks.forEach((block) => {
+        if (!blockColorList.includes(block[3])) { blockColorList.push(block[3]) };
+    });
     if (scene.inst_seg_tags) {
         scene.inst_seg_tags.forEach(tag => {
+            while (blockColorList.includes(color_idx)) { color_idx++ }; // avoid colors of other blocks
             // For each mask block location, find the corresponding block in the block list and set the color to a unique value
             tag.locs.forEach((loc) => {
                 let match_block_idx = scene.blocks.findIndex((block) => block[0] == loc[0] && block[1] == loc[1] && block[2] == loc[2] && block[3] != 46 && block[3] != 0);

--- a/droidlet/perception/craftassist/voxel_models/instance_segmentation/mask_output_viewer/voxel_wrapper.css
+++ b/droidlet/perception/craftassist/voxel_models/instance_segmentation/mask_output_viewer/voxel_wrapper.css
@@ -16,6 +16,10 @@ canvas {
     padding: 5px;
 }
 
+.btn {
+    width: 200px;
+}
+
 #buttons {
     text-align: center;
 }

--- a/droidlet/perception/craftassist/voxel_models/instance_segmentation/mask_output_viewer/voxel_wrapper.html
+++ b/droidlet/perception/craftassist/voxel_models/instance_segmentation/mask_output_viewer/voxel_wrapper.html
@@ -11,6 +11,11 @@
     </head>
     <body>
         <div id="voxel_viewer"></div>  <!--three.js canvases-->
+        <br>
+        <div id="buttons">
+            <button type="button" class="center btn btn-secondary" id="prevScene">Load the previous scene</button>
+            <button type="button" class="center btn btn-secondary" id="nextScene">Load the next scene    </button>
+        </div>
     </body>
     <script type='module' id="voxelViewer" src='voxel_viewer.mjs'></script>
     <link rel="stylesheet" href="voxel_wrapper.css">


### PR DESCRIPTION
# Description

This PR is an update the the voxel vision model output viewing tool that allows the user to cycle through scenes if more than one scene is in the json file(s) provided.  If a single scene is in the list it will just refresh the scene when the buttons are clicked.

Also included is a bug fix where the colors of scene objects and segmentation masks could be the same, now prohibited.

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [X] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [X] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Previously if the user wanted to view a new scene, they needed to refresh the page and provide a link to the new json file.  Now if the json file provided has multiple scenes, they can cycle through them.

![cycle_scenes](https://user-images.githubusercontent.com/42893316/152441878-b02d3f3d-1bb2-407b-8018-8fdcd3afb7b5.gif)

# Testing

I tested by pointing the tool to a json file with a bunch of scenes and cycling through in both directions.  Anyone who wishes to test on the same file can use this link: https://craftassist.s3.us-west-2.amazonaws.com/pubr/scenes/1643856864.json

# Checklist:

- [X] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [X] New and existing unit tests pass locally with my changes.
- [X] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
