### PR TITLE
New Agent Chat Schema

### DIFF
--- a/agents/craftassist/craftassist_agent.py
+++ b/agents/craftassist/craftassist_agent.py
@@ -8,8 +8,11 @@ import signal
 import random
 import sentry_sdk
 import time
+import json
 from multiprocessing import set_start_method
 from collections import namedtuple
+from datetime import datetime
+from copy import deepcopy
 
 # `from craftassist.agent` instead of `from .` because this file is
 # also used as a standalone script and invoked via `python craftassist_agent.py`
@@ -342,12 +345,28 @@ class CraftAssistAgent(DroidletAgent):
         new_pitch = self.get_player().look.pitch - angle
         self.set_look(self.get_player().look.yaw, new_pitch)
 
-    def send_chat(self, chat):
+    def send_chat(self, chat: str):
         """Send chat from agent to player"""
-        logging.info("Sending chat: {}".format(chat))
-        sio.emit("showAssistantReply", {"agent_reply": "Agent: {}".format(chat)})
-        self.memory.add_chat(self.memory.self_memid, chat)
-        return self.cagent.send_chat(chat)
+
+        chat_json = False
+        try:
+            chat_json = json.loads(chat)
+            chat_text = list(filter(lambda x: x["id"] == "text", chat_json["content"]))[0]["content"]
+        except:
+            chat_text = chat
+
+        logging.info("Sending chat: {}".format(chat_text))
+        chat_memid = self.memory.add_chat(self.memory.self_memid, chat_text)
+
+        if chat_json:
+            chat_json["chat_memid"] = chat_memid
+            chat_json["timestamp"] = round(datetime.timestamp(datetime.now())*1000)
+            # Send the socket event to show this reply on dashboard
+            sio.emit("showAssistantReply", chat_json)
+        else:
+            sio.emit("showAssistantReply", {"agent_reply": "Agent: {}".format(chat_text)})
+
+        return self.cagent.send_chat(chat_text)
 
     def update_agent_pos_dashboard(self):
         agent_pos = self.get_player().pos

