### PR TITLE
[mrp] setup_commands part of env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,7 +358,7 @@ jobs:
           command: python3 -m pip install ./mrp
       - run:
           name: Run PyTest
-          command: pytest ./mrp
+          command: pytest -s -vvv ./mrp
   update-docs:
     docker:
       - image: cimg/node:current

--- a/mrp/setup.py
+++ b/mrp/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="mrp",
-    version="0.1.6",
+    version="0.1.7",
     author="Leonid Shamis",
     package_dir={"": "src"},
     packages=find_packages(

--- a/mrp/tests/runtime/test_conda_build.py
+++ b/mrp/tests/runtime/test_conda_build.py
@@ -1,6 +1,22 @@
 import a0
 import mrp
 import mrp.process_def
+import os
+import shutil
+import subprocess
+
+
+def clear_process_list():
+    mrp.process_def.defined_processes.clear()
+
+
+def reset_state(*procs):
+    clear_process_list()
+    for proc in procs:
+        shutil.rmtree(
+            os.path.expanduser(f"~/.config/mrp/conda/mrp_{proc}"), ignore_errors=True
+        )
+
 
 def read_logs(topic):
     output = []
@@ -12,9 +28,8 @@ def read_logs(topic):
     return output
 
 
-def test_conda_build():
-    # Reset defined processes.
-    mrp.process_def.defined_processes.clear()
+def test_conda_nobuild():
+    reset_state("proc")
 
     # Define process to run Python 3.7.11
     mrp.process(
@@ -31,10 +46,8 @@ def test_conda_build():
 
     assert read_logs("proc") == ["Python 3.7.11\n"]
 
-    # Reset defined processes.
-    mrp.process_def.defined_processes.clear()
-
     # Define process to run Python 3.8.8
+    clear_process_list()
     mrp.process(
         name="proc",
         runtime=mrp.Conda(
@@ -50,7 +63,135 @@ def test_conda_build():
     assert read_logs("proc") == ["Python 3.7.11\n"]
 
     # Run the proc with building.
+    clear_process_list()
+    mrp.process(
+        name="proc",
+        runtime=mrp.Conda(
+            dependencies=["python=3.8.8"],
+            run_command=["python", "--version"],
+        ),
+    )
+
     mrp.cmd.up("proc", reset_logs=True)
     mrp.cmd.wait("proc")
 
     assert read_logs("proc") == ["Python 3.8.8\n"]
+
+
+def test_conda_build_cache():
+    reset_state("proc")
+
+    test_counter_path = "/tmp/test_counter"
+    test_counter_increment_command = [
+        "bash",
+        "-c",
+        'bc <<< "1 + $(</tmp/test_counter)" > /tmp/test_counter',
+    ]
+    open(test_counter_path, "w").write("0")
+
+    mrp.process(
+        name="proc",
+        runtime=mrp.Conda(
+            dependencies=["python=3.7.11"],
+            setup_commands=[test_counter_increment_command],
+            run_command=[],
+        ),
+    )
+
+    # Run the proc and wait for it to complete.
+    mrp.cmd.up("proc", reset_logs=True)
+    mrp.cmd.wait("proc")
+
+    # The setup should have run and incremented the counter.
+    assert open(test_counter_path).read() == "1\n"
+
+    # Run the proc again with no changes.
+    mrp.cmd.up("proc", reset_logs=True)
+    mrp.cmd.wait("proc")
+
+    # The setup should NOT have run and the counter should be unchanged.
+    assert open(test_counter_path).read() == "1\n"
+
+    # Defining the same process shouldn't change anything.
+    clear_process_list()
+    mrp.process(
+        name="proc",
+        runtime=mrp.Conda(
+            dependencies=["python=3.7.11"],
+            setup_commands=[test_counter_increment_command],
+            run_command=[],
+        ),
+    )
+    mrp.cmd.up("proc", reset_logs=True)
+    mrp.cmd.wait("proc")
+
+    # The setup should NOT have run and the counter should be unchanged.
+    assert open(test_counter_path).read() == "1\n"
+
+    # Changing the dependencies should cause a rebuild.
+    clear_process_list()
+    mrp.process(
+        name="proc",
+        runtime=mrp.Conda(
+            dependencies=["python=3.8.8"],
+            setup_commands=[test_counter_increment_command],
+            run_command=[],
+        ),
+    )
+    mrp.cmd.up("proc", reset_logs=True)
+    mrp.cmd.wait("proc")
+
+    # The setup should have run and the counter should be incremented.
+    assert open(test_counter_path).read() == "2\n"
+
+    clear_process_list()
+
+    # Changing the setup command should cause a rebuild.
+    mrp.process(
+        name="proc",
+        runtime=mrp.Conda(
+            dependencies=["python=3.8.8"],
+            setup_commands=[["echo", "0"], test_counter_increment_command],
+            run_command=[],
+        ),
+    )
+    mrp.cmd.up("proc", reset_logs=True)
+    mrp.cmd.wait("proc")
+
+    # The setup should have run and the counter should be incremented.
+    assert open(test_counter_path).read() == "3\n"
+
+    # Remake with identical setup.
+    clear_process_list()
+    mrp.process(
+        name="proc",
+        runtime=mrp.Conda(
+            dependencies=["python=3.8.8"],
+            setup_commands=[["echo", "0"], test_counter_increment_command],
+            run_command=[],
+        ),
+    )
+    mrp.cmd.up("proc", reset_logs=True)
+    mrp.cmd.wait("proc")
+
+    # The setup should NOT have run and the counter should be incremented.
+    assert open(test_counter_path).read() == "3\n"
+
+    # Update the conda history, poisoning the cache.
+    subprocess.run(["conda", "install", "-n", "mrp_proc", "-y", "pycparser"])
+
+    # Catch that the conda env has been updated.
+    clear_process_list()
+    mrp.process(
+        name="proc",
+        runtime=mrp.Conda(
+            dependencies=["python=3.8.8"],
+            setup_commands=[["echo", "0"], test_counter_increment_command],
+            run_command=[],
+        ),
+    )
+    mrp.cmd.up("proc", reset_logs=True)
+    mrp.cmd.wait("proc")
+
+    # The setup should have run and the counter should be incremented.
+    assert open(test_counter_path).read() == "4\n"


### PR DESCRIPTION
# Description

Moves `setup_commands` from being per-process to being per-environment.

Update cache to check:
1) Changes to conda env definition.
1) Changes to setup commands.
1) Changes to conda command history.

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [x] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Before, setup commands would run even if there was a cache hit.
After, setup commands run only if there is a cache miss.

# Testing

New integration tests.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [x] I have added tests that show that the PR is functional.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
