### PR TITLE
[fbrp] fix psutil json

### DIFF
--- a/fbrp/setup.py
+++ b/fbrp/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="fbrp",
-    version="0.1.1",
+    version="0.1.2",
     author="Leonid Shamis",
     package_dir={"": "src"},
     packages=find_packages(


### PR DESCRIPTION
# Description

FBRP automatically collects psutil data for all managed processes.
The data is json-ified, but was not in the most readable state.

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

This PR converts memory_info, and other psutil objects, from
```
[11984896, 31031296, ...]
```
to
```
{"rss": 11984896, "vms": 31031296, ...}
```

# Testing

Manual testing. Ran standard fbrp examples and watched the generated psutil.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