--- a/droidlet/dialog/chat_schema.md
+++ b/droidlet/dialog/chat_schema.md
@@ -1,0 +1,71 @@
+## Description ##
+This is the source of truth for the most updated version of the schema to be followed when sending chats from the agent the the user (and perhaps eventually from the agent to other agents).  When updating this document please increment the version number.  Older versions of the schema can be found in git history.
+
+Note that chats sent from the user to the agent should always be in plaintext, as all messages should be parsed by the NSP and interpreted.  I.e. special pathways and conditionals on agent input are discouraged.  It is possible to help the NSP by including special tokens that are reserved for specific use cases, eg. clarification response.
+
+### Content Types ###
+ - `chat_string`: Only text to display in the chat window with no response assumed.
+    - Example: "I finished building this!"
+ - `chat_and_media`: Text and media to display in the chat window, with no response assumed.
+    - Example: "I finished building this!" (with accompanying photo)
+ - `chat_and_text_options`: Text to display in the chat window along with a list of possible response options.
+    - Example: "Are these the Droidlets you are looking for?" ('no', 'no')
+ - `chat_and_media_options`: Text to display in the chat window along with a list of clickable media options.
+    - Example: "Which of these is the 'blue sphere' you were referring to?" (pictures of blue spheres)
+ - `chat_and_media_and_text_options`: Text and media to display in the chat window alond with a list of possible response options.
+    - Example: "Is this funny?" <img src='https://external-preview.redd.it/hWh_8TpqrT6zAwpzHJ_m9Rx3iHjc_yI4zSI6aazMFTc.jpg?auto=webp&s=6d8006ac3edca5bad98dd7b5b9a4a8d5554eaff0' width="200"> ('yes', 'no')
+
+### Schema ###
+
+<pre>
+{
+	"title": "Droidlet Chat",
+	"description": "A single chat sent from a Droidlet agent to the user",
+    "version": 1,
+	"type": "object",
+	
+	"properties": {
+		"speaker_id": {
+			"description": "The memid of the speaker",
+			"type": "string"
+		},
+
+		"timestamp": {
+			"description": "Unix timestamp of when the chat was sent",
+			"type": "integer"
+		},
+
+		"content_type": {
+			"description": "The type of content to be rendered to the user",
+			"type": "array",
+			"items": {
+                "enum": [
+                    "chat_string",
+                    "chat_and_media",
+                    "chat_and_text_options",
+                    "chat_and_media_options",
+                    "chat_and_media_and_text_options"
+                ]
+			},
+            "minItems": 1,
+            "maxItems": 1
+		},
+		
+		"content": {
+			"description": "The chat content",
+			"type": "array",
+            "items": {
+                "type": "array",
+                "items": [
+                    {"enum": ["text", "image_link", "response_option", "response_image_link"]},
+                    {"type": "string"}
+                ],
+                "minItems": 2,
+                "maxItems": 2
+			},
+            "minItems": 1,
+		},
+
+	"required": ["speaker_id", "timestamp", "content_type", "content"]
+}
+</pre>

--- a/droidlet/dialog/chat_schema.md
+++ b/droidlet/dialog/chat_schema.md
@@ -21,9 +21,9 @@ Note that chats sent from the user to the agent should always be in plaintext, a
 {
 	"title": "Droidlet Chat",
 	"description": "A single chat sent from a Droidlet agent to the user",
-    "version": 1,
+	"version": 1,
 	"type": "object",
-	
+
 	"properties": {
 		"speaker_id": {
 			"description": "The memid of the speaker",
@@ -39,32 +39,32 @@ Note that chats sent from the user to the agent should always be in plaintext, a
 			"description": "The type of content to be rendered to the user",
 			"type": "array",
 			"items": {
-                "enum": [
-                    "chat_string",
-                    "chat_and_media",
-                    "chat_and_text_options",
-                    "chat_and_media_options",
-                    "chat_and_media_and_text_options"
-                ]
+				"enum": [
+					"chat_string",
+					"chat_and_media",
+					"chat_and_text_options",
+					"chat_and_media_options",
+					"chat_and_media_and_text_options"
+				]
 			},
-            "minItems": 1,
-            "maxItems": 1
+			"minItems": 1,
+			"maxItems": 1
 		},
-		
+
 		"content": {
 			"description": "The chat content",
 			"type": "array",
-            "items": {
-                "type": "array",
-                "items": [
-                    {"enum": ["text", "image_link", "response_option", "response_image_link"]},
-                    {"type": "string"}
-                ],
-                "minItems": 2,
-                "maxItems": 2
+			"items": {
+				"type": "array",
+				"items": [
+					{ "enum": [ "text", "image_link", "response_option", "response_image_link" ] },
+					{ "type": "string" }
+				],
+				"minItems": 2,
+				"maxItems": 2
 			},
-            "minItems": 1,
-		},
+			"minItems": 1
+		}
 
 	"required": ["speaker_id", "timestamp", "content_type", "content"]
 }

--- a/droidlet/dialog/chat_schema.md
+++ b/droidlet/dialog/chat_schema.md
@@ -14,6 +14,8 @@ Note that chats sent from the user to the agent should always be in plaintext, a
     - Example: "Which of these is the 'blue sphere' you were referring to?" (pictures of blue spheres)
  - `chat_and_media_and_text_options`: Text and media to display in the chat window alond with a list of possible response options.
     - Example: "Is this funny?" <img src='https://external-preview.redd.it/hWh_8TpqrT6zAwpzHJ_m9Rx3iHjc_yI4zSI6aazMFTc.jpg?auto=webp&s=6d8006ac3edca5bad98dd7b5b9a4a8d5554eaff0' width="200"> ('yes', 'no')
+ - `point`: A special chat type indicating the coordinates to which the agent is pointing in 3D space.  `point`s are not displayed in the chat window.
+	- Example: "/point -4 62 8 -3 62 12"
 
 ### Schema ###
 
@@ -37,34 +39,40 @@ Note that chats sent from the user to the agent should always be in plaintext, a
 
 		"content_type": {
 			"description": "The type of content to be rendered to the user",
-			"type": "array",
-			"items": {
-				"enum": [
-					"chat_string",
-					"chat_and_media",
-					"chat_and_text_options",
-					"chat_and_media_options",
-					"chat_and_media_and_text_options"
-				]
-			},
-			"minItems": 1,
-			"maxItems": 1
+			"type": "string",
+			"enum": [
+				"chat_string",
+				"chat_and_media",
+				"chat_and_text_options",
+				"chat_and_media_options",
+				"chat_and_media_and_text_options",
+				"point"
+			]
 		},
 
 		"content": {
 			"description": "The chat content",
 			"type": "array",
 			"items": {
-				"type": "array",
-				"items": [
-					{ "enum": [ "text", "image_link", "response_option", "response_image_link" ] },
-					{ "type": "string" }
-				]
+				"type": "object",
+				"properties": {
+					"id": {
+						"enum": [
+							"text",
+							"image_link",
+							"response_option",
+							"response_image_link"
+						]
+					},
+					"content": {
+						"type": "string"
+					}
+				}
 			},
 			"minItems": 1
 		}
 	},
 
-	"required": ["speaker_id", "timestamp", "content_type", "content"]
+	"required": ["chat_memid", "timestamp", "content_type", "content"]
 }
 </pre>

