### PR TITLE
[WIP] Adding skeleton for perceiving from detection model with text span

### DIFF
--- a/agents/craftassist/craftassist_agent.py
+++ b/agents/craftassist/craftassist_agent.py
@@ -45,6 +45,7 @@ from droidlet.lowlevel.minecraft.mc_util import (
 from droidlet.perception.craftassist.voxel_models.subcomponent_classifier import (
     SubcomponentClassifierWrapper,
 )
+from droidlet.perception.craftassist.detection_model_perception import DetectionWrapper
 from droidlet.lowlevel.minecraft import craftassist_specs
 from droidlet.lowlevel.minecraft.craftassist_cuberite_utils.block_data import (
     COLOR_BID_MAP,
@@ -224,6 +225,14 @@ class CraftAssistAgent(DroidletAgent):
             self.perception_modules["semseg"] = SubcomponentClassifierWrapper(
                 self, self.opts.semseg_model_path, low_level_data=self.low_level_data
             )
+        # set up the detection model
+        # TODO: @kavya to check that this gets passed in when running the agent
+        # TODO: fetch text_span here ?
+        if os.path.isfile(self.opts.detection_model_path):
+            self.perception_modules["detection_model"] = DetectionWrapper(agent=self,
+                                                                          model_path=self.opts.detection_model_path,
+                                                                          text_span=text_span
+                                                                          ) # <Initialize the detection model>
 
     def init_controller(self):
         """Initialize all controllers"""
@@ -275,6 +284,14 @@ class CraftAssistAgent(DroidletAgent):
             sem_seg_perception_output = self.perception_modules["semseg"].perceive()
             self.memory.update(sem_seg_perception_output)
         self.areas_to_perceive = []
+        # 5. If detection model is initialized and text_span exists in logical form, call perceive()
+        # TODO: Add a check for checking whether "text_span" exists in logical form
+        # TODO: fetch text_span from logical form
+        text_span_from_lf = None
+        if "detection_model" in self.perception_modules:
+            detection_model_output = self.perception_modules["detection_model"].perceive(text_form=text_span_from_lf)
+            self.memory.update(detection_model_output)
+
         self.update_dashboard_world()
 
     def get_time(self):

--- a/droidlet/perception/craftassist/detection_model_perception.py
+++ b/droidlet/perception/craftassist/detection_model_perception.py
@@ -1,0 +1,48 @@
+"""
+Copyright (c) Facebook, Inc. and its affiliates.
+"""
+import logging
+from droidlet.shared_data_struct.craftassist_shared_utils import CraftAssistPerceptionData
+
+
+class DetectionWrapper:
+    """Detect objects using voxel and language input and return updates.
+
+    Args:
+        agent (LocoMCAgent): reference to the minecraft Agent
+        model_path (str): path to the segmentation model
+        text_span (str): Any text span of reference object
+    """
+
+    def __init__(self, agent, model_path):
+        self.agent = agent
+        # Note remove the following
+        self.memory = self.agent.memory
+        if model_path is not None:
+            logging.info(
+                "Using detection_model_path={}".format(model_path))
+            # TODO: Yuxuan to add detection model wrapper / querier here
+            self.detection_model = None # DetectionModelWrapper(model_path, text_span)
+        else:
+            self.detection_model = None
+
+    def perceive(self, text_span=None):
+        """
+        Run the detection classifier and get the resulting voxel predictions
+
+        Args:
+            text_span (str): text span of a reference object from logical form. This is
+            used to detect a specific reference object.
+
+        """
+        if text_span is None:
+            return CraftAssistPerceptionData()
+        if self.detection_model is None:
+            return CraftAssistPerceptionData()
+        voxel_predictions = self.detection_model.parse()
+        if not voxel_predictions:
+            return CraftAssistPerceptionData()
+        # TODO: write a method to parse through voxels and check if they pass a threshold
+        updated_voxel_predictions = voxel_predictions
+        # TODO: check if voxels pass a certain threshold, if not return blank
+        return CraftAssistPerceptionData(detected_voxels=updated_voxel_predictions)

--- a/droidlet/shared_data_structs.py
+++ b/droidlet/shared_data_structs.py
@@ -117,6 +117,7 @@ class MockOpt:
         self.nsp_data_dir = ""
         self.ground_truth_data_dir = ""
         self.semseg_model_path = ""
+        self.detection_model_path = ""
         self.no_ground_truth = True
         self.mark_airtouching_blocks = False
         # test does not instantiate cpp client


### PR DESCRIPTION
# Description

Adding a skeleton for perceiving from detection model using text span of a reference object.
Remaining action items on this :
- fetching "text_span" from logical form
- providing a model querier
- adding a functionality to check threshold on predictions
- adding a test for this route

Sharing WIP as @aszlam and I will be collaborating on this branch.

Fixes : Adds a perceive for the new perception model in craftassist that takes in language + voxels to predict detections.

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Before: No perception route for the above feature

After: A perception route for the above : when chat comes in: run the NLU model -> get logical form -> fetch text_span -> if text_span not None -> run detection model -> fetch results and postprocess on a certain threshold on predictions -> make any updates to memory

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
