### PR TITLE
[fbrp] support fbrp as library

### DIFF
--- a/fbrp/src/fbrp/__init__.py
+++ b/fbrp/src/fbrp/__init__.py
@@ -13,7 +13,7 @@ def cli():
     pass
 
 
-def main():
+def main(*args):
     cmd_list = [
         "down",
         "info",
@@ -29,7 +29,14 @@ def main():
         module = SourceFileLoader(cmd, path).load_module()
         cli.add_command(module.cli, cmd)
 
-    cli()
+    try:
+        cli(*args)
+    except SystemExit as sys_exit:
+        if sys_exit.code == 0:
+            return
+        raise RuntimeError(
+            f"fbrp.main failed with exit code {sys_exit.code}"
+        ) from sys_exit
 
 
 __all__ = ["main", "process", "NoEscape", "Docker", "Conda", "Host"]


### PR DESCRIPTION
# Description

FBRP support execution as library.
For example
```py
# fsetup.py

import fbrp
fbrp.main(["ps"])
fbrp.main(["info"])
fbrp.main()  # reads from sys.argv
```

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

# Testing

Manually tested. 

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