--- a/droidlet/dialog/chat_schema.md
+++ b/droidlet/dialog/chat_schema.md
@@ -1,5 +1,5 @@
 ## Description ##
-This is the source of truth for the most updated version of the schema to be followed when sending chats from the agent the the user (and perhaps eventually from the agent to other agents).  When updating this document please increment the version number.  Older versions of the schema can be found in git history.
+This is the source of truth for the most updated version of the schema to be followed when sending chats from the agent to the user (and perhaps eventually from the agent to other agents).  When updating this document please increment the version number.  Older versions of the schema can be found in git history.
 
 Note that chats sent from the user to the agent should always be in plaintext, as all messages should be parsed by the NSP and interpreted.  I.e. special pathways and conditionals on agent input are discouraged.  It is possible to help the NSP by including special tokens that are reserved for specific use cases, eg. clarification response.
 
@@ -19,19 +19,19 @@ Note that chats sent from the user to the agent should always be in plaintext, a
 
 <pre>
 {
-	"title": "Droidlet Chat",
+	"title": "Droidlet agent initiated chat",
 	"description": "A single chat sent from a Droidlet agent to the user",
 	"version": 1,
 	"type": "object",
 
 	"properties": {
-		"speaker_id": {
-			"description": "The memid of the speaker",
+		"chat_memid": {
+			"description": "The memid of the chat",
 			"type": "string"
 		},
 
 		"timestamp": {
-			"description": "Unix timestamp of when the chat was sent",
+			"description": "UTC Unix timestamp of when the chat was sent, in milliseconds",
 			"type": "integer"
 		},
 
@@ -59,12 +59,11 @@ Note that chats sent from the user to the agent should always be in plaintext, a
 				"items": [
 					{ "enum": [ "text", "image_link", "response_option", "response_image_link" ] },
 					{ "type": "string" }
-				],
-				"minItems": 2,
-				"maxItems": 2
+				]
 			},
 			"minItems": 1
 		}
+	},
 
 	"required": ["speaker_id", "timestamp", "content_type", "content"]
 }


### PR DESCRIPTION
# Description

This is a PR to discuss the adoption of a JSON schema that will govern chats sent from the agent to the user.  It should support, or provide a platform to build on for ongoing workstreams in human-in-the-loop, multi-turn dialog, mobile AR, and multi-agent swarms.

The file being checked in is a single piece of documentation, so please see that file for more details.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [X] I want a deep design review.

## Before and After

Previously chats sent from the agent take the form of plain text strings without any metadata or hints as to their purpose / what should be done with them.  This is fine for the existing use case where the agent most often issues chats that don't require response from the user or special rendering.  The new schema should provide a structure for those new use cases.

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [X] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [X] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
