### PR TITLE
[Polymetis] Misc. Franka client features for debugging

### DIFF
--- a/polymetis/polymetis/conf/robot_client/franka_hardware.yaml
+++ b/polymetis/polymetis/conf/robot_client/franka_hardware.yaml
@@ -25,6 +25,7 @@ robot_client:
     exec: ${exec}
     robot_client_metadata_path: ???
 
+    limit_rate: true
     lpf_cutoff_frequency: 100
 
     limits: 

--- a/polymetis/polymetis/conf/robot_client/franka_hardware.yaml
+++ b/polymetis/polymetis/conf/robot_client/franka_hardware.yaml
@@ -25,6 +25,8 @@ robot_client:
     exec: ${exec}
     robot_client_metadata_path: ???
 
+    lpf_cutoff_frequency: 100
+
     limits: 
       # bounding box of the workspace
       cartesian_pos_upper:

--- a/polymetis/polymetis/conf/robot_client/franka_hardware.yaml
+++ b/polymetis/polymetis/conf/robot_client/franka_hardware.yaml
@@ -9,8 +9,8 @@ robot_client:
     _target_: polymetis.robot_client.metadata.RobotClientMetadata
     default_Kq: [80, 120, 100, 100, 70, 50, 20]
     default_Kqd: [10, 10, 10, 10, 5, 5, 5]
-    default_Kx: [300, 300, 300, 40, 40, 40]
-    default_Kxd: [35, 35, 35, 14, 14, 14]
+    default_Kx: [150, 150, 150, 10, 10, 10]
+    default_Kxd: [25, 25, 25, 7, 7, 7]
     hz: ${hz}
     robot_model_cfg: ${robot_model}
   executable_cfg:

--- a/polymetis/polymetis/include/polymetis/clients/franka_panda_client.hpp
+++ b/polymetis/polymetis/include/polymetis/clients/franka_panda_client.hpp
@@ -56,11 +56,11 @@ private:
       torque_applied_;
   bool prev_command_successful_;
 
-  // Low pass filter
+  // Torque processing
+  bool limit_rate_;
   double lpf_alpha_;
   std::array<double, NUM_DOFS> torque_applied_prev_;
 
-  // limits
   bool limits_exceeded_;
   std::string error_str_;
 

--- a/polymetis/polymetis/include/polymetis/clients/franka_panda_client.hpp
+++ b/polymetis/polymetis/include/polymetis/clients/franka_panda_client.hpp
@@ -49,9 +49,10 @@ private:
   bool mock_franka_;
   bool readonly_mode_;
   std::unique_ptr<franka::Robot> robot_ptr_;
+  std::unique_ptr<franka::Model> model_ptr_;
   std::array<double, NUM_DOFS> torque_commanded_, torque_safety_,
       torque_applied_;
-  std::unique_ptr<franka::Model> model_ptr_;
+  bool prev_command_successful_;
 
   // limits
   bool limits_exceeded_;

--- a/polymetis/polymetis/include/polymetis/clients/franka_panda_client.hpp
+++ b/polymetis/polymetis/include/polymetis/clients/franka_panda_client.hpp
@@ -54,7 +54,6 @@ private:
   std::unique_ptr<franka::Model> model_ptr_;
   std::array<double, NUM_DOFS> torque_commanded_, torque_safety_,
       torque_applied_;
-  bool prev_command_successful_;
 
   // Torque processing
   bool limit_rate_;

--- a/polymetis/polymetis/include/polymetis/clients/franka_panda_client.hpp
+++ b/polymetis/polymetis/include/polymetis/clients/franka_panda_client.hpp
@@ -20,6 +20,7 @@
 
 #define NUM_DOFS 7
 #define FRANKA_HZ 1000.0
+#define M_PI 3.14159265358979323846
 #define RECOVERY_WAIT_SECS 1
 #define RECOVERY_MAX_TRIES 3
 
@@ -29,7 +30,7 @@ private:
                            std::array<double, NUM_DOFS> &torque_out);
   void checkStateLimits(const franka::RobotState &libfranka_robot_state,
                         std::array<double, NUM_DOFS> &torque_out);
