### PR TITLE
Remove ee requirement from Polymetis

### DIFF
--- a/polymetis/polymetis/conf/robot_model/allegro_hand.yaml
+++ b/polymetis/polymetis/conf/robot_model/allegro_hand.yaml
@@ -2,9 +2,6 @@
 robot_description_path: "allegro_hand/allegro_hand_description_right.urdf"
 controlled_joints:  [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
 num_dofs: 16
-ee_link_idx: 0
-ee_link_name: fixme-no-ee-link
-rest_pose: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 joint_limits_low: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 joint_limits_high: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 joint_damping: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]

--- a/polymetis/polymetis/conf/robot_model/allegro_hand.yaml
+++ b/polymetis/polymetis/conf/robot_model/allegro_hand.yaml
@@ -2,6 +2,7 @@
 robot_description_path: "allegro_hand/allegro_hand_description_right.urdf"
 controlled_joints:  [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
 num_dofs: 16
+rest_pose: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 joint_limits_low: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 joint_limits_high: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 joint_damping: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]

--- a/polymetis/polymetis/python/polymetis/robot_client/metadata.py
+++ b/polymetis/polymetis/python/polymetis/robot_client/metadata.py
@@ -87,8 +87,10 @@ class RobotClientMetadata:
         robot_client_metadata = polymetis_pb2.RobotClientMetadata()
         robot_client_metadata.hz = hz
         robot_client_metadata.dof = robot_model_cfg.num_dofs
-        robot_client_metadata.ee_link_name = robot_model_cfg.ee_link_name
-        robot_client_metadata.ee_link_idx = robot_model_cfg.ee_link_idx
+        if "ee_link_name" in robot_model_cfg:
+            robot_client_metadata.ee_link_name = robot_model_cfg.ee_link_name
+        if "ee_link_idx" in robot_model_cfg:
+            robot_client_metadata.ee_link_idx = robot_model_cfg.ee_link_idx
 
         # Set gains as shared metadata
         robot_client_metadata.default_Kq[:] = default_Kq

--- a/polymetis/polymetis/python/polymetis/robot_interface.py
+++ b/polymetis/polymetis/python/polymetis/robot_interface.py
@@ -9,10 +9,8 @@ import tempfile
 import threading
 import atexit
 import logging
-from enum import Enum
 
 import grpc  # This requires `conda install grpcio protobuf`
-import numpy as np
 import torch
 
 import polymetis
@@ -324,7 +322,7 @@ class RobotInterface(BaseRobotInterface):
         """Sets the home pose for `go_home()` to use."""
         self.home_pose = home_pose
 
