### PR TITLE
[Polymetis] Change safety limits behavior during readonly mode

### DIFF
--- a/polymetis/polymetis/include/polymetis/clients/franka_panda_client.hpp
+++ b/polymetis/polymetis/include/polymetis/clients/franka_panda_client.hpp
@@ -60,14 +60,13 @@ private:
   double lpf_cutoff_freq_;
   std::array<double, NUM_DOFS> torque_applied_prev_;
 
-  bool limits_exceeded_;
-
   std::array<double, 3> cartesian_pos_ulimits_, cartesian_pos_llimits_;
   std::array<double, NUM_DOFS> joint_pos_ulimits_, joint_pos_llimits_,
       joint_vel_limits_, joint_torques_limits_;
   double elbow_vel_limit_;
 
   // safety controller
+  std::unordered_map<std::string, bool> active_constraints_map_;
   bool is_safety_controller_active_;
   double margin_cartesian_pos_, margin_joint_pos_, margin_joint_vel_;
   double k_cartesian_pos_, k_joint_pos_, k_joint_vel_;

--- a/polymetis/polymetis/include/polymetis/clients/franka_panda_client.hpp
+++ b/polymetis/polymetis/include/polymetis/clients/franka_panda_client.hpp
@@ -61,7 +61,6 @@ private:
   std::array<double, NUM_DOFS> torque_applied_prev_;
 
   bool limits_exceeded_;
-  std::string error_str_;
 
   std::array<double, 3> cartesian_pos_ulimits_, cartesian_pos_llimits_;
   std::array<double, NUM_DOFS> joint_pos_ulimits_, joint_pos_llimits_,

--- a/polymetis/polymetis/src/clients/franka_panda_client/franka_panda_client.cpp
+++ b/polymetis/polymetis/src/clients/franka_panda_client/franka_panda_client.cpp
@@ -365,25 +365,37 @@ void FrankaTorqueControlClient::computeSafetyReflex(
    */
   double upper_violation, lower_violation;
   double lower_sign = 1.0;
+  bool safety_constraint_triggered = false;
 
+  std::string item_name_str(item_name);
   if (invert_lower) {
     lower_sign = -1.0;
   }
 
+  // Init constraint active map
+  if (active_constraints_map_.find(item_name_str) ==
+      active_constraints_map_.end()) {
+    active_constraints_map_.emplace(std::make_pair(item_name_str, false));
+  }
+
+  // Check limits & compute safety controller
   for (int i = 0; i < N; i++) {
     upper_violation = values[i] - upper_limit[i];
     lower_violation = lower_sign * lower_limit[i] - values[i];
 
-    // Check hard limits (use limits_exceeded_ to prevent flooding terminal)
+    // Check hard limits (use active_constraints_map_ to prevent flooding
+    // terminal)
     if (upper_violation > 0 || lower_violation > 0) {
-      if (!limits_exceeded_) {
+      safety_constraint_triggered = true;
+
+      if (!active_constraints_map_[item_name_str]) {
         spdlog::warn("Safety limits exceeded: "
                      "\n\ttype = \"{}\""
                      "\n\tdim = {}"
                      "\n\tlimits = {}, {}"
                      "\n\tvalue = {}",
-                     item_name, i, lower_sign * lower_limit[i], upper_limit[i],
-                     values[i]);
+                     item_name_str, i, lower_sign * lower_limit[i],
+                     upper_limit[i], values[i]);
 
         std::string error_str =
             "Safety limits exceeded in FrankaTorqueControlClient. ";
@@ -393,13 +405,7 @@ void FrankaTorqueControlClient::computeSafetyReflex(
           spdlog::warn(error_str + "Ignoring issue during readonly mode.");
         }
 
-        limits_exceeded_ = true;
-      }
-
-    } else {
-      if (limits_exceeded_) {
-        spdlog::info("Safety limits no longer violated.");
-        limits_exceeded_ = false;
+        active_constraints_map_[item_name_str] = true;
       }
     }
 
@@ -411,6 +417,12 @@ void FrankaTorqueControlClient::computeSafetyReflex(
         safety_torques[i] += k * (margin + lower_violation);
       }
     }
+  }
+
+  // Reset constraint active map
+  if (!safety_constraint_triggered && active_constraints_map_[item_name_str]) {
+    active_constraints_map_[item_name_str] = false;
+    spdlog::info("Safety limits no longer violated: \"{}\"", item_name_str);
   }
 }
 

--- a/polymetis/polymetis/src/clients/franka_panda_client/franka_panda_client.cpp
+++ b/polymetis/polymetis/src/clients/franka_panda_client/franka_panda_client.cpp
@@ -389,6 +389,8 @@ void FrankaTorqueControlClient::computeSafetyReflex(
       safety_constraint_triggered = true;
 
       if (!active_constraints_map_[item_name_str]) {
+        active_constraints_map_[item_name_str] = true;
+
         spdlog::warn("Safety limits exceeded: "
                      "\n\ttype = \"{}\""
                      "\n\tdim = {}"
@@ -404,8 +406,6 @@ void FrankaTorqueControlClient::computeSafetyReflex(
         } else {
           spdlog::warn(error_str + "Ignoring issue during readonly mode.");
         }
-
-        active_constraints_map_[item_name_str] = true;
       }
     }
 


### PR DESCRIPTION
# Description

Implement feature requested in #1099 

Changes:
- Change safety constraints to only print out warnings instead of raising an exception during readonly mode
- Add mechanisms to prevent continuous constraint violations to flood the terminal
- Minor unrelated fix: remove unused member variables

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After
Behavior when moving the robot out of the bounding box (and back) during readonly mode:

Before
<img width="1029" alt="image" src="https://user-images.githubusercontent.com/9565466/163467714-10939fe7-794e-47f9-8188-31ae049ce3e9.png">
-- Polymetis server terminates without any visible behavior on the hardware side. 

After
<img width="895" alt="image" src="https://user-images.githubusercontent.com/9565466/163467523-8ba7778a-1626-4162-942d-bc0b43dfdbd3.png">
-- Polymetis server prints out warning and continues to run.

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [x] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
