### PR TITLE
[Polymetis] Adaptive time_to_go

### DIFF
--- a/polymetis/polymetis/python/polymetis/robot_interface.py
+++ b/polymetis/polymetis/python/polymetis/robot_interface.py
@@ -278,7 +278,7 @@ class RobotInterface(BaseRobotInterface):
 
     def __init__(
         self,
-        time_to_go_default: float = 2.0,
+        time_to_go_default: float = 3.0,
         use_grav_comp: bool = True,
         *args,
         **kwargs,

--- a/polymetis/polymetis/python/polymetis/robot_interface.py
+++ b/polymetis/polymetis/python/polymetis/robot_interface.py
@@ -362,12 +362,12 @@ class RobotInterface(BaseRobotInterface):
         ), "Robot model not assigned! Call 'set_robot_model(<path_to_urdf>, <ee_link_name>)' to enable use of dynamics controllers"
 
         # Parse parameters
+        joint_pos_current = self.get_joint_positions()
         joint_pos_desired = torch.Tensor(positions)
         if delta:
-            joint_pos_desired += self.get_joint_positions()
+            joint_pos_desired += joint_pos_current
 
         # Plan trajectory
-        joint_pos_current = self.get_joint_positions()
         waypoints = toco.planning.generate_joint_space_min_jerk(
             start=joint_pos_current,
             goal=joint_pos_desired,

--- a/polymetis/polymetis/python/polymetis/robot_interface.py
+++ b/polymetis/polymetis/python/polymetis/robot_interface.py
@@ -372,7 +372,17 @@ class RobotInterface(BaseRobotInterface):
         Kqd: torch.Tensor = None,
         **kwargs,
     ) -> List[RobotState]:
-        """Uses JointGoToPolicy to move to the desired positions with the given gains."""
+        """Uses JointGoToPolicy to move to the desired positions with the given gains.
+        Args:
+            positions: Desired target joint positions.
+            time_to_go: Amount of time to execute the motion. Uses an adaptive value if not specified (see `_adaptive_time_to_go` for details).
+            delta: Whether the specified `positions` are relative to current pose or absolute.
+            Kq: Joint P gains for the tracking controller. Uses default values if not specified.
+            Kqd: Joint D gains for the tracking controller. Uses default values if not specified.
+
+        Returns:
+            Same as `send_torch_policy`
+        """
         assert (
             self.robot_model is not None
         ), "Robot model not assigned! Call 'set_robot_model(<path_to_urdf>, <ee_link_name>)' to enable use of dynamics controllers"
@@ -427,7 +437,18 @@ class RobotInterface(BaseRobotInterface):
         Kxd: torch.Tensor = None,
         **kwargs,
     ) -> List[RobotState]:
-        """Uses an operational space controller to move to a desired end-effector position (and, optionally orientation)."""
+        """Uses an operational space controller to move to a desired end-effector position (and, optionally orientation).
+        Args:
+            positions: Desired target end-effector position.
+            positions: Desired target end-effector orientation (quaternion).
+            time_to_go: Amount of time to execute the motion. Uses an adaptive value if not specified (see `_adaptive_time_to_go` for details).
+            delta: Whether the specified `position` and `orientation` are relative to current pose or absolute.
+            Kx: P gains for the tracking controller. Uses default values if not specified.
+            Kxd: D gains for the tracking controller. Uses default values if not specified.
+
+        Returns:
+            Same as `send_torch_policy`
+        """
         assert (
             self.robot_model is not None
         ), "Robot model not assigned! Call 'set_robot_model(<path_to_urdf>, <ee_link_name>)' to enable use of dynamics controllers"

--- a/polymetis/tests/scripts/5_multithreaded.py
+++ b/polymetis/tests/scripts/5_multithreaded.py
@@ -34,8 +34,11 @@ def connect_and_send_policy():
         delta_joint_pos_desired = torch.Tensor([0.0, 0.0, 0.0, 0.5, 0.0, -0.5, 0.0])
         joint_pos_desired = joint_pos + delta_joint_pos_desired
 
-        state_log = robot.move_to_joint_positions(joint_pos_desired)
-        check_episode_log(state_log, int(robot.time_to_go_default * hz))
+        time_to_go = 4.0
+        state_log = robot.move_to_joint_positions(
+            joint_pos_desired, time_to_go=time_to_go
+        )
+        check_episode_log(state_log, int(time_to_go * hz))
 
         joint_pos = robot.get_joint_positions()
         assert torch.allclose(joint_pos, joint_pos_desired, atol=0.01)


### PR DESCRIPTION
# Description

Changes:
- Allow macros in `RobotInterface` to use adaptive time-to-go computed using joint velocity limits from the URDF.
- Change default time-to-go from 4.0 to 3.0.

Fixes issue where moving to far away joint positions would violate the velocity limit.
Happens occasionally on RoboPen when trying to move to home pose from a pose caused by the previous policy.

Concerns:
- Print a warning if user-specified time-to-go is shorter than the computed adaptive time-to-go?

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [x] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

If this PR introduces a change or fixes a bug, please add before and after screenshots (if this is causes a UX change) or before and after examples(this could be plain text, videos etc ) to demonstrate the change.

If this PR introduces a new feature, please also add examples or screenshots demonstrating the feature.

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [x] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