-    def set_robot_model(self, robot_description_path: str, ee_link_name: str):
+    def set_robot_model(self, robot_description_path: str, ee_link_name: str = None):
         """Loads the URDF as a RobotModelPinocchio."""
         # Create Torchscript Pinocchio model for DynamicsControllers
         self.robot_model = toco.models.RobotModelPinocchio(

--- a/polymetis/polymetis/python/torchcontrol/models/torchscript_pinocchio.py
+++ b/polymetis/polymetis/python/torchcontrol/models/torchscript_pinocchio.py
@@ -138,8 +138,8 @@ class RobotModelPinocchio(torch.nn.Module):
         https://gepettoweb.laas.fr/doc/stack-of-tasks/pinocchio/master/doxygen-html/md_doc_b-examples_i-inverse-kinematics.html
 
         Args:
-            link_pos (torch.Tensor): desired end-effector position
-            link_quat (torch.Tensor): desired end-effector orientation
+            link_pos (torch.Tensor): desired link position
+            link_quat (torch.Tensor): desired link orientation
             link_name (str, optional): name of the link desired. Defaults to the
                                        end-effector link, if it was set during initialization.
             rest_pose (torch.Tensor): (optional) initial solution for IK

--- a/polymetis/polymetis/python/torchcontrol/models/torchscript_pinocchio.py
+++ b/polymetis/polymetis/python/torchcontrol/models/torchscript_pinocchio.py
@@ -61,9 +61,10 @@ class RobotModelPinocchio(torch.nn.Module):
     def _get_link_idx_or_use_ee(self, link_name: str) -> int:
         if not link_name:
             frame_idx = self.ee_link_idx
-            assert (
-                frame_idx
-            ), "No end-effector link set during initialization, so link_name must be set."
+            assert frame_idx, (
+                "No end-effector link set during initialization, so link_name must "
+                + "be either input as parameter or set as default using `set_ee_link`."
+            )
         else:
             frame_idx = self.model.get_link_idx_from_name(link_name)
         return frame_idx

--- a/polymetis/polymetis/python/torchcontrol/models/torchscript_pinocchio.py
+++ b/polymetis/polymetis/python/torchcontrol/models/torchscript_pinocchio.py
@@ -52,6 +52,7 @@ class RobotModelPinocchio(torch.nn.Module):
         self.set_ee_link(ee_link_name)
 
     def set_ee_link(self, ee_link_name):
+        """Sets the `ee_link_name`, `ee_link_idx` using pinocchio::ModelTpl::getBodyId."""
         self.ee_link_name = ee_link_name
         if self.ee_link_name is not None:
             self.ee_link_idx = self.model.get_link_idx_from_name(self.ee_link_name)
@@ -59,6 +60,10 @@ class RobotModelPinocchio(torch.nn.Module):
             self.ee_link_idx = None
 
     def _get_link_idx_or_use_ee(self, link_name: str) -> int:
+        """
+        Get the link index from the link name, or use the end-effector link index
+        if link_name is None.
+        """
         if not link_name:
             frame_idx = self.ee_link_idx
             assert frame_idx, (

--- a/polymetis/polymetis/python/torchcontrol/models/torchscript_pinocchio.py
+++ b/polymetis/polymetis/python/torchcontrol/models/torchscript_pinocchio.py
@@ -47,6 +47,11 @@ class RobotModelPinocchio(torch.nn.Module):
         self.model = torch.classes.torchscript_pinocchio.RobotModelPinocchio(
             urdf_filename, False
         )
+        self.ee_link_name = None
+        self.ee_link_idx = None
+        self.set_ee_link(ee_link_name)
+
+    def set_ee_link(self, ee_link_name):
         self.ee_link_name = ee_link_name
         if self.ee_link_name is not None:
             self.ee_link_idx = self.model.get_link_idx_from_name(self.ee_link_name)

--- a/polymetis/polymetis/tests/python/polymetis/test_torchscript_pinocchio.py
+++ b/polymetis/polymetis/tests/python/polymetis/test_torchscript_pinocchio.py
@@ -55,6 +55,13 @@ def pinocchio_wrapper(request):
     return toco.models.RobotModelPinocchio(urdf_path, link_name)
 
 
+def test_incorrect_init(pinocchio_wrapper):
+    with pytest.raises(RuntimeError):
+        toco.models.RobotModelPinocchio(urdf_path, "panda_link_nonexistent")
+    with pytest.raises(RuntimeError):
+        pinocchio_wrapper.set_ee_link("panda_link_nonexistent")
+
+
 @pytest.fixture
 def joint_states():
     num_dofs = 7

--- a/polymetis/polymetis/torch_isolation/pinocchio_isolation/include/pinocchio_wrapper.hpp
+++ b/polymetis/polymetis/torch_isolation/pinocchio_isolation/include/pinocchio_wrapper.hpp
@@ -15,8 +15,7 @@ namespace pinocchio_wrapper {
 
 struct State;
 
-C_TORCH_EXPORT struct State *initialize(const char *ee_link_name,
-                                        const char *xml_buffer);
+C_TORCH_EXPORT struct State *initialize(const char *xml_buffer);
 
 C_TORCH_EXPORT void destroy(State *state);
 
@@ -29,22 +28,25 @@ get_velocity_limits(struct State *pinocchio_state);
 C_TORCH_EXPORT int get_nq(struct State *pinocchio_state);
 
 C_TORCH_EXPORT Eigen::VectorXd forward_kinematics(struct State *pinocchio_state,
-                                                  const Eigen::VectorXd &q);
+                                                  const Eigen::VectorXd &q,
+                                                  int64_t frame_idx);
 C_TORCH_EXPORT void
 compute_jacobian(State *state, const Eigen::VectorXd &joint_positions,
                  Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic,
-                                          Eigen::Dynamic, Eigen::RowMajor>> &J);
+                                          Eigen::Dynamic, Eigen::RowMajor>> &J,
+                 int64_t frame_idx);
 C_TORCH_EXPORT Eigen::Matrix<double, Eigen::Dynamic, 1>
 inverse_dynamics(State *state, const Eigen::VectorXd &q,
                  const Eigen::VectorXd &v, const Eigen::VectorXd &a);
 
-C_TORCH_EXPORT void inverse_kinematics(State *state,
-                                       const Eigen::Vector3d &ee_pos_,
-                                       const Eigen::Quaterniond &ee_quat,
-                                       Eigen::VectorXd &rest_pose,
-                                       double eps = 1e-4,
-                                       int64_t max_iters = 1000,
-                                       double dt = 0.1, double damping = 1e-12);
+C_TORCH_EXPORT void
+inverse_kinematics(State *state, const Eigen::Vector3d &link_pos,
+                   const Eigen::Quaterniond &link_quat, int64_t frame_idx,
+                   Eigen::VectorXd &rest_pose, double eps = 1e-4,
+                   int64_t max_iters = 1000, double dt = 0.1,
+                   double damping = 1e-12);
+C_TORCH_EXPORT std::size_t get_link_idx_from_name(State *state,
+                                                  const char *link_name);
 } // namespace pinocchio_wrapper
 
 #ifdef __cplusplus