-  void checkTorqueLimits(std::array<double, NUM_DOFS> &torque_applied);
+  void postprocessTorques(std::array<double, NUM_DOFS> &torque_applied);
 
   template <std::size_t N>
   void computeSafetyReflex(std::array<double, N> values,
@@ -48,11 +49,16 @@ private:
   // libfranka
   bool mock_franka_;
   bool readonly_mode_;
+
   std::unique_ptr<franka::Robot> robot_ptr_;
   std::unique_ptr<franka::Model> model_ptr_;
   std::array<double, NUM_DOFS> torque_commanded_, torque_safety_,
       torque_applied_;
   bool prev_command_successful_;
+
+  // Low pass filter
+  double lpf_alpha_;
+  std::array<double, NUM_DOFS> torque_applied_prev_;
 
   // limits
   bool limits_exceeded_;

--- a/polymetis/polymetis/protos/polymetis.proto
+++ b/polymetis/polymetis/protos/polymetis.proto
@@ -114,9 +114,10 @@ message RobotState {
   repeated float prev_joint_torques_computed_safened = 6; //Torques after adding safety mechanisms in the previous timestep
   repeated float motor_torques_measured = 7;              //Measured torque signals from the robot motors
   repeated float motor_torques_external = 8;              //Measured external torques exerted on the robot motors
-  float prev_controller_latency_ms = 9;                   //Latency of previous ControlUpdate call
-  bool prev_command_successful = 10;                      //Whether previous command packet is successfully transmitted
-  int32 error_code = 11;
+  repeated float motor_torques_desired = 9;               //Desired torques signals from the robot motors
+  float prev_controller_latency_ms = 10;                  //Latency of previous ControlUpdate call
+  bool prev_command_successful = 11;                      //Whether previous command packet is successfully transmitted
+  int32 error_code = 12;
 }
 
 message TorqueCommand {

--- a/polymetis/polymetis/protos/polymetis.proto
+++ b/polymetis/polymetis/protos/polymetis.proto
@@ -115,7 +115,7 @@ message RobotState {
   repeated float motor_torques_measured = 7;              //Measured torque signals from the robot motors
   repeated float motor_torques_external = 8;              //Measured external torques exerted on the robot motors
   float prev_controller_latency_ms = 9;                   //Latency of previous ControlUpdate call
-  bool prev_command_successful = 10;
+  bool prev_command_successful = 10;                      //Whether previous command packet is successfully transmitted
 }
 
 message TorqueCommand {

--- a/polymetis/polymetis/protos/polymetis.proto
+++ b/polymetis/polymetis/protos/polymetis.proto
@@ -116,6 +116,7 @@ message RobotState {
   repeated float motor_torques_external = 8;              //Measured external torques exerted on the robot motors
   float prev_controller_latency_ms = 9;                   //Latency of previous ControlUpdate call
   bool prev_command_successful = 10;                      //Whether previous command packet is successfully transmitted
+  int32 error_code = 11;
 }
 
 message TorqueCommand {

--- a/polymetis/polymetis/protos/polymetis.proto
+++ b/polymetis/polymetis/protos/polymetis.proto
@@ -115,6 +115,7 @@ message RobotState {
   repeated float motor_torques_measured = 7;              //Measured torque signals from the robot motors
   repeated float motor_torques_external = 8;              //Measured external torques exerted on the robot motors
   float prev_controller_latency_ms = 9;                   //Latency of previous ControlUpdate call
+  bool prev_command_successful = 10;
 }
 
 message TorqueCommand {

--- a/polymetis/polymetis/python/polysim/grpc_sim_client.py
+++ b/polymetis/polymetis/python/polysim/grpc_sim_client.py
@@ -160,6 +160,7 @@ class GrpcSimulationClient(AbstractRobotClient):
             robot_state.timestamp.GetCurrentTime()
             robot_state.prev_controller_latency_ms = self.round_trip_time_buffer
             robot_state.prev_command_successful = True
+            robot_state.error_code = 0
 
             # Query controller manager server for action
             # TODO: have option for async mode through async calls, see

--- a/polymetis/polymetis/python/polysim/grpc_sim_client.py
+++ b/polymetis/polymetis/python/polysim/grpc_sim_client.py
@@ -159,6 +159,7 @@ class GrpcSimulationClient(AbstractRobotClient):
 
             robot_state.timestamp.GetCurrentTime()
             robot_state.prev_controller_latency_ms = self.round_trip_time_buffer
+            robot_state.prev_command_successful = True
 
             # Query controller manager server for action
             # TODO: have option for async mode through async calls, see

--- a/polymetis/polymetis/python/scripts/benchmark_control_latency.py
+++ b/polymetis/polymetis/python/scripts/benchmark_control_latency.py
@@ -12,15 +12,20 @@ def output_episode_stats(episode_name, robot_states):
     latency_max = np.max(latency_arr)
     latency_min = np.min(latency_arr)
 
+    success_arr = np.array(
+        [robot_state.prev_command_successful for robot_state in robot_states]
+    )
+    success_rate = np.mean(success_arr)
+
     print(
-        f"{episode_name}: {latency_mean:.4f}/ {latency_std:.4f} / {latency_max:.4f} / {latency_min:.4f}"
+        f"{episode_name}: {latency_mean:.4f}/ {latency_std:.4f} / {latency_max:.4f} / {latency_min:.4f} / {100 * success_rate:.2f}%"
     )
 
 
 if __name__ == "__main__":
     robot = RobotInterface()
 
-    print("Control loop latency stats in milliseconds (avg / std / max / min): ")
+    print("Control loop stats in milliseconds (avg / std / max / min / success_rate): ")
 
     # Test joint PD
     robot_states = robot.move_to_joint_positions(robot.get_joint_positions())

--- a/polymetis/polymetis/python/scripts/benchmark_control_latency.py
+++ b/polymetis/polymetis/python/scripts/benchmark_control_latency.py
@@ -25,7 +25,9 @@ def output_episode_stats(episode_name, robot_states):
 if __name__ == "__main__":
     robot = RobotInterface()
 
-    print("Control loop stats in milliseconds (avg / std / max / min / success_rate): ")
+    print(
+        "Control loop latency stats in milliseconds (avg / std / max / min / success_rate): "
+    )
 
     # Test joint PD
     robot_states = robot.move_to_joint_positions(robot.get_joint_positions())

--- a/polymetis/polymetis/src/clients/franka_panda_client/franka_panda_client.cpp
+++ b/polymetis/polymetis/src/clients/franka_panda_client/franka_panda_client.cpp
@@ -78,6 +78,7 @@ FrankaTorqueControlClient::FrankaTorqueControlClient(
   }
 
   // Parse yaml
+  bool limit_rate_ = config["limit_rate"].as<bool>();
   double lpf_cutoff_freq = config["lpf_cutoff_frequency"].as<double>();
   if (lpf_cutoff_freq > 0.0) {
     double tmp = 2 * M_PI * lpf_cutoff_freq / FRANKA_HZ;
@@ -160,7 +161,7 @@ void FrankaTorqueControlClient::run() {
     while (is_robot_operational) {
       // Send lambda function
       try {
-        robot_ptr_->control(control_callback, false,
+        robot_ptr_->control(control_callback, limit_rate_,
                             franka::kMaxCutoffFrequency);
       } catch (const std::exception &ex) {
         spdlog::error("Robot is unable to be controlled: {}", ex.what());

--- a/polymetis/polymetis/src/clients/franka_panda_client/franka_panda_client.cpp
+++ b/polymetis/polymetis/src/clients/franka_panda_client/franka_panda_client.cpp
@@ -229,7 +229,7 @@ void FrankaTorqueControlClient::updateServerCommand(
     std::array<double, NUM_DOFS> &torque_out) {
   // Record robot states
   if (!mock_franka_) {
-    prev_command_successful_ = false;
+    bool prev_command_successful = false;
 
     for (int i = 0; i < NUM_DOFS; i++) {
       robot_state_.set_joint_positions(i, libfranka_robot_state.q[i]);
@@ -242,15 +242,16 @@ void FrankaTorqueControlClient::updateServerCommand(
       // Check if previous command is successful by checking whether
       // constant torque policy for packet drops is applied
       // (If applied, desired torques will be exactly the same as last timestep)
-      if (libfranka_robot_state.tau_J_d[i] !=
-          robot_state_.motor_torques_desired(i)) {
-        prev_command_successful_ = true;
+      if (!prev_command_successful &&
+          float(libfranka_robot_state.tau_J_d[i]) !=
+              robot_state_.motor_torques_desired(i)) {
+        prev_command_successful = true;
       }
       robot_state_.set_motor_torques_desired(i,
                                              libfranka_robot_state.tau_J_d[i]);
     }
 
-    robot_state_.set_prev_command_successful(prev_command_successful_);
+    robot_state_.set_prev_command_successful(prev_command_successful);
 
     // Error code: can only set to 0 if no errors and 1 if any errors exist for
     // now

--- a/polymetis/polymetis/src/clients/franka_panda_client/franka_panda_client.cpp
+++ b/polymetis/polymetis/src/clients/franka_panda_client/franka_panda_client.cpp
@@ -79,11 +79,11 @@ FrankaTorqueControlClient::FrankaTorqueControlClient(
 
   // Parse yaml
   double lpf_cutoff_freq = config["lpf_cutoff_frequency"].as<double>();
-  double tmp = 2 * M_PI * lpf_cutoff_freq / FRANKA_HZ;
-  if (lpf_cutoff_freq >= FRANKA_HZ) {
-    lpf_alpha_ = 1.0;
-  } else {
+  if (lpf_cutoff_freq > 0.0) {
+    double tmp = 2 * M_PI * lpf_cutoff_freq / FRANKA_HZ;
     lpf_alpha_ = tmp / (tmp + 1.0);
+  } else {
+    lpf_alpha_ = 1.0;
   }
 
   cartesian_pos_ulimits_ =

--- a/polymetis/polymetis/src/clients/franka_panda_client/franka_panda_client.cpp
+++ b/polymetis/polymetis/src/clients/franka_panda_client/franka_panda_client.cpp
@@ -245,6 +245,10 @@ void FrankaTorqueControlClient::updateServerCommand(
     }
 
     robot_state_.set_prev_command_successful(prev_command_successful_);
+
+    // Error code: can only set to 0 if no errors and 1 if any errors exist for
+    // now
+    robot_state_.set_error_code(bool(libfranka_robot_state.current_errors));
   }
   setTimestampToNow(robot_state_.mutable_timestamp());
 

--- a/polymetis/polymetis/src/clients/franka_panda_client/franka_panda_client.cpp
+++ b/polymetis/polymetis/src/clients/franka_panda_client/franka_panda_client.cpp
@@ -151,7 +151,8 @@ void FrankaTorqueControlClient::run() {
     while (is_robot_operational) {
       // Send lambda function
       try {
-        robot_ptr_->control(control_callback);
+        robot_ptr_->control(control_callback, true,
+                            franka::kMaxCutoffFrequency);
       } catch (const std::exception &ex) {
         spdlog::error("Robot is unable to be controlled: {}", ex.what());
         is_robot_operational = false;


### PR DESCRIPTION
# Description

Changes:
- Tune Cartesian impedance default gains to remove observed oscillations under certain conditions.
- Disable native low-pass filter for Franka control
- Allow disabling rate limiting for Franka control through configs
- Re-add our own configurable low-pass filter in the robot client (with a default value of `100`, same as `franka::kDefaultCutoffFrequency`)
- Add boolean representing command packet success to robot state (By measuring whether the desired torque is exactly the same across two steps, since a constant torque policy is applied to the robot by default if a command packet is dropped)
- Add error code to robot state

Note: currently the error code is `0` if there are no errors and `1` if any errors exist. I originally wanted to include an error string since this is the other form [`franka::Error`](https://frankaemika.github.io/libfranka/structfranka_1_1Errors.html#a50cb6e50c1ce2b5ec281dcad83f1779e) is able to be casted to, but the gRPC socket closes for some unknown reason if I try to include a string field within the RobotState message. (Perhaps due to C isolation?)

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

If this PR introduces a change or fixes a bug, please add before and after screenshots (if this is causes a UX change) or before and after examples(this could be plain text, videos etc ) to demonstrate the change.

If this PR introduces a new feature, please also add examples or screenshots demonstrating the feature.

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [x] I have added Docstrings and comments to the code.
- [x] I have made changes to existing documentation where needed.
- [x] I have added tests that show that the PR is functional.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
