### PR TITLE
Use num_mobs from config

### DIFF
--- a/droidlet/lowlevel/minecraft/small_scenes_with_shapes.py
+++ b/droidlet/lowlevel/minecraft/small_scenes_with_shapes.py
@@ -74,6 +74,7 @@ def parse_and_execute_mob_config(args):
     elif c.get("mob_generator"):
         return c["mob_generator"](args)
     elif c.get("num_mobs"):
+        num_mobs = c.get("num_mobs")
         if not c["mob_probs"]:
             md = [("rabbit", "cow", "pig", "chicken", "sheep"), (1.0, 1.0, 1.0, 1.0, 1.0)]
         else:
@@ -81,7 +82,7 @@ def parse_and_execute_mob_config(args):
         probs = np.array(md[1])
         assert probs.min() >= 0.0
         probs = probs / probs.sum()
-        mobnames = np.random.choice(md[0], size=2, p=probs).tolist()
+        mobnames = np.random.choice(md[0], size=num_mobs, p=probs).tolist()
         mobs = []
         for m in mobnames:
             # mob pose set in collect_scene for now if not specified


### PR DESCRIPTION
Previously, we were always using 2 mobs. This allows us to use the num_mobs variable from the config.

# Description

Please include a summary of the change and link to an issue this PR fixes. Please also include relevant context. List any downstream components that might be affected by this change.

Fixes # (issue)

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Previously we were using a hard-coded 2 mobs in every sample. This allows us to use the num_mobs from the config.

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