--- a/polymetis/polymetis/torch_isolation/pinocchio_isolation/include/pinocchio_wrapper.hpp
+++ b/polymetis/polymetis/torch_isolation/pinocchio_isolation/include/pinocchio_wrapper.hpp
@@ -45,8 +45,8 @@ inverse_kinematics(State *state, const Eigen::Vector3d &link_pos,
                    Eigen::VectorXd &rest_pose, double eps = 1e-4,
                    int64_t max_iters = 1000, double dt = 0.1,
                    double damping = 1e-12);
-C_TORCH_EXPORT std::size_t get_link_idx_from_name(State *state,
-                                                  const char *link_name);
+C_TORCH_EXPORT int64_t get_link_idx_from_name(State *state,
+                                              const char *link_name);
 } // namespace pinocchio_wrapper
 
 #ifdef __cplusplus

--- a/polymetis/polymetis/torch_isolation/pinocchio_isolation/src/pinocchio_wrapper.cpp
+++ b/polymetis/polymetis/torch_isolation/pinocchio_isolation/src/pinocchio_wrapper.cpp
@@ -4,6 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 
 #include "spdlog/spdlog.h"
+#include <stdexcept>
 #include <string>
 
 #include "pinocchio/algorithm/frames.hpp"
@@ -156,8 +157,13 @@ void inverse_kinematics(State *state, const Eigen::Vector3d &link_pos,
   }
 }
 
-std::size_t get_link_idx_from_name(State *state, const char *link_name) {
-  return state->model->getBodyId(std::string(link_name));
+int64_t get_link_idx_from_name(State *state, const char *link_name) {
+  std::string link_name_(link_name);
+  int64_t result = state->model->getBodyId(link_name_);
+  if (result == state->model->nframes) {
+    throw std::invalid_argument("Unknown link name " + link_name_);
+  }
+  return result;
 }
 
 } // namespace pinocchio_wrapper

