### PR TITLE
[hello-robot] add a on-the-fly calibration process for tilt correction

### DIFF
--- a/droidlet/lowlevel/hello_robot/remote/launch.sh
+++ b/droidlet/lowlevel/hello_robot/remote/launch.sh
@@ -24,7 +24,7 @@ export CAMERA_NAME="hello_realsense"
 
 echo $ip
 python3 ./remote_hello_robot.py --ip $ip &
-timeout 10s bash -c "until python check_connected.py hello_robot $ip; do sleep 0.5; done;" || true
+timeout 20s bash -c "until python check_connected.py hello_robot $ip; do sleep 0.5; done;" || true
 
 python3 ./remote_hello_realsense.py --ip $ip &
 timeout 20s bash -c "until python check_connected.py hello_realsense $ip; do sleep 0.5; done;" || true

--- a/droidlet/lowlevel/hello_robot/remote/launch.sh
+++ b/droidlet/lowlevel/hello_robot/remote/launch.sh
@@ -27,7 +27,7 @@ python3 ./remote_hello_robot.py --ip $ip &
 timeout 10s bash -c "until python check_connected.py hello_robot $ip; do sleep 0.5; done;" || true
 
 python3 ./remote_hello_realsense.py --ip $ip &
-timeout 10s bash -c "until python check_connected.py hello_realsense $ip; do sleep 0.5; done;" || true
+timeout 20s bash -c "until python check_connected.py hello_realsense $ip; do sleep 0.5; done;" || true
 
 python3 ./remote_hello_saver.py --ip $ip &
 timeout 10s bash -c "until python check_connected.py hello_data_logger $ip; do sleep 0.5; done;" || true

--- a/droidlet/lowlevel/hello_robot/remote/remote_hello_realsense.py
+++ b/droidlet/lowlevel/hello_robot/remote/remote_hello_realsense.py
@@ -243,6 +243,21 @@ class RemoteHelloRealsense(object):
         depth = blosc_encode(depth)
         return rgb, depth, base2cam_rot, base2cam_trans
 
+    def calibrate_tilt(self):
+        self.bot.set_tilt(math.radians(-60) )
+        time.sleep(2)
+        pcd = self.get_open3d_pcd()
+        plane, points = pcd.segment_plane(
+            distance_threshold=0.03,
+            ransac_n=3,
+            num_iterations=1000,
+        )
+        angle = math.atan(plane[0] / plane[2])
+        self.bot.set_tilt_correction(angle)
+
+        self.bot.set_tilt(math.radians(0) )
+        time.sleep(2)
+
 
 if __name__ == "__main__":
     import argparse
@@ -266,6 +281,7 @@ if __name__ == "__main__":
         with Pyro4.locateNS() as ns:
             ns.register("hello_realsense", robot_uri)
 
+        robot.calibrate_tilt()
         print("Server is started...")
         # try:
         #     while True:

--- a/droidlet/lowlevel/hello_robot/remote/remote_hello_realsense.py
+++ b/droidlet/lowlevel/hello_robot/remote/remote_hello_realsense.py
@@ -244,7 +244,7 @@ class RemoteHelloRealsense(object):
         return rgb, depth, base2cam_rot, base2cam_trans
 
     def calibrate_tilt(self):
