### PR TITLE
[hello-realsense] fix clipping bug that incorrectly clipped points too much

### DIFF
--- a/droidlet/lowlevel/hello_robot/remote/remote_hello_realsense.py
+++ b/droidlet/lowlevel/hello_robot/remote/remote_hello_realsense.py
@@ -195,8 +195,8 @@ class RemoteHelloRealsense(object):
     def get_pcd_data(self, rotate=True):
         """Gets all the data to calculate the point cloud for a given rgb, depth frame."""
         rgb, depth = self.get_rgb_depth(rotate=rotate, compressed=True)
-        # cap anything more than np.power(2,9)~ 64 meter
-        depth[depth > np.power(2, 9) - 1] = np.power(2, 9) - 1
+        # cap anything more than np.power(2,16)~ 64 meter
+        depth[depth > np.power(2, 16) - 1] = np.power(2, 16) - 1
         T = self.get_camera_transform()
         rot = T[:3, :3]
         trans = T[:3, 3]


### PR DESCRIPTION
This was a dumb bug from the previous giant PR that clipped points on the hello backend to 512mm and produced incorrect results.

After the fix, point-cloud is correct again:

<img width="654" alt="Screen Shot 2022-03-28 at 4 46 19 PM" src="https://user-images.githubusercontent.com/1310570/160484169-d94ca792-717b-4426-b9f6-968e8f81a273.png">

