### PR TITLE
[fbrp] direct command invokation

### DIFF
--- a/fbrp/src/fbrp/cmd/down.py
+++ b/fbrp/src/fbrp/cmd/down.py
@@ -5,7 +5,7 @@ import click
 
 @click.command()
 @click.argument("procs", nargs=-1, shell_complete=_autocomplete.running_processes)
-def cli(procs):
+def cli(procs=[]):
     down_procs = life_cycle.system_state().procs.keys()
 
     if procs:

--- a/fbrp/src/fbrp/cmd/logs.py
+++ b/fbrp/src/fbrp/cmd/logs.py
@@ -26,7 +26,7 @@ import sys
     ),
 )
 @click.option("-o", "--old", is_flag=True, default=False)
-def cli(procs, old):
+def cli(procs=[], old=False):
     # Find all defined processes.
     display_procs = process_def.defined_processes.items()
     # Filter out processes that have no runtime defined.

--- a/fbrp/src/fbrp/cmd/up.py
+++ b/fbrp/src/fbrp/cmd/up.py
@@ -93,7 +93,7 @@ def down_existing(names: typing.List[str], force: bool):
 @click.option("--run/--norun", is_flag=True, default=True)
 @click.option("-f", "--force/--noforce", is_flag=True, default=False)
 @click.option("--reset_logs", is_flag=True, default=False)
-def cli(procs, verbose, deps, build, run, force, reset_logs):
+def cli(procs=[], verbose=True, deps=True, build=True, run=True, force=False, reset_logs=False):
     names = get_proc_names(procs, deps)
     names = [name for name in names if process_def.defined_processes[name].runtime]
     if not names:
@@ -116,6 +116,7 @@ def cli(procs, verbose, deps, build, run, force, reset_logs):
         for name in names:
             print(f"running {name}...")
             life_cycle.set_ask(name, life_cycle.Ask.UP)
+            life_cycle.set_state(name, life_cycle.State.STARTING)
 
             if os.fork() != 0:
                 continue

--- a/fbrp/src/fbrp/cmd/wait.py
+++ b/fbrp/src/fbrp/cmd/wait.py
@@ -8,14 +8,15 @@ import types
 @click.command()
 @click.argument("procs", nargs=-1, shell_complete=_autocomplete.running_processes)
 @click.option("-t", "--timeout", type=float, default=0)
-def cli(procs, timeout):
+def cli(procs=[], timeout=0):
     wait_procs = set(life_cycle.system_state().procs.keys())
     if procs:
         wait_procs = set(wait_procs) & set(procs)
 
-    ns = types.SimpleNamespace()
-    ns.cv = threading.Condition()
-    ns.sat = False
+    ns = types.SimpleNamespace(
+        cv=threading.Condition(),
+        sat=False,
+    )
 
     def callback(sys_state):
         for proc, info in sys_state.procs.items():

--- a/fbrp/src/fbrp/process_def.py
+++ b/fbrp/src/fbrp/process_def.py
@@ -38,7 +38,7 @@ def process(
     cfg: dict = {},
     deps: typing.List[str] = [],
     env: dict = {},
-):
+) -> ProcDef:
     if name in defined_processes:
         raise ValueError(f"fbrp.process({name=}) defined multiple times.")
 
@@ -64,3 +64,5 @@ def process(
         rule_file=rule_file,
         env=env,
     )
+
+    return defined_processes[name]

--- a/fbrp/src/fbrp/runtime/conda.py
+++ b/fbrp/src/fbrp/runtime/conda.py
@@ -136,7 +136,6 @@ class Launcher(BaseLauncher):
             pass
 
     async def run(self):
-        life_cycle.set_state(self.name, life_cycle.State.STARTING)
         conda_env = await self.activate_conda_envvar()
         await self.run_cmd_with_envvar(conda_env)
         life_cycle.set_state(self.name, life_cycle.State.STARTED)

--- a/fbrp/src/fbrp/runtime/docker.py
+++ b/fbrp/src/fbrp/runtime/docker.py
@@ -84,7 +84,6 @@ class Launcher(BaseLauncher):
         }
         util.nested_dict_update(run_kwargs, self.kwargs)
 
-        life_cycle.set_state(self.name, life_cycle.State.STARTING)
         docker = aiodocker.Docker()
 
         try:

--- a/fbrp/src/fbrp/runtime/host.py
+++ b/fbrp/src/fbrp/runtime/host.py
@@ -48,8 +48,6 @@ class Launcher(BaseLauncher):
             pass
 
     async def run(self):
-        life_cycle.set_state(self.name, life_cycle.State.STARTING)
-
         subprocess_env = os.environ.copy()
         subprocess_env.update(self.proc_def.env)
 

--- a/fbrp/tests/fbrp/runtime/test_conda.py
+++ b/fbrp/tests/fbrp/runtime/test_conda.py
@@ -113,9 +113,9 @@ class TestLauncher(IsolatedAsyncioTestCase):
         mock_activate_conda_env.assert_called_once()
         mock_run_cmd_with_envvar.assert_called_once()
         mock_gather_cmd_outputs.assert_called_once()
-        assert mock_set_state.call_count == 2
+        assert mock_set_state.call_count == 1
         mock_set_state.assert_has_calls(
-            [call("test_conda", State.STARTING), call("test_conda", State.STARTED)]
+            [call("test_conda", State.STARTED)]
         )
 
 


### PR DESCRIPTION
# Description

Allow `fsetup.py` to invoke commands directly, outside the command line args.

For example:
```py
import fbrp

...

fbrp.cmd.up(procs=["proc"], build=False, reset_logs=True)
fbrp.cmd.wait(procs=["proc"])
fbrp.cmd.logs(procs=["proc"], old=True)
```

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [x] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

...

# Testing

Manual testing.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