--- a/polymetis/polymetis/torch_isolation/pinocchio_isolation/src/pinocchio_wrapper.cpp
+++ b/polymetis/polymetis/torch_isolation/pinocchio_isolation/src/pinocchio_wrapper.cpp
@@ -23,18 +23,16 @@ namespace pinocchio_wrapper {
 struct State {
   pinocchio::Model *model = nullptr;
   pinocchio::Data *model_data = nullptr;
-  pinocchio::FrameIndex ee_frame_idx;
   Eigen::VectorXd ik_sol_v;
   pinocchio::Data::Matrix6x ik_sol_J;
 };
 
-State *initialize(const char *ee_link_name, const char *xml_buffer) {
+State *initialize(const char *xml_buffer) {
   auto model = new pinocchio::Model();
   pinocchio::urdf::buildModelFromXML(xml_buffer, *model);
   auto model_data = new pinocchio::Data(*model);
 
-  return new State{model, model_data, model->getBodyId(ee_link_name),
-                   Eigen::VectorXd(model->nv),
+  return new State{model, model_data, Eigen::VectorXd(model->nv),
                    pinocchio::Data::Matrix6x(6, model->nv)};
 }
 
@@ -56,16 +54,18 @@ Eigen::VectorXd get_velocity_limits(State *pinocchio_state) {
 int get_nq(State *pinocchio_state) { return pinocchio_state->model->nq; }
 
 Eigen::VectorXd forward_kinematics(State *pinocchio_state,
-                                   const Eigen::VectorXd &q) {
+                                   const Eigen::VectorXd &q,
+                                   int64_t frame_idx) {
+  pinocchio::FrameIndex frame_idx_ =
+      static_cast<pinocchio::FrameIndex>(frame_idx);
   auto model = *pinocchio_state->model;
   auto model_data = *pinocchio_state->model_data;
-  auto ee_frame_idx = pinocchio_state->ee_frame_idx;
 
   pinocchio::forwardKinematics(model, model_data, q);
-  pinocchio::updateFramePlacement(model, model_data, ee_frame_idx);
+  pinocchio::updateFramePlacement(model, model_data, frame_idx_);
 
-  auto pos_data = model_data.oMf[ee_frame_idx].translation().transpose();
-  auto quat_data = Eigen::Quaterniond(model_data.oMf[ee_frame_idx].rotation());
+  auto pos_data = model_data.oMf[frame_idx_].translation().transpose();
+  auto quat_data = Eigen::Quaterniond(model_data.oMf[frame_idx_].rotation());
 
   Eigen::VectorXd result(7);
   for (int i = 0; i < 3; i++) {
@@ -82,12 +82,14 @@ Eigen::VectorXd forward_kinematics(State *pinocchio_state,
 void compute_jacobian(
     State *state, const Eigen::VectorXd &joint_positions,
     Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic,
-                             Eigen::RowMajor>> &J) {
+                             Eigen::RowMajor>> &J,
+    int64_t frame_idx) {
+  pinocchio::FrameIndex frame_idx_ =
+      static_cast<pinocchio::FrameIndex>(frame_idx);
   auto model = *state->model;
   auto model_data = *state->model_data;
-  auto ee_frame_idx = state->ee_frame_idx;
   pinocchio::computeFrameJacobian(model, model_data, joint_positions,
-                                  ee_frame_idx, pinocchio::LOCAL_WORLD_ALIGNED,
+                                  frame_idx_, pinocchio::LOCAL_WORLD_ALIGNED,
                                   J);
 }
 
@@ -96,41 +98,40 @@ inverse_dynamics(State *state, const Eigen::VectorXd &q,
                  const Eigen::VectorXd &v, const Eigen::VectorXd &a) {
   auto model = *state->model;
   auto model_data = *state->model_data;
-  auto ee_frame_idx = state->ee_frame_idx;
   return pinocchio::rnea(model, model_data, q, v, a);
 }
 
-void inverse_kinematics(State *state, const Eigen::Vector3d &ee_pos_,
-                        const Eigen::Quaterniond &ee_quat_,
+void inverse_kinematics(State *state, const Eigen::Vector3d &link_pos,
+                        const Eigen::Quaterniond &link_quat, int64_t frame_idx,
                         Eigen::VectorXd &ik_sol_p_, double eps,
                         int64_t max_iters, double dt, double damping) {
-  auto model_ = *state->model;
-  auto model_data_ = *state->model_data;
-  auto ee_frame_idx_ = state->ee_frame_idx;
-  auto ik_sol_v_ = state->ik_sol_v;
-  auto ik_sol_J_ = state->ik_sol_J;
+  pinocchio::FrameIndex frame_idx_ =
+      static_cast<pinocchio::FrameIndex>(frame_idx);
+  auto model = *state->model;
+  auto model_data = *state->model_data;
+  auto ik_sol_v = state->ik_sol_v;
+  auto ik_sol_J = state->ik_sol_J;
 
-  auto ee_orient_ = ee_quat_.toRotationMatrix();
+  auto link_orient = link_quat.toRotationMatrix();
 
   // Initialize IK variables
-  const pinocchio::SE3 desired_ee(ee_orient_, ee_pos_);
+  const pinocchio::SE3 desired_ee(link_orient, link_pos);
 
-  ik_sol_J_.setZero();
+  ik_sol_J.setZero();
 
   Eigen::Matrix<double, 6, 1> err;
-  ik_sol_v_.setZero();
+  ik_sol_v.setZero();
 
   // Reset robot pose
-  pinocchio::forwardKinematics(model_, model_data_, ik_sol_p_);
-  pinocchio::updateFramePlacement(model_, model_data_, ee_frame_idx_);
+  pinocchio::forwardKinematics(model, model_data, ik_sol_p_);
+  pinocchio::updateFramePlacement(model, model_data, frame_idx_);
 
   // Solve IK iteratively
   for (int i = 0; i < max_iters; i++) {
     // Compute forward kinematics error
-    pinocchio::forwardKinematics(model_, model_data_, ik_sol_p_);
-    pinocchio::updateFramePlacement(model_, model_data_, ee_frame_idx_);
-    const pinocchio::SE3 dMf =
-        desired_ee.actInv(model_data_.oMf[ee_frame_idx_]);
+    pinocchio::forwardKinematics(model, model_data, ik_sol_p_);
+    pinocchio::updateFramePlacement(model, model_data, frame_idx_);
+    const pinocchio::SE3 dMf = desired_ee.actInv(model_data.oMf[frame_idx_]);
     err = pinocchio::log6(dMf).toVector();
 
     // Check termination
@@ -140,19 +141,23 @@ void inverse_kinematics(State *state, const Eigen::Vector3d &ee_pos_,
     }
 
     // Descent solution
-    pinocchio::computeFrameJacobian(model_, model_data_, ik_sol_p_,
-                                    ee_frame_idx_, pinocchio::LOCAL, ik_sol_J_);
+    pinocchio::computeFrameJacobian(model, model_data, ik_sol_p_, frame_idx_,
+                                    pinocchio::LOCAL, ik_sol_J);
 
     pinocchio::Data::Matrix6 JJt;
-    JJt.noalias() = ik_sol_J_ * ik_sol_J_.transpose();
+    JJt.noalias() = ik_sol_J * ik_sol_J.transpose();
     JJt.diagonal().array() += damping;
-    ik_sol_v_.noalias() = -ik_sol_J_.transpose() * JJt.ldlt().solve(err);
-    ik_sol_p_ = pinocchio::integrate(model_, ik_sol_p_, ik_sol_v_ * dt);
+    ik_sol_v.noalias() = -ik_sol_J.transpose() * JJt.ldlt().solve(err);
+    ik_sol_p_ = pinocchio::integrate(model, ik_sol_p_, ik_sol_v * dt);
   }
 
   if (err.norm() >= eps) {
     spdlog::warn("WARNING: IK did not converge!");
   }
+}
+
+std::size_t get_link_idx_from_name(State *state, const char *link_name) {
+  return state->model->getBodyId(std::string(link_name));
 }
 
 } // namespace pinocchio_wrapper


### PR DESCRIPTION
# Description

RobotModelPinocchio should not assume that a single end-effector exists. Changes:

- Refactor `pinocchio_wrapper.cpp`, `pinocchio.cpp` to specify frame index for methods `forward_kinematics`, `compute_jacobian`, `inverse_kinematics`
- Refactor torchscript_pinocchio.py to reflect these changes, including defaulting to end effector (if specified)
  - Add documentation explaining default values
- Remove unnecessary end-effector fields from `allegro_hand.yaml` and RobotClientMetadata initialization

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [x] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

If this PR introduces a change or fixes a bug, please add before and after screenshots (if this is causes a UX change) or before and after examples(this could be plain text, videos etc ) to demonstrate the change.

If this PR introduces a new feature, please also add examples or screenshots demonstrating the feature.

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [x] I have added Docstrings and comments to the code.
- [x] I have made changes to existing documentation where needed.
- [x] I have added tests that show that the PR is functional.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
