### PR TITLE
make a stop task to explicitly tell robot to stop (instead of just pa…

### DIFF
--- a/droidlet/interpreter/robot/loco_interpreter.py
+++ b/droidlet/interpreter/robot/loco_interpreter.py
@@ -22,6 +22,7 @@ from .point_target import PointTargetInterpreter
 import droidlet.interpreter.robot.dance as dance
 import droidlet.interpreter.robot.tasks as tasks
 from droidlet.task.task import task_to_generator
+from droidlet.dialog.dialogue_task import Say
 
 
 def post_process_loc(loc, interpreter):

--- a/droidlet/interpreter/robot/loco_interpreter.py
+++ b/droidlet/interpreter/robot/loco_interpreter.py
@@ -23,6 +23,7 @@ import droidlet.interpreter.robot.dance as dance
 import droidlet.interpreter.robot.tasks as tasks
 from droidlet.task.task import task_to_generator
 
+
 def post_process_loc(loc, interpreter):
     self_mem = interpreter.memory.get_mem_by_id(interpreter.memory.self_memid)
     yaw, _ = self_mem.get_yaw_pitch()
@@ -82,7 +83,6 @@ class LocoInterpreter(Interpreter):
         if self.memory.task_stack_pause():
             Say(agent, task_data={"response_options": "Stopping"})
         return task_to_generator(self.task_objects["stop"](agent, {}))
-
 
     def handle_get(self, agent, speaker, d) -> Tuple[Optional[str], Any]:
         default_ref_d = {"filters": {"location": AGENTPOS}}

--- a/droidlet/interpreter/robot/tasks.py
+++ b/droidlet/interpreter/robot/tasks.py
@@ -39,7 +39,6 @@ class Stop(Task):
         self.finished = True
 
 
-
 # FIXME store dances, etc.
 class Dance(Task):
     def __init__(self, agent, task_data, featurizer=None):

--- a/droidlet/interpreter/robot/tasks.py
+++ b/droidlet/interpreter/robot/tasks.py
@@ -26,6 +26,20 @@ from droidlet.lowlevel.robot_mover_utils import (
     get_circular_path,
 )
 
+
+# TODO make this highest priority, hardstop, etc
+class Stop(Task):
+    def __init__(self, agent, task_data, featurizer=None):
+        super().__init__(agent)
+        TaskNode(self.agent.memory, self.memid).update_task(task=self)
+
+    @Task.step_wrapper
+    def step(self):
+        self.agent.mover.stop()
+        self.finished = True
+
+
+
 # FIXME store dances, etc.
 class Dance(Task):
     def __init__(self, agent, task_data, featurizer=None):

--- a/droidlet/interpreter/robot/tests/fake_agent.py
+++ b/droidlet/interpreter/robot/tests/fake_agent.py
@@ -362,7 +362,7 @@ class FakeMover:
 
     def get_pan(self):
         return self.agent.pan
-    
+
     def stop(self):
         pass
 

--- a/droidlet/interpreter/robot/tests/fake_agent.py
+++ b/droidlet/interpreter/robot/tests/fake_agent.py
@@ -362,6 +362,9 @@ class FakeMover:
 
     def get_pan(self):
         return self.agent.pan
+    
+    def stop(self):
+        pass
 
     def reset(self):
         pass


### PR DESCRIPTION
…using old task)

# Description

because robot moves are async, just pausing a move Task in memory without telling robot explicitly to stop does not make it stop.  This adds a new stop task and interprets it on robot.   This does not handle emergency/hard stops.

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.


# Testing

Tested on robot

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
