### PR TITLE
[Polymetis] Add controller warmup

### DIFF
--- a/polymetis/polymetis/src/polymetis_server.cpp
+++ b/polymetis/polymetis/src/polymetis_server.cpp
@@ -89,9 +89,9 @@ Status PolymetisControllerServerImpl::InitRobotClient(
 
   // Load default controller from model buffer
   try {
-    robot_client_context_.default_controller =
-        new TorchScriptedController(controller_model_buffer_.data(),
-                                    controller_model_buffer_.size(), num_dofs_);
+    robot_client_context_.default_controller = new TorchScriptedController(
+        controller_model_buffer_.data(), controller_model_buffer_.size(),
+        *torch_robot_state_);
   } catch (const std::exception &e) {
     std::string error_msg =
         "Failed to load default controller: " + std::string(e.what());
@@ -240,9 +240,9 @@ Status PolymetisControllerServerImpl::SetController(
 
   try {
     // Load new controller
-    auto new_controller =
-        new TorchScriptedController(controller_model_buffer_.data(),
-                                    controller_model_buffer_.size(), num_dofs_);
+    auto new_controller = new TorchScriptedController(
+        controller_model_buffer_.data(), controller_model_buffer_.size(),
+        *torch_robot_state_);
 
     // Switch in new controller by updating controller context
     custom_controller_context_.controller_mtx.lock();

--- a/polymetis/polymetis/src/polymetis_server.cpp
+++ b/polymetis/polymetis/src/polymetis_server.cpp
@@ -89,8 +89,9 @@ Status PolymetisControllerServerImpl::InitRobotClient(
 
   // Load default controller from model buffer
   try {
-    robot_client_context_.default_controller = new TorchScriptedController(
-        controller_model_buffer_.data(), controller_model_buffer_.size());
+    robot_client_context_.default_controller =
+        new TorchScriptedController(controller_model_buffer_.data(),
+                                    controller_model_buffer_.size(), num_dofs_);
   } catch (const std::exception &e) {
     std::string error_msg =
         "Failed to load default controller: " + std::string(e.what());
@@ -239,8 +240,9 @@ Status PolymetisControllerServerImpl::SetController(
 
   try {
     // Load new controller
-    auto new_controller = new TorchScriptedController(
-        controller_model_buffer_.data(), controller_model_buffer_.size());
+    auto new_controller =
+        new TorchScriptedController(controller_model_buffer_.data(),
+                                    controller_model_buffer_.size(), num_dofs_);
 
     // Switch in new controller by updating controller context
     custom_controller_context_.controller_mtx.lock();

--- a/polymetis/polymetis/torch_isolation/include/torch_server_ops.hpp
+++ b/polymetis/polymetis/torch_isolation/include/torch_server_ops.hpp
@@ -53,7 +53,8 @@ private:
   struct TorchInput *empty_input_ = nullptr;
 
 public:
-  TorchScriptedController(char *data, size_t size, int num_dofs);
+  TorchScriptedController(char *data, size_t size,
+                          TorchRobotState &init_robot_state);
   ~TorchScriptedController();
 
   std::vector<float> forward(TorchRobotState &input);

--- a/polymetis/polymetis/torch_isolation/include/torch_server_ops.hpp
+++ b/polymetis/polymetis/torch_isolation/include/torch_server_ops.hpp
@@ -13,6 +13,7 @@ extern "C" {
 #endif /* __cplusplus */
 
 #define C_TORCH_EXPORT __attribute__((visibility("default")))
+#define WARM_UP_ITERS 5
 
 struct TorchTensor;       // torch::Tensor
 struct TorchScriptModule; // torch::jit::script::Module
@@ -52,7 +53,7 @@ private:
   struct TorchInput *empty_input_ = nullptr;
 
 public:
-  TorchScriptedController(char *data, size_t size);
+  TorchScriptedController(char *data, size_t size, int num_dofs);
   ~TorchScriptedController();
 
   std::vector<float> forward(TorchRobotState &input);

--- a/polymetis/polymetis/torch_isolation/include/torch_server_ops.hpp
+++ b/polymetis/polymetis/torch_isolation/include/torch_server_ops.hpp
@@ -57,6 +57,8 @@ public:
                           TorchRobotState &init_robot_state);
   ~TorchScriptedController();
 
+  void warmup_controller(int warmup_iters, TorchRobotState &init_robot_state);
+
   std::vector<float> forward(TorchRobotState &input);
 
   bool param_dict_load(char *data, size_t size);

--- a/polymetis/polymetis/torch_isolation/src/torch_server_ops.cpp
+++ b/polymetis/polymetis/torch_isolation/src/torch_server_ops.cpp
@@ -113,8 +113,8 @@ void TorchRobotState::update_state(int timestamp_s, int timestamp_ns,
   }
 }
 
-TorchScriptedController::TorchScriptedController(char *data, size_t size,
-                                                 int num_dofs) {
+TorchScriptedController::TorchScriptedController(
+    char *data, size_t size, TorchRobotState &init_robot_state) {
   memstream stream(data, size);
   module_ = new TorchScriptModule{torch::jit::load(stream)};
 
@@ -124,9 +124,8 @@ TorchScriptedController::TorchScriptedController(char *data, size_t size,
   // Backup, warm up, and reload module
   auto tmp_module_data = module_->data.deepcopy();
 
-  TorchRobotState dummy_robot_state(num_dofs);
   for (int i = 0; i < WARM_UP_ITERS; i++) {
-    this->forward(dummy_robot_state);
+    this->forward(init_robot_state);
   }
 
   module_->data = tmp_module_data;

--- a/polymetis/polymetis/torch_isolation/src/torch_server_ops.cpp
+++ b/polymetis/polymetis/torch_isolation/src/torch_server_ops.cpp
@@ -121,14 +121,9 @@ TorchScriptedController::TorchScriptedController(
   param_dict_input_ = new TorchInput{std::vector<torch::jit::IValue>()};
   empty_input_ = new TorchInput{std::vector<torch::jit::IValue>()};
 
-  // Backup, warm up, and reload module
-  auto tmp_module_data = module_->data.deepcopy();
-
-  for (int i = 0; i < WARM_UP_ITERS; i++) {
-    this->forward(init_robot_state);
-  }
-
-  module_->data = tmp_module_data;
+  // Warm up controller (TorchScript models take time to compile during first 2
+  // queries)
+  this->warmup_controller(WARM_UP_ITERS, init_robot_state);
 }
 
 TorchScriptedController::~TorchScriptedController() {
@@ -151,6 +146,20 @@ std::vector<float> TorchScriptedController::forward(TorchRobotState &input) {
     result.push_back(desired_torque[i].item<float>());
   }
   return result;
+}
+
+void TorchScriptedController::warmup_controller(
+    int warmup_iters, TorchRobotState &init_robot_state) {
+  // Backup
+  auto tmp_module_data = module_->data.deepcopy();
+
+  // Warmup
+  for (int i = 0; i < warmup_iters; i++) {
+    this->forward(init_robot_state);
+  }
+
+  // Reload
+  module_->data = tmp_module_data;
 }
 
 bool TorchScriptedController::is_terminated() {


### PR DESCRIPTION
# Description

Resolves issue where first few controller steps after loading the controller takes a long time.
Warms the controller up by calling forward a few times and reloading it. 

Related issue: https://github.com/pytorch/pytorch/issues/33354 

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Hardware benchmarks were run by testing the latency of each control loop.

Previous results:
```
Control loop latency stats in milliseconds (avg / std / max / min):
Joint PD: 0.2239/ 0.0892 / 3.9081 / 0.1451
Cartesian PD: 0.3057/ 0.1341 / 5.7486 / 0.1322
```

After implementing the warmup:
```
Control loop latency stats in milliseconds (avg / std / max / min):
Joint PD: 0.2287/ 0.0134 / 0.6303 / 0.1371
Cartesian PD: 0.3076/ 0.0147 / 0.7768 / 0.1483
```

Histograms of the first 50 steps of running a Cartesian PD controller:
![image](https://user-images.githubusercontent.com/9565466/156272551-2d1212c2-e0bf-4de2-bebb-19da16729a55.png)


# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
