### PR TITLE
[fbrp] up -v

### DIFF
--- a/fbrp/src/fbrp/__init__.py
+++ b/fbrp/src/fbrp/__init__.py
@@ -1,4 +1,3 @@
-from fbrp.cmd._common import CommonFlags
 from fbrp.process_def import process
 from fbrp.runtime.conda import Conda
 from fbrp.runtime.docker import Docker
@@ -9,9 +8,8 @@ import os
 
 
 @click.group()
-@click.option("-v/-q", "--verbose/--quiet", is_flag=True, default=False)
-def cli(verbose):
-    CommonFlags.verbose = verbose
+def cli():
+    pass
 
 
 def main():

--- a/fbrp/src/fbrp/cmd/_common.py
+++ b/fbrp/src/fbrp/cmd/_common.py
@@ -1,2 +1,0 @@
-class CommonFlags:
-    verbose = False

--- a/fbrp/src/fbrp/cmd/up.py
+++ b/fbrp/src/fbrp/cmd/up.py
@@ -86,12 +86,13 @@ def down_existing(names: typing.List[str], force: bool):
 
 @click.command()
 @click.argument("procs", nargs=-1, shell_complete=_autocomplete.defined_processes)
+@click.option("-v/-q", "--verbose/--quiet", is_flag=True, default=True)
 @click.option("--deps/--nodeps", is_flag=True, default=True)
 @click.option("--build/--nobuild", is_flag=True, default=True)
 @click.option("--run/--norun", is_flag=True, default=True)
 @click.option("-f", "--force/--noforce", is_flag=True, default=False)
 @click.option("--reset_logs", is_flag=True, default=False)
-def cli(procs, deps, build, run, force, reset_logs):
+def cli(procs, verbose, deps, build, run, force, reset_logs):
     names = get_proc_names(procs, deps)
     names = [name for name in names if process_def.defined_processes[name].runtime]
     if not names:
@@ -107,7 +108,7 @@ def cli(procs, deps, build, run, force, reset_logs):
         for name in names:
             proc_def = process_def.defined_processes[name]
             print(f"building {name}...")
-            proc_def.runtime._build(name, proc_def)
+            proc_def.runtime._build(name, proc_def, verbose)
             print(f"built {name}\n")
 
     if run:

--- a/fbrp/src/fbrp/runtime/base.py
+++ b/fbrp/src/fbrp/runtime/base.py
@@ -81,7 +81,7 @@ class BaseRuntime:
     def asdict(self, root: pathlib.Path):
         raise NotImplementedError("Runtime hasn't implemented asdict!")
 
-    def _build(self, name: str, proc_def: ProcDef):
+    def _build(self, name: str, proc_def: ProcDef, verbose: bool):
         raise NotImplementedError("Runtime hasn't implemented build!")
 
     def _launcher(self, name: str, proc_def: ProcDef) -> BaseLauncher:

--- a/fbrp/src/fbrp/runtime/conda.py
+++ b/fbrp/src/fbrp/runtime/conda.py
@@ -271,7 +271,7 @@ class Conda(BaseRuntime):
 
     def _build(self, name: str, proc_def: ProcDef, verbose: bool):
         if not self.env_nosandbox:
-            self._create_env(name, proc_def)
+            self._create_env(name, proc_def, verbose)
 
         if self.setup_commands:
             print(f"setting up conda env for {name}")

--- a/fbrp/src/fbrp/runtime/conda.py
+++ b/fbrp/src/fbrp/runtime/conda.py
@@ -1,6 +1,5 @@
 from fbrp import life_cycle
 from fbrp import util
-from fbrp.cmd._common import CommonFlags
 from fbrp.process_def import ProcDef
 from fbrp.runtime.base import BaseLauncher, BaseRuntime
 import asyncio
@@ -245,7 +244,7 @@ class Conda(BaseRuntime):
             "dependencies": self.conda_env.dependencies,
         }
 
