### PR TITLE
Added support for customized mc agent spawn location

### DIFF
--- a/agents/argument_parser.py
+++ b/agents/argument_parser.py
@@ -99,6 +99,13 @@ class ArgumentParser:
             help="run thenearby_airtouching_blocks heuristic?",
         )
         mc_parser.add_argument("--port", type=int, default=25565)
+        mc_parser.add_argument(
+        "--spawn_location",
+        type=float,
+        nargs=3,
+        default=[0, 63, 0],
+        help="Spawn location of the agent",
+    )
 
     def add_loco_parser(self):
         loco_parser = self.parser.add_argument_group("Locobot Agent Args")

--- a/agents/craftassist/craftassist_agent.py
+++ b/agents/craftassist/craftassist_agent.py
@@ -439,7 +439,7 @@ class CraftAssistAgent(DroidletAgent):
         if self.opts.port == -1:
             return
         logging.info("Attempting to connect to port {}".format(self.opts.port))
-        self.cagent = MCAgent("localhost", self.opts.port, self.name)
+        self.cagent = MCAgent("localhost", self.opts.port, self.name, *self.opts.spawn_location)
         logging.info("Logged in to server")
         self.dig = self.cagent.dig
         self.drop_item_stack_in_hand = self.cagent.drop_item_stack_in_hand

--- a/droidlet/lowlevel/minecraft/client/src/client.cpp
+++ b/droidlet/lowlevel/minecraft/client/src/client.cpp
@@ -35,7 +35,7 @@ bool IS_GLOG_INITIALIZED = false;
 ////////////////
 // Public
 
-Client::Client(const string& host, int port, const string& username) {
+Client::Client(const string& host, int port, const string& username, double x, double y, double z) {
   // Init glog. Better place for this?
   if (!IS_GLOG_INITIALIZED) {
     google::InitGoogleLogging("client");
@@ -62,6 +62,12 @@ Client::Client(const string& host, int port, const string& username) {
 
   // Wait until chunks have loaded
   eventHandler_->waitForCondition();
+
+  // teleport to spawn location
+  Pos spawnPos = Pos{x, y, z};
+  if (gameState_->getBlockMap().canWalkthrough(spawnPos)) {
+  doMoveUnsafe(spawnPos);
+  }
 }
 
 void Client::disconnect() {

--- a/droidlet/lowlevel/minecraft/client/src/client.h
+++ b/droidlet/lowlevel/minecraft/client/src/client.h
@@ -21,7 +21,7 @@ class Client {
  public:
   static constexpr double HEIGHT = 1.5;
 
-  Client(const std::string& host, int port, const std::string& username);
+  Client(const std::string& host, int port, const std::string& username, double x, double y, double z);
   ~Client() { disconnect(); }
   void disconnect();
   Pos getPosition() { return gameState_->getPosition(); }

--- a/droidlet/lowlevel/minecraft/client/src/mc_agent.cpp
+++ b/droidlet/lowlevel/minecraft/client/src/mc_agent.cpp
@@ -26,7 +26,7 @@ class Agent {
   // Main constructor
   //  - host/port: the Minecraft server to connect to
   //  - username:  username visible to other players on the server. Recommended to be unique.
-  Agent(const string& host, int port, const string& username) : client_(host, port, username) {}
+  Agent(const string& host, int port, const string& username, double x, double y, double z) : client_(host, port, username, x, y, z) {}
 
   ////////////////
   // Observations
@@ -355,7 +355,7 @@ void Agent::doMove(int x, int y, int z) {
 
 PYBIND11_MODULE(mc_agent, m) {
   py::class_<Agent>(m, "Agent")
-      .def(py::init<const string&, int, const string&>())
+      .def(py::init<const string&, int, const string&, double, double, double>())
       .def("disconnect", &Agent::disconnect, "Disconnect the agent from the server")
       .def("dig", &Agent::dig)
       .def("drop_item_stack_in_hand", &Agent::dropItemStackInHand)


### PR DESCRIPTION
# Description

As title says, now you can pass agent spawn location as an argument when start the agent.

Try something like: 

`python agents/craftassist/craftassist_agent.py --no_default_behavior --agent_debug_mode --spawn_location 5 70 9`


## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

**Before**

Agent will always be spawned at a given location

**After**

You can specify where to spawn the agent

# Testing

Tested locally and passed.

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
