### PR TITLE
[HiTL] fix pipeline crash when incentive bonus fails

### DIFF
--- a/droidlet/tools/crowdsourcing/droidlet_static_html_task/issue_bonus.py
+++ b/droidlet/tools/crowdsourcing/droidlet_static_html_task/issue_bonus.py
@@ -67,7 +67,11 @@ def issue_bonuses(task_name: str) -> list:
                         amount = float(f'{(click["id"]["interactionScores"]["stoplight"] * 0.30):.2f}')
                         total_bonus += amount
                         new_bonus_records.append((task_name, unit_id, worker.worker_name, amount))
-                        bonus_result, _ = worker.bonus_worker(amount, "Virtual assistant interaction quality bonus", unit)
+                        bonus_result = False
+                        try:
+                            bonus_result, _ = worker.bonus_worker(amount, "Virtual assistant interaction quality bonus", unit)
+                        except:
+                            pass
                         bonus_results.append(bonus_result)
                         if not bonus_result:
                             logging.info(f"Bonus NOT successfully issued for worker {worker.worker_name} , debug")

--- a/droidlet/tools/crowdsourcing/droidlet_static_html_task/issue_bonus.py
+++ b/droidlet/tools/crowdsourcing/droidlet_static_html_task/issue_bonus.py
@@ -61,28 +61,32 @@ def issue_bonuses(task_name: str) -> list:
             outputs = data["data"]["outputs"]
             clean_click_string = outputs["clickedElements"].replace("'", "")
             clicks = json.loads(clean_click_string)
+            bonus_result = False
             if clicks:
                 for click in clicks:
                     if "interactionScores" in click["id"]:
-                        amount = float(f'{(click["id"]["interactionScores"]["stoplight"] * 0.30):.2f}')
-                        total_bonus += amount
-                        new_bonus_records.append((task_name, unit_id, worker.worker_name, amount))
-                        bonus_result = False
                         try:
+                            amount = float(f'{(click["id"]["interactionScores"]["stoplight"] * 0.30):.2f}')
                             bonus_result, _ = worker.bonus_worker(amount, "Virtual assistant interaction quality bonus", unit)
+                            total_bonus += amount
+                            new_bonus_records.append((task_name, unit_id, worker.worker_name, amount))
                         except:
+                            logging.error(f"Exception raised on bonus issue for {worker.worker_name}, debug")
+                            new_bonus_records.append((task_name, unit_id, worker.worker_name, "ERR"))
                             pass
-                        bonus_results.append(bonus_result)
-                        if not bonus_result:
-                            logging.info(f"Bonus NOT successfully issued for worker {worker.worker_name} , debug")
+                if not bonus_result:
+                    logging.info(f"Bonus NOT successfully issued for worker {worker.worker_name}, but no error was raised.  \
+                        Make sure interaction score exists and retry.")
             else:
                 logging.info(f'Recorded click data not found for {worker.worker_name}, no bonus will be issued')
+            bonus_results.append(bonus_result)
         else:
             units_skipped += 1
 
     logging.info(f"Num completed units: {len(completed_units)}")
     logging.info(f"Num bonuses skipped because bonus was issued previously for the same unit: {units_skipped}")
     logging.info(f"Num new bonuses issued: {len([x for x in bonus_results if x])}")
+    logging.info(f"Num bonuses FAILED: {len([x for x in bonus_results if not x])}")
     logging.info(f"Total bonus amount issued: {total_bonus}")
 
     if new_bonus_records:


### PR DESCRIPTION
# Description

This is an addendum to #902 where incentives are automatically issued to turkers after interaction jobs.  If the Mephisto `bonus_worker` function fails, previously the whole script would fail and derail the HiTL pipeline.  This PR introduces exception handling on that function.

## Type of change

Please check the options that are relevant.

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [X] I want a high level review. 
- [ ] I want a deep design review.

# Testing

I've tested this locally and with paid MTurk interaction jobs.

# Checklist:

- [X] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [X] New and existing unit tests pass locally with my changes.
- [X] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
