### PR TITLE
[fbrp] cmd syntax support proc star

### DIFF
--- a/fbrp/src/fbrp/cmd/down.py
+++ b/fbrp/src/fbrp/cmd/down.py
@@ -5,7 +5,10 @@ import click
 
 @click.command()
 @click.argument("procs", nargs=-1, shell_complete=_autocomplete.running_processes)
-def cli(procs=[]):
+def cli(*cmd_procs, procs=[]):
+    # Support procs as *args when using cmd syntax.
+    procs += cmd_procs
+
     down_procs = life_cycle.system_state().procs.keys()
 
     if procs:

--- a/fbrp/src/fbrp/cmd/logs.py
+++ b/fbrp/src/fbrp/cmd/logs.py
@@ -26,7 +26,10 @@ import sys
     ),
 )
 @click.option("-o", "--old", is_flag=True, default=False)
-def cli(procs=[], old=False):
+def cli(*cmd_procs, procs=[], old=False):
+    # Support procs as *args when using cmd syntax.
+    procs += cmd_procs
+
     # Find all defined processes.
     display_procs = process_def.defined_processes.items()
     # Filter out processes that have no runtime defined.

--- a/fbrp/src/fbrp/cmd/up.py
+++ b/fbrp/src/fbrp/cmd/up.py
@@ -93,7 +93,10 @@ def down_existing(names: typing.List[str], force: bool):
 @click.option("--run/--norun", is_flag=True, default=True)
 @click.option("-f", "--force/--noforce", is_flag=True, default=False)
 @click.option("--reset_logs", is_flag=True, default=False)
-def cli(procs=[], verbose=True, deps=True, build=True, run=True, force=False, reset_logs=False):
+def cli(*cmd_procs, procs=[], verbose=True, deps=True, build=True, run=True, force=False, reset_logs=False):
+    # Support procs as *args when using cmd syntax.
+    procs += cmd_procs
+
     names = get_proc_names(procs, deps)
     names = [name for name in names if process_def.defined_processes[name].runtime]
     if not names:

--- a/fbrp/src/fbrp/cmd/wait.py
+++ b/fbrp/src/fbrp/cmd/wait.py
@@ -8,7 +8,10 @@ import types
 @click.command()
 @click.argument("procs", nargs=-1, shell_complete=_autocomplete.running_processes)
 @click.option("-t", "--timeout", type=float, default=0)
-def cli(procs=[], timeout=0):
+def cli(*cmd_procs, procs=[], timeout=0):
+    # Support procs as *args when using cmd syntax.
+    procs += cmd_procs
+
     wait_procs = set(life_cycle.system_state().procs.keys())
     if procs:
         wait_procs = set(wait_procs) & set(procs)


### PR DESCRIPTION
# Description

FBRP command syntax now supports processes as *args.

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Before:
```py
fbrp.cmd.up(procs=["proc"], reset_logs=True)
import time
time.sleep(1)
fbrp.cmd.down(procs=["proc"])
fbrp.cmd.logs(procs=["proc"], old=True)
```

After:
```py
fbrp.cmd.up("proc", reset_logs=True)
import time
time.sleep(1)
fbrp.cmd.down("proc")
fbrp.cmd.logs("proc", old=True)
```

# Testing

Manual testing.
Ensure new command syntax works.
Ensure old command syntax works.
Ensure `fbrp.main()` works.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
