### PR TITLE
[fbrp] check bad env

### DIFF
--- a/fbrp/src/fbrp/process_def.py
+++ b/fbrp/src/fbrp/process_def.py
@@ -1,3 +1,4 @@
+from fbrp import util
 import dataclasses
 import inspect
 import os
@@ -48,6 +49,11 @@ def process(
         root = os.path.normpath(os.path.join(rule_dir, root))
     else:
         root = rule_dir
+
+    # Validate env is dict[str, str]
+    for k, v in env.items():
+        if [type(k), type(v)] != [str, str]:
+            util.fail(f"fbrp process [{name}] invalid. env is not dict[str, str]")
 
     defined_processes[name] = ProcDef(
         name=name,

--- a/fbrp/tests/fbrp/test_process_def.py
+++ b/fbrp/tests/fbrp/test_process_def.py
@@ -10,4 +10,4 @@ def test_invalid_env(capsys):
 
     stdout, stderr = capsys.readouterr()
     assert stdout == ""
-    assert stderr == "fbrp process [foo] invalid. env is not dict[str, str]"
+    assert stderr == "fbrp process [foo] invalid. env is not dict[str, str]\n"

--- a/fbrp/tests/fbrp/test_process_def.py
+++ b/fbrp/tests/fbrp/test_process_def.py
@@ -1,0 +1,13 @@
+from fbrp import process_def
+import pytest
+
+
+def test_invalid_env(capsys):
+    with pytest.raises(SystemExit) as exit_info:
+        process_def.process("foo", env={1: 2})
+    assert exit_info.type == SystemExit
+    assert exit_info.value.code == 1
+
+    stdout, stderr = capsys.readouterr()
+    assert stdout == ""
+    assert stderr == "fbrp process [foo] invalid. env is not dict[str, str]"


### PR DESCRIPTION
# Description

FBRP process env can only handle dict[str, str]. This PR adds an explicit check.

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [x] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Before:
Passing non-string env would cause undefined behavior.

After:
Passing non-string env would cause print an error and exit.

# Testing

Added unit test.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [x] I have added tests that show that the PR is functional.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
