### PR TITLE
Use RPLidar for obstacle detection

### DIFF
--- a/droidlet/lowlevel/hello_robot/remote/lidar.py
+++ b/droidlet/lowlevel/hello_robot/remote/lidar.py
@@ -1,0 +1,35 @@
+from rplidar import RPLidar
+import sys
+import threading
+import time
+import traceback
+
+
+class Lidar:
+    def __init__(self):
+        self._lidar = RPLidar('/dev/hello-lrf')
+        self._lock = threading.Lock()
+        self._thread = None
+        self.latest_scan = None
+
+    def start(self):
+        self._thread = threading.Thread(target=self.lidar_loop, daemon=True)
+        self._thread.start()
+
+    def get_latest_scan(self):
+        with self._lock:
+            return self.latest_scan
+
+    def lidar_loop(self):
+        while True:
+            try:
+                for scan in self._lidar.iter_scans():
+                    timestamp = time.time()
+                    with self._lock:
+                        self.latest_scan = (timestamp, scan)
+            except:
+                traceback.print_exc()
+                self._lidar.stop()
+                self._lidar.stop_motor()
+                # just keep going
+

--- a/droidlet/lowlevel/hello_robot/remote/obstacle_utils.py
+++ b/droidlet/lowlevel/hello_robot/remote/obstacle_utils.py
@@ -1,6 +1,7 @@
 import open3d as o3d
 import numpy as np
 import copy
+import time
 import warnings
 
 