-    def _create_env(self, name: str, proc_def: ProcDef):
+    def _create_env(self, name: str, proc_def: ProcDef, verbose: bool):
         env_path = f"/tmp/fbrp_conda_{name}.yml"
 
         env_content = self._generate_env_content(proc_def.root)
@@ -261,16 +260,16 @@ class Conda(BaseRuntime):
         # Updating an existing environment does not remove old packages, even with --prune.
         subprocess.run(
             [update_bin, "env", "remove", "-n", self._env_name(name)],
-            capture_output=not CommonFlags.verbose,
+            capture_output=not verbose,
         )
         result = subprocess.run(
             [update_bin, "env", "update", "--prune", "-f", env_path],
-            capture_output=not CommonFlags.verbose,
+            capture_output=not verbose,
         )
         if result.returncode:
             util.fail(f"Failed to set up conda env: {result.stderr}")
 
-    def _build(self, name: str, proc_def: ProcDef):
+    def _build(self, name: str, proc_def: ProcDef, verbose: bool):
         if not self.env_nosandbox:
             self._create_env(name, proc_def)
 
@@ -288,7 +287,7 @@ class Conda(BaseRuntime):
                 """,
                 shell=True,
                 executable="/bin/bash",
-                capture_output=not CommonFlags.verbose,
+                capture_output=not verbose,
             )
             if result.returncode:
                 util.fail(f"Failed to set up conda env: {result.stderr}")

--- a/fbrp/src/fbrp/runtime/docker.py
+++ b/fbrp/src/fbrp/runtime/docker.py
@@ -1,6 +1,5 @@
 from fbrp import life_cycle
 from fbrp import util
-from fbrp.cmd._common import CommonFlags
 from fbrp.process_def import ProcDef
 from fbrp.runtime.base import BaseLauncher, BaseRuntime
 import aiodocker
@@ -166,7 +165,7 @@ class Docker(BaseRuntime):
             ret["run_kwargs"] = self.run_kwargs
         return ret
 
-    def _build(self, name: str, proc_def: ProcDef):
+    def _build(self, name: str, proc_def: ProcDef, verbose: bool):
         docker_api = docker.from_env()
         docker_api.lowlevel = docker.APIClient()
 
@@ -187,7 +186,7 @@ class Docker(BaseRuntime):
 
             for line in docker_api.lowlevel.build(**build_kwargs):
                 lineinfo = json.loads(line.decode())
-                if CommonFlags.verbose and "stream" in lineinfo:
+                if verbose and "stream" in lineinfo:
                     print(lineinfo["stream"].strip())
                 elif "errorDetail" in lineinfo:
                     util.fail(json.dumps(lineinfo["errorDetail"], indent=2))
@@ -198,7 +197,7 @@ class Docker(BaseRuntime):
                 try:
                     for line in docker_api.lowlevel.pull(self.image, stream=True):
                         lineinfo = json.loads(line.decode())
-                        if CommonFlags.verbose and "status" in lineinfo:
+                        if verbose and "status" in lineinfo:
                             print(lineinfo["status"].strip())
                 except docker.errors.NotFound as e:
                     util.fail(e)
@@ -277,7 +276,7 @@ class Docker(BaseRuntime):
                 },
             ):
                 lineinfo = json.loads(line.decode())
-                if CommonFlags.verbose and "stream" in lineinfo:
+                if verbose and "stream" in lineinfo:
                     print(lineinfo["stream"].strip())
                 elif "errorDetail" in lineinfo:
                     util.fail(json.dumps(lineinfo["errorDetail"], indent=2))


### PR DESCRIPTION
# Description

Remove global verbose flag and add it as a flag to `up` (which was the only command that used it).

Also, `--verbose` has become default. To disable, use `--quiet` or `-q`

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [x] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Before:
```
fbrp -v up foo --nobuild --reset_logs ...
```

After:
```
fbrp up foo --nobuild --reset_logs ...
```

# Testing

Manual testing of examples.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [x] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
