### PR TITLE
[fbrp] reroute stdio

### DIFF
--- a/fbrp/src/fbrp/runtime/conda.py
+++ b/fbrp/src/fbrp/runtime/conda.py
@@ -113,9 +113,13 @@ class Launcher(BaseLauncher):
     async def gather_cmd_outputs(self):
         async def log_pipe(logger, pipe):
             while True:
-                line = await pipe.readline()
-                if line:
-                    logger(line)
+                try:
+                    async for line in pipe:
+                        logger(line)
+                except ValueError:
+                    # TODO(lshamis): Can we grab the line in chucks?
+                    logger("<[FBRP] line length exceeded. skipping>")
+                    continue
                 else:
                     break
 


### PR DESCRIPTION
# Description

Reroute fbrp launcher stdout/stderr to `/tmp/fbrp_{name}.log`

Better try-except that catches fatal issues.

Catch issue with subprocess pipes not able to handle long lines. Bypassed for now. Fix for later.

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Before:
launcher crashes and fbrp is left in an inconsistent state. No crash info available to debug.

After:
launcher forwards stdio to file for debugging. Catches death, fbrp should remain consistent even with bugs in the runtime .

# Testing

Run FBRP with the following process:
```py
import time
import os

i = 0
while True:
    print(os.urandom(1024 * 1024 * 4))
    i += 1
    time.sleep(1)
```

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
