### PR TITLE
mrp support py37

### DIFF
--- a/mrp/examples/01_basic/proc.py
+++ b/mrp/examples/01_basic/proc.py
@@ -2,6 +2,6 @@ import time
 
 i = 0
 while True:
-    print(f"{i=}")
+    print(f"i={i}")
     i += 1
     time.sleep(1)

--- a/mrp/src/mrp/process_def.py
+++ b/mrp/src/mrp/process_def.py
@@ -40,7 +40,7 @@ def process(
     env: dict = {},
 ) -> ProcDef:
     if name in defined_processes:
-        raise ValueError(f"mrp.process({name=}) defined multiple times.")
+        raise ValueError(f"mrp.process(name={name}) defined multiple times.")
 
     rule_file = os.path.abspath(inspect.stack()[1].filename)
     rule_dir = os.path.dirname(rule_file)
@@ -54,7 +54,7 @@ def process(
     for k, v in env.items():
         if [type(k), type(v)] != [str, str]:
             raise ValueError(
-                f"mrp process [{name}] invalid. env is not dict[str, str]"
+                f"mrp.process(name={name}) invalid. env is not dict[str, str]"
             )
 
     defined_processes[name] = ProcDef(

--- a/mrp/tests/test_process_def.py
+++ b/mrp/tests/test_process_def.py
@@ -6,4 +6,4 @@ def test_invalid_env():
     with pytest.raises(ValueError) as err:
         process_def.process("foo", env={1: 2})
     assert err.type == ValueError
-    assert str(err.value) == "mrp process [foo] invalid. env is not dict[str, str]"
+    assert str(err.value) == "mrp.process(name=foo) invalid. env is not dict[str, str]"


### PR DESCRIPTION
# Description

Remove features from MRP that do not support py37

[Fixes #1058](https://github.com/facebookresearch/fairo/issues/1058)

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Previously, MRP only worked in environments with py38+
The minimum requirement has been reduced to py37+

# Testing

Created a conda env with py37. Confirmed mrp fails without these changes. Rebuilt with these changes. Ran through all examples.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
