### PR TITLE
rename VOXEL_OBJECT as _VOXEL_OBJECT

### DIFF
--- a/droidlet/interpreter/craftassist/mc_interpreter.py
+++ b/droidlet/interpreter/craftassist/mc_interpreter.py
@@ -114,7 +114,7 @@ class MCInterpreter(Interpreter):
         ref_d = d.get("reference_object", default_ref_d)
         # only modify blockobjects...
         objs = self.subinterpret["reference_objects"](
-            self, speaker, ref_d, extra_tags=["_physical_object", "VOXEL_OBJECT"]
+            self, speaker, ref_d, extra_tags=["_physical_object", "_VOXEL_OBJECT"]
         )
         if len(objs) == 0:
             raise ErrorWithResponse("I don't understand what you want me to modify.")
@@ -242,7 +242,7 @@ class MCInterpreter(Interpreter):
                 self,
                 speaker,
                 md["reference_object"],
-                extra_tags=["VOXEL_OBJECT"],
+                extra_tags=["_VOXEL_OBJECT"],
                 loose_speakerlook=True,
             )
             if len(objs) == 0:

--- a/droidlet/interpreter/tests/all_test_commands.py
+++ b/droidlet/interpreter/tests/all_test_commands.py
@@ -141,14 +141,14 @@ FILTERS["the first thing that was built"] = {
         "ordinal": "FIRST",
         "return_quantity": {"argval": {"polarity": "MIN", "quantity": ATTRIBUTES["create time"]}},
     },
-    "where_clause": {"AND": [{"pred_text": "has_tag", "obj_text": "VOXEL_OBJECT"}]},
+    "where_clause": {"AND": [{"pred_text": "has_tag", "obj_text": "_VOXEL_OBJECT"}]},
 }
 FILTERS["the last thing that was built"] = {
     "selector": {
         "ordinal": "FIRST",
         "return_quantity": {"argval": {"polarity": "MAX", "quantity": ATTRIBUTES["create time"]}},
     },
-    "where_clause": {"AND": [{"pred_text": "has_tag", "obj_text": "VOXEL_OBJECT"}]},
+    "where_clause": {"AND": [{"pred_text": "has_tag", "obj_text": "_VOXEL_OBJECT"}]},
 }
 FILTERS["number of blocks in the first thing built"] = {
     "output": {"attribute": ATTRIBUTES["number of blocks"]},
@@ -156,7 +156,7 @@ FILTERS["number of blocks in the first thing built"] = {
         "ordinal": "FIRST",
         "return_quantity": {"argval": {"polarity": "MIN", "quantity": ATTRIBUTES["create time"]}},
     },
-    "where_clause": {"AND": [{"pred_text": "has_tag", "obj_text": "VOXEL_OBJECT"}]},
+    "where_clause": {"AND": [{"pred_text": "has_tag", "obj_text": "_VOXEL_OBJECT"}]},
 }
 FILTERS["number of blocks in the second thing built"] = {
     "output": {"attribute": ATTRIBUTES["number of blocks"]},
@@ -164,7 +164,7 @@ FILTERS["number of blocks in the second thing built"] = {
         "ordinal": "SECOND",
         "return_quantity": {"argval": {"polarity": "MIN", "quantity": ATTRIBUTES["create time"]}},
     },
-    "where_clause": {"AND": [{"pred_text": "has_tag", "obj_text": "VOXEL_OBJECT"}]},
+    "where_clause": {"AND": [{"pred_text": "has_tag", "obj_text": "_VOXEL_OBJECT"}]},
 }
 FILTERS["number of blocks in the last thing built"] = {
     "output": {"attribute": ATTRIBUTES["number of blocks"]},
@@ -172,7 +172,7 @@ FILTERS["number of blocks in the last thing built"] = {
         "ordinal": "FIRST",
         "return_quantity": {"argval": {"polarity": "MAX", "quantity": ATTRIBUTES["create time"]}},
     },
-    "where_clause": {"AND": [{"pred_text": "has_tag", "obj_text": "VOXEL_OBJECT"}]},
+    "where_clause": {"AND": [{"pred_text": "has_tag", "obj_text": "_VOXEL_OBJECT"}]},
 }
 
 

--- a/droidlet/memory/craftassist/mc_memory_nodes.py
+++ b/droidlet/memory/craftassist/mc_memory_nodes.py
@@ -167,7 +167,7 @@ class BlockObjectNode(VoxelObjectNode):
         for block in blocks:
             memory.upsert_block(block, memid, "BlockObjects")
         memory.tag(memid, "_block_object")
-        memory.tag(memid, "VOXEL_OBJECT")
+        memory.tag(memid, "_VOXEL_OBJECT")
         memory.tag(memid, "_physical_object")
         memory.tag(memid, "_destructible")
         # this is a hack until memory_filters does "not"
@@ -253,7 +253,7 @@ class InstSegNode(VoxelObjectNode):
         for loc in locs:
             cmd = "INSERT INTO VoxelObjects (uuid, x, y, z, ref_type) VALUES ( ?, ?, ?, ?, ?)"
             memory.db_write(cmd, memid, loc[0], loc[1], loc[2], "inst_seg")
-        memory.tag(memid, "VOXEL_OBJECT")
+        memory.tag(memid, "_VOXEL_OBJECT")
         memory.tag(memid, "_inst_seg")
         memory.tag(memid, "_destructible")
         # this is a hack until memory_filters does "not"


### PR DESCRIPTION
# Description

Renames VOXEL_OBJECT as _VOXEL_OBJECT

Tags starting with and underscore are non-queriable, and we don't want to query VOXEL_OBJECTs (for now).

Fixes # (issue)

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

If this PR introduces a change or fixes a bug, please add before and after screenshots (if this is causes a UX change) or before and after examples(this could be plain text, videos etc ) to demonstrate the change.

If this PR introduces a new feature, please also add examples or screenshots demonstrating the feature.

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