@@ -57,6 +58,7 @@ def get_ground_plane(
 def is_obstacle(
     pcd,
     base_pos,
+    lidar=None,
     pix_threshold=100,
     min_dist=0.3,
     max_dist=1.0,
@@ -66,6 +68,7 @@ def is_obstacle(
     return_viz=False,
 ):
     # print("num points", np.asarray(pcd.points).shape)
+    rest = None
     crop, bbox = get_points_in_front(pcd, base_pos, min_dist, max_dist, robot_width, height)
     # print("num cropped", np.asarray(crop.points).shape)
     num_cropped_points = np.asarray(crop.points).shape[0]
@@ -79,12 +82,44 @@ def is_obstacle(
         raise RuntimeError("Not Implemented")
     elif num_cropped_points >= pix_threshold:
         rest = get_ground_plane(crop, return_ground=False)
-        obstacle = np.asarray(rest.points).shape[0] > 100
+        if np.asarray(rest.points).shape[0] > 100:
+            obstacle = True
+
+    if lidar is not None:
+        if is_lidar_obstacle(lidar):
+            obstacle = True
+
     if return_viz:
         return obstacle, pcd, crop, bbox, rest
     else:
         return obstacle
 
+def is_lidar_obstacle(lidar_scan, bbox=(0.0, 0.5, -0.25, 0.25), min_quality=0):
+    # bbox specifies coordinates of rectangle (xmin, xmax, ymin, ymax) centered
+    # at lidar. Any points within this box are considered an obstacle.
+    # Note that positive x is the front of the robot.
+    timestamp, scan = lidar_scan
+
+    age = time.time() - timestamp  # in seconds
+    if age > 1.0:
+        warnings.warn(f"[is_lidar_obstacle] lidar scan is {age:.2f} seconds old")
+        return False
+
+    xmin, xmax, ymin, ymax = bbox
+    scan = np.asarray(scan)
+
+    # filter on quality
+    scan = scan[scan[:, 0] >= min_quality]
+
+    # convert degrees to radians and mm to meters
+    rads = np.radians(scan[:, 1])
+    dist = scan[:, 2] / 1000.0
+
+    xs = np.cos(rads) * dist
+    ys = np.sin(rads) * dist
+
+    in_bounds = (xs >= xmin) & (xs <= xmax) & (ys >= ymin) & (ys <= ymax)
+    return in_bounds.any()
 
 def get_o3d_pointcloud(points, colors):
     points, colors = points.reshape(-1, 3), colors.reshape(-1, 3)

--- a/droidlet/lowlevel/hello_robot/remote/obstacle_utils.py
+++ b/droidlet/lowlevel/hello_robot/remote/obstacle_utils.py
@@ -58,7 +58,7 @@ def get_ground_plane(
 def is_obstacle(
     pcd,
     base_pos,
-    lidar=None,
+    lidar_scan=None,
     pix_threshold=100,
     min_dist=0.3,
     max_dist=1.0,
@@ -85,8 +85,8 @@ def is_obstacle(
         if np.asarray(rest.points).shape[0] > 100:
             obstacle = True
 
-    if lidar is not None:
-        if is_lidar_obstacle(lidar):
+    if lidar_scan is not None:
+        if is_lidar_obstacle(lidar_scan):
             obstacle = True
 
     if return_viz:
@@ -108,7 +108,7 @@ def is_lidar_obstacle(lidar_scan, bbox=(0.0, 0.5, -0.25, 0.25), min_quality=0):
     xmin, xmax, ymin, ymax = bbox
     scan = np.asarray(scan)
 
-    # filter on quality
+    # filter on quality (reflected laser strength, range 0-15).
     scan = scan[scan[:, 0] >= min_quality]
 
     # convert degrees to radians and mm to meters

--- a/droidlet/lowlevel/hello_robot/remote/remote_hello_realsense.py
+++ b/droidlet/lowlevel/hello_robot/remote/remote_hello_realsense.py
@@ -16,7 +16,9 @@ import numpy as np
 import cv2
 import open3d as o3d
 from droidlet.lowlevel.hello_robot.remote.utils import transform_global_to_base, goto
+from droidlet.lowlevel.hello_robot.remote.lidar import Lidar
 from slam_pkg.utils import depth_util as du
+import obstacle_utils
 from obstacle_utils import is_obstacle
 from droidlet.dashboard.o3dviz import serialize as o3d_pickle
 from data_compression import *
@@ -40,6 +42,8 @@ class RemoteHelloRealsense(object):
 
     def __init__(self, bot):
         self.bot = bot
+        self._lidar = Lidar()
+        self._lidar.start()
         self._done = True
         self._connect_to_realsense()
         # Slam stuff
@@ -57,6 +61,17 @@ class RemoteHelloRealsense(object):
 
     def get_camera_transform(self):
         return self.bot.get_camera_transform()
+
+    def get_lidar_scan(self):
+        # returns tuple (timestamp, scan)
+        return self._lidar.get_latest_scan()
+
+    def is_lidar_obstacle(self):
+        lidar_scan = self._lidar.get_latest_scan()
+        if lidar_scan is None:
+            print("no scan")
+            return False
+        return obstacle_utils.is_lidar_obstacle(lidar_scan)
 
     def _connect_to_realsense(self):
         config = rs.config()
@@ -178,9 +193,9 @@ class RemoteHelloRealsense(object):
 
     def is_obstacle_in_front(self, return_viz=False):
         base_state = self.bot.get_base_state()
-        lidar_scan = self.bot.get_latest_lidar_scan()
+        lidar_scan = self.get_lidar_scan()
         pcd = self.get_open3d_pcd()
-        ret = is_obstacle(pcd, base_state, lidar=lidar_scan, max_dist=0.5, return_viz=return_viz)
+        ret = is_obstacle(pcd, base_state, lidar_scan=lidar_scan, max_dist=0.5, return_viz=return_viz)
         if return_viz:
             obstacle, cpcd, crop, bbox, rest = ret
             # cpcd = o3d_pickle(cpcd)

--- a/droidlet/lowlevel/hello_robot/remote/remote_hello_realsense.py
+++ b/droidlet/lowlevel/hello_robot/remote/remote_hello_realsense.py
@@ -178,8 +178,9 @@ class RemoteHelloRealsense(object):
 
     def is_obstacle_in_front(self, return_viz=False):
         base_state = self.bot.get_base_state()
+        lidar_scan = self.bot.get_latest_lidar_scan()
         pcd = self.get_open3d_pcd()
-        ret = is_obstacle(pcd, base_state, max_dist=0.5, return_viz=return_viz)
+        ret = is_obstacle(pcd, base_state, lidar=lidar_scan, max_dist=0.5, return_viz=return_viz)
         if return_viz:
             obstacle, cpcd, crop, bbox, rest = ret
             # cpcd = o3d_pickle(cpcd)

--- a/droidlet/lowlevel/hello_robot/remote/remote_hello_robot.py
+++ b/droidlet/lowlevel/hello_robot/remote/remote_hello_robot.py
@@ -13,7 +13,6 @@ from math import *
 import Pyro4
 from stretch_body.robot import Robot
 from colorama import Fore, Back, Style
-from droidlet.lowlevel.hello_robot.remote.lidar import Lidar
 import stretch_body.hello_utils as hu
 
 hu.print_stretch_re_use()
@@ -59,13 +58,11 @@ class RemoteHelloRobot(object):
         if not self._robot.is_calibrated():
             self._robot.home()
         self._robot.stow()
-        self._lidar = Lidar()
         self._done = True
         self.cam = None
         # Read battery maintenance guide https://docs.hello-robot.com/battery_maintenance_guide/
         self._check_battery()
         self._load_urdf()
-        self._lidar.start()
 
     def _check_battery(self):
         p = self._robot.pimu
@@ -113,17 +110,6 @@ class RemoteHelloRobot(object):
     def get_base_state(self):
         s = self._robot.get_status()
         return (s["base"]["x"], s["base"]["y"], s["base"]["theta"])
-
-    def get_latest_lidar_scan(self):
-        return self._lidar.get_latest_scan()
-
-    def is_lidar_obstacle(self):
-        from obstacle_utils import is_lidar_obstacle
-        lidar_scan = self._lidar.get_latest_scan()
-        if lidar_scan is None:
-            print("no scan")
-            return False
-        return is_lidar_obstacle(lidar_scan)
 
     def get_pan(self):
         s = self._robot.get_status()

--- a/droidlet/lowlevel/hello_robot/remote/remote_hello_robot.py
+++ b/droidlet/lowlevel/hello_robot/remote/remote_hello_robot.py
@@ -13,6 +13,7 @@ from math import *
 import Pyro4
 from stretch_body.robot import Robot
 from colorama import Fore, Back, Style
+from droidlet.lowlevel.hello_robot.remote.lidar import Lidar
 import stretch_body.hello_utils as hu
 
 hu.print_stretch_re_use()
@@ -58,11 +59,13 @@ class RemoteHelloRobot(object):
         if not self._robot.is_calibrated():
             self._robot.home()
         self._robot.stow()
+        self._lidar = Lidar()
         self._done = True
         self.cam = None
         # Read battery maintenance guide https://docs.hello-robot.com/battery_maintenance_guide/
         self._check_battery()
         self._load_urdf()
+        self._lidar.start()
 
     def _check_battery(self):
         p = self._robot.pimu
@@ -110,6 +113,17 @@ class RemoteHelloRobot(object):
     def get_base_state(self):
         s = self._robot.get_status()
         return (s["base"]["x"], s["base"]["y"], s["base"]["theta"])
+
+    def get_latest_lidar_scan(self):
+        return self._lidar.get_latest_scan()
+
+    def is_lidar_obstacle(self):
+        from obstacle_utils import is_lidar_obstacle
+        lidar_scan = self._lidar.get_latest_scan()
+        if lidar_scan is None:
+            print("no scan")
+            return False
+        return is_lidar_obstacle(lidar_scan)
 
     def get_pan(self):
         s = self._robot.get_status()


### PR DESCRIPTION
# Description

The Lidar class uses a thread to constantly read the RPLidar returns
and keep track of the latest scan. I expect this class to change as we
use the lidar for more purposes.

Objects in the area up to 0.5m in front and 0.25m on either side of the
lidar are considered obstacles.

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

# Testing

Manual testing of "is_lidar_obstacle()" with object in front and to the side of the robot. Manual testing of "robot.go_to_relative()" with obstacle ~1 meter in front. (Robot properly approaches obstacle and stops.)

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
