### PR TITLE
Run CI on formatting commits

### DIFF
--- a/tools/codetools/check_and_fix_black_failures.sh
+++ b/tools/codetools/check_and_fix_black_failures.sh
@@ -19,7 +19,7 @@ do
     if [ -n "$(git status --porcelain)" ]; then
       git config user.name >/dev/null || git config --global user.name "bot"
       git config user.email >/dev/null || git config --global user.email "bot@fb.com"
-      git add $CHECK_DIR && git commit -m "[skip ci] Automatic style fix for $CHECK_DIR" && git push --set-upstream origin $(git rev-parse --abbrev-ref HEAD)
+      git add $CHECK_DIR && git commit -m "Automatic style fix for $CHECK_DIR" && git push --set-upstream origin $(git rev-parse --abbrev-ref HEAD)
       echo "Auto fix style."
     else
       echo "Style is perfect. No need to fix."


### PR DESCRIPTION
# Description

If the last commit in a PR is an automatic formatting change which skips CI, then the merge to main branch also skips CI (e.g. see [this run](https://app.circleci.com/pipelines/github/facebookresearch/fairo/4874/workflows/c2ecf451-4a77-477a-8c4f-769fa5961c92) ). This is not great because some jobs are only run on main (doc update, polymetis conda upload).

Fixes # (issue)

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

If this PR introduces a change or fixes a bug, please add before and after screenshots (if this is causes a UX change) or before and after examples(this could be plain text, videos etc ) to demonstrate the change.

If this PR introduces a new feature, please also add examples or screenshots demonstrating the feature.

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