-        self.bot.set_tilt(math.radians(-60) )
+        self.bot.set_tilt(math.radians(-60))
         time.sleep(2)
         pcd = self.get_open3d_pcd()
         plane, points = pcd.segment_plane(
@@ -255,7 +255,7 @@ class RemoteHelloRealsense(object):
         angle = math.atan(plane[0] / plane[2])
         self.bot.set_tilt_correction(angle)
 
-        self.bot.set_tilt(math.radians(0) )
+        self.bot.set_tilt(math.radians(0))
         time.sleep(2)
 
 

--- a/droidlet/lowlevel/hello_robot/remote/remote_hello_robot.py
+++ b/droidlet/lowlevel/hello_robot/remote/remote_hello_robot.py
@@ -65,6 +65,7 @@ class RemoteHelloRobot(object):
         # Read battery maintenance guide https://docs.hello-robot.com/battery_maintenance_guide/
         self._check_battery()
         self._load_urdf()
+        self.tilt_correction = 0.0
 
     def _check_battery(self):
         p = self._robot.pimu
@@ -94,10 +95,22 @@ class RemoteHelloRobot(object):
             urdf = f.read()
             self.tm.load_urdf(urdf)
 
+    def set_tilt_correction(self, angle):
+        """
+        angle in radians
+        """
+        print("[hello-robot] Setting tilt correction "
+              "to angle: {} degrees".format(degrees(angle)))
+
+        self.tilt_correction = angle
+
     def get_camera_transform(self):
         s = self._robot.get_status()
         head_pan = s["head"]["head_pan"]["pos"]
         head_tilt = s["head"]["head_tilt"]["pos"]
+
+        if self.tilt_correction != 0.0:
+            head_tilt += self.tilt_correction
 
         # Get Camera transform
         self.tm.set_joint("joint_head_pan", head_pan)

--- a/droidlet/lowlevel/hello_robot/remote/remote_hello_robot.py
+++ b/droidlet/lowlevel/hello_robot/remote/remote_hello_robot.py
@@ -99,8 +99,9 @@ class RemoteHelloRobot(object):
         """
         angle in radians
         """
-        print("[hello-robot] Setting tilt correction "
-              "to angle: {} degrees".format(degrees(angle)))
+        print(
+            "[hello-robot] Setting tilt correction " "to angle: {} degrees".format(degrees(angle))
+        )
 
         self.tilt_correction = angle
 

--- a/droidlet/lowlevel/hello_robot/remote/remote_hello_robot.py
+++ b/droidlet/lowlevel/hello_robot/remote/remote_hello_robot.py
@@ -270,5 +270,5 @@ if __name__ == "__main__":
         with Pyro4.locateNS() as ns:
             ns.register("hello_robot", robot_uri)
 
-        print("Server is started...")
+        print("Hello Robot Server is started...")
         daemon.requestLoop()

--- a/droidlet/lowlevel/hello_robot/remote/remote_hello_saver.py
+++ b/droidlet/lowlevel/hello_robot/remote/remote_hello_saver.py
@@ -54,7 +54,9 @@ class LabelPropSaver:
 
         # save camera intrinsics
         cam_intrinsics = safe_call(self.cam.get_intrinsics)
-        cam_intrinsics_path = os.path.join(self.save_folder, str(self.save_id), 'cam_intrinsics.npz')
+        cam_intrinsics_path = os.path.join(
+            self.save_folder, str(self.save_id), "cam_intrinsics.npz"
+        )
         np.save(cam_intrinsics_path, cam_intrinsics)
 
         start_time = time.time()

--- a/droidlet/lowlevel/hello_robot/remote/remote_hello_saver.py
+++ b/droidlet/lowlevel/hello_robot/remote/remote_hello_saver.py
@@ -88,14 +88,27 @@ class LabelPropSaver:
     def ready(self):
         return True
 
-    def save(self, id_, name, timestamp, lidar, rgb, depth, pos, cam_pan, cam_tilt, cam_transform, pose_dict):
+    def save(
+        self,
+        id_,
+        name,
+        timestamp,
+        lidar,
+        rgb,
+        depth,
+        pos,
+        cam_pan,
+        cam_tilt,
+        cam_transform,
+        pose_dict,
+    ):
         img_folder, img_folder_dbg, depth_folder, lidar_folder, data_file = self.return_paths(id_)
 
         self.skip_frame_count += 1
         if self.skip_frame_count % self.save_frequency == 0:
             # store the lidar
             lidar_fname = lidar_folder + "/{}.pkl".format(name)
-            with open(lidar_fname, 'wb') as fp:
+            with open(lidar_fname, "wb") as fp:
                 pickle.dump(lidar, fp)
             # store the images and depth
             cv2.imwrite(

--- a/droidlet/lowlevel/hello_robot/remote/remote_hello_saver.py
+++ b/droidlet/lowlevel/hello_robot/remote/remote_hello_saver.py
@@ -3,6 +3,7 @@ import time
 import shutil
 import json
 import cv2
+import pickle
 import numpy as np
 import Pyro4
 from droidlet.lowlevel.pyro_utils import safe_call
@@ -30,14 +31,15 @@ class LabelPropSaver:
         img_folder = os.path.join(self.save_folder, id_, "rgb")
         img_folder_dbg = os.path.join(self.save_folder, id_, "rgb_dbg")
         depth_folder = os.path.join(self.save_folder, id_, "depth")
+        lidar_folder = os.path.join(self.save_folder, id_, "lidar")
         data_file = os.path.join(self.save_folder, id_, "data.json")
-        return img_folder, img_folder_dbg, depth_folder, data_file
+        return img_folder, img_folder_dbg, depth_folder, lidar_folder, data_file
 
     def create_dirs(self, id_):
 
-        img_folder, img_folder_dbg, depth_folder, data_file = self.return_paths(id_)
+        img_folder, img_folder_dbg, depth_folder, lidar_folder, data_file = self.return_paths(id_)
 
-        for x in [img_folder, img_folder_dbg, depth_folder]:
+        for x in [img_folder, img_folder_dbg, depth_folder, lidar_folder]:
             os.makedirs(x, exist_ok=True)
 
     def stop(self):
@@ -53,16 +55,20 @@ class LabelPropSaver:
         frame_count = 0
         end_time = seconds
         while time.time() - start_time <= seconds:
-            rgb, depth = safe_call(self.cam.get_rgb_depth)
+            lidar = safe_call(self.cam.get_lidar_scan)
+            rgb, depth = safe_call(self.cam.get_rgb_depth, rotate=False, compressed=True)
             base_pos = safe_call(self.bot.get_base_state)
             cam_pan = safe_call(self.bot.get_pan)
             cam_tilt = safe_call(self.bot.get_tilt)
             cam_transform = safe_call(self.bot.get_camera_transform)
+            timestamp = time.time()
 
             name = "{}".format(frame_count)
             self.save(
                 self.save_id,
                 name,
+                timestamp,
+                lidar,
                 rgb,
                 depth,
                 base_pos,
@@ -82,11 +88,15 @@ class LabelPropSaver:
     def ready(self):
         return True
 
-    def save(self, id_, name, rgb, depth, pos, cam_pan, cam_tilt, cam_transform, pose_dict):
-        img_folder, img_folder_dbg, depth_folder, data_file = self.return_paths(id_)
+    def save(self, id_, name, timestamp, lidar, rgb, depth, pos, cam_pan, cam_tilt, cam_transform, pose_dict):
+        img_folder, img_folder_dbg, depth_folder, lidar_folder, data_file = self.return_paths(id_)
 
         self.skip_frame_count += 1
         if self.skip_frame_count % self.save_frequency == 0:
+            # store the lidar
+            lidar_fname = lidar_folder + "/{}.pkl".format(name)
+            with open(lidar_fname, 'wb') as fp:
+                pickle.dump(lidar, fp)
             # store the images and depth
             cv2.imwrite(
                 img_folder + "/{}.jpg".format(name),
@@ -100,19 +110,12 @@ class LabelPropSaver:
                 rgb,
             )
 
-            # convert depth to milimetres
-            depth *= 1e3
-
-            # saturate maximum depth to 65,535mm or 65.53cm
-            max_depth = np.power(2, 16) - 1
-            depth[depth > max_depth] = max_depth
-
-            depth = depth.astype(np.uint16)
             np.save(depth_folder + "/{}.npy".format(name), depth)
 
             # store pos
             if pos is not None:
                 pose_dict[name] = {
+                    "timestamp": timestamp,
                     "base_xyt": pos,
                     "cam_pan_tilt": [cam_pan, cam_tilt],
                     "cam_transform": cam_transform.tolist(),

--- a/droidlet/lowlevel/hello_robot/remote/remote_hello_saver.py
+++ b/droidlet/lowlevel/hello_robot/remote/remote_hello_saver.py
@@ -51,6 +51,12 @@ class LabelPropSaver:
         pose_dict = {}
         self.save_id += 1
         self.create_dirs(self.save_id)
+
+        # save camera intrinsics
+        cam_intrinsics = safe_call(self.cam.get_intrinsics)
+        cam_intrinsics_path = os.path.join(self.save_folder, str(self.save_id), 'cam_intrinsics.npz')
+        np.save(cam_intrinsics_path, cam_intrinsics)
+
         start_time = time.time()
         frame_count = 0
         end_time = seconds


### PR DESCRIPTION
At the beginning of the startup process,
1. the camera tilts down 60 degrees
2. we find the ground plane in the point cloud
3. determine the correction (camera motors for some of the hellos have zero tilt miscalibrated)
4. add the correction to the robot interface to correctly compute camera transforms going forward

