### PR TITLE
[Polymetis] Add read only mode for Franka client

### DIFF
--- a/polymetis/docs/source/usage.md
+++ b/polymetis/docs/source/usage.md
@@ -29,6 +29,14 @@ launch_robot.py robot_client=franka_hardware
 ```
 
 For hardware, `use_real_time` acquires the necessary `sudo` rights for real-time optimizations (see [here](https://github.com/facebookresearch/fairo/blob/main/polymetis/polymetis/include/real_time.hpp) for the specific optimizations.)
+
+
+For debugging and calibration purposes, we provide a read-only mode for the robot client, where no torques will be applied to the robot but robot states are still recorded normally. To launch the robot client in read-only mode:
+```bash
+# On the NUC
+launch_robot.py robot_client=franka_hardware robot_client.executable_cfg.readonly=true
+```
+
 ### Running user-code controllers **on your machine**:
 
 Once you start an instance of `launch_robot.py`, you can send commands by utilizing the example user code, found in [scripts](https://github.com/facebookresearch/fairo/tree/main/polymetis/examples).

--- a/polymetis/polymetis/conf/robot_client/franka_hardware.yaml
+++ b/polymetis/polymetis/conf/robot_client/franka_hardware.yaml
@@ -17,6 +17,7 @@ robot_client:
     robot_ip: "172.16.0.2"
     control_ip: ${ip}
     control_port: ${port}
+    readonly: false
     mock: false
     use_real_time: ${use_real_time}
     hz: ${hz}

--- a/polymetis/polymetis/include/polymetis/clients/franka_panda_client.hpp
+++ b/polymetis/polymetis/include/polymetis/clients/franka_panda_client.hpp
@@ -47,6 +47,7 @@ private:
 
   // libfranka
   bool mock_franka_;
+  bool readonly_mode_;
   std::unique_ptr<franka::Robot> robot_ptr_;
   std::array<double, NUM_DOFS> torque_commanded_, torque_safety_,
       torque_applied_;

--- a/polymetis/polymetis/src/clients/franka_panda_client/franka_panda_client.cpp
+++ b/polymetis/polymetis/src/clients/franka_panda_client/franka_panda_client.cpp
@@ -182,7 +182,7 @@ void FrankaTorqueControlClient::run() {
     }
 
   } else {
-    // Run mocked robot that returns dummy states
+    // Run mocked robot control loops
     franka::RobotState robot_state;
     franka::Duration duration;
 
@@ -194,9 +194,13 @@ void FrankaTorqueControlClient::run() {
       clock_gettime(CLOCK_REALTIME, &abs_target_time);
       abs_target_time.tv_nsec += period_ns;
 
+      // Pull data from robot if in readonly mode
       if (readonly_mode_) {
         robot_state = robot_ptr_->readOnce();
       }
+
+      // Perform control loop with dummy variables (robot_state is populated if
+      // in readonly mode)
       control_callback(robot_state, duration);
 
       clock_nanosleep(CLOCK_REALTIME, TIMER_ABSTIME, &abs_target_time, nullptr);


### PR DESCRIPTION
# Description

Adds a read-only mode for Franka. Robot states are read from the robot, but no control will be applied. Can work in white LED mode.

Potential uses include:
- Controller debugging
- Demonstration recording
- Measuring ideal EE poses for grasps
- Data collection for camera calibration

Read-only mode can be launched with: `launch_robot.py robot_client=franka_hardware robot_client.executable_cfg.readonly=true`

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

If this PR introduces a change or fixes a bug, please add before and after screenshots (if this is causes a UX change) or before and after examples(this could be plain text, videos etc ) to demonstrate the change.

If this PR introduces a new feature, please also add examples or screenshots demonstrating the feature.

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [x] I have added Docstrings and comments to the code.
- [x] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
