### PR TITLE
[mrp] bug fix conda defer env name

### DIFF
--- a/mrp/setup.py
+++ b/mrp/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="mrp",
-    version="0.1.5",
+    version="0.1.6",
     author="Leonid Shamis",
     package_dir={"": "src"},
     packages=find_packages(

--- a/mrp/src/mrp/runtime/conda.py
+++ b/mrp/src/mrp/runtime/conda.py
@@ -445,6 +445,8 @@ class Conda(BaseRuntime):
                 raise RuntimeError(f"Failed to set up conda env: {result.stderr}")
 
     def _launcher(self, name: str, proc_def: ProcDef):
+        if self._env.name == "__defer__":
+            self._env.name = name
         return Launcher(self.run_command, name, self._env._env_name(), proc_def)
 
 


### PR DESCRIPTION
# Description

Fix a bug in the conda runtime where the env name isn't populated if build is bypassed

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

# Testing

`mrp up --nobuild` in the examples

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
