### PR TITLE
[fbrp] 0.1.5

### DIFF
--- a/fbrp/setup.py
+++ b/fbrp/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="fbrp",
-    version="0.1.4",
+    version="0.1.5",
     author="Leonid Shamis",
     package_dir={"": "src"},
     packages=find_packages(

--- a/fbrp/src/fbrp/cmd/up.py
+++ b/fbrp/src/fbrp/cmd/up.py
@@ -10,6 +10,7 @@ import json
 import os
 import sys
 import threading
+import traceback
 import types
 import typing
 
@@ -162,5 +163,6 @@ def cli(
                             )
                         except BaseException as e:
                             click.echo(f"FATAL: {e}")
+                            traceback.print_exc()
                         life_cycle.set_launcher_running(name, False)
                         sys.exit(0)

--- a/fbrp/src/fbrp/tool/__init__.py
+++ b/fbrp/src/fbrp/tool/__init__.py
@@ -19,6 +19,7 @@ def main():
         return
 
     # Run the entrypoint file.
+    sys.path.append(os.path.dirname(fsetup_path))
     SourceFileLoader("fsetup", fsetup_path).load_module()
 
 


### PR DESCRIPTION
# Description

FBRP bumping version for next pypi release.

Sneaking in two minor updates:
* fsetup.py import syntax should be identical between `python fsetup.py` and `fbrp`. Python thought it was a good idea to handle imports differently for script vs module mode: https://stackoverflow.com/questions/14132789/relative-imports-for-the-billionth-time
  * Added the directory containing `fsetup.py` as the module root. Should I add/set the cwd?
* Dump stack-trace to `/tmp/fbrp_{name}.log` if the launcher dies. The launcher will currently die if the `run_command` contains non-string elements. I need to fix this, but it was a pain to track down with just the error message and no trace.

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

See above.

# Testing

Manual testing.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
