### PR TITLE
Shape sizes

### DIFF
--- a/droidlet/lowlevel/minecraft/shape_util.py
+++ b/droidlet/lowlevel/minecraft/shape_util.py
@@ -6,7 +6,7 @@ import random
 import numpy as np
 from droidlet.lowlevel.minecraft import shapes
 
-FORCE_SMALL = 5  # for debug
+FORCE_SMALL = 2  # for debug
 
 # Map shape name to function in shapes.py
 SHAPE_FNS = {
@@ -88,24 +88,24 @@ def bernoulli(p=0.5):
     return np.random.rand() > p
 
 
-def slope(ranges=10):
+def slope(ranges=2):
     return np.random.randint(1, ranges)
 
 
-def sizes1(ranges=(1, 15)):
+def sizes1(ranges=(1, 3)):
     ranges = list(ranges)
     ranges[1] = min(ranges[1], FORCE_SMALL)
     return np.random.randint(ranges[0], ranges[1])
 
 
-def sizes2(ranges=(15, 15)):
+def sizes2(ranges=(2, 3)):
     ranges = list(ranges)
     for i in range(2):
         ranges[i] = min(ranges[i], FORCE_SMALL)
     return (np.random.randint(1, ranges[0]), np.random.randint(1, ranges[1]))
 
 
-def sizes3(ranges=(15, 15, 15)):
+def sizes3(ranges=(3, 3, 3)):
     ranges = list(ranges)
     for i in range(3):
         ranges[i] = min(ranges[i], FORCE_SMALL)
@@ -145,7 +145,7 @@ def options_disk():
 
 
 def options_cube():
-    return {"size": sizes1(ranges=(1, 8))}
+    return {"size": sizes1(ranges=(1, 2))}
 
 
 def options_hollow_cube():
@@ -153,7 +153,7 @@ def options_hollow_cube():
 
 
 def options_rectanguloid():
-    return {"size": sizes3(ranges=(8, 8, 8))}
+    return {"size": sizes3(ranges=(2, 2, 2))}
 
 
 def options_hollow_rectanguloid():
@@ -161,7 +161,7 @@ def options_hollow_rectanguloid():
 
 
 def options_sphere():
-    return {"radius": sizes1(ranges=(3, 5))}
+    return {"radius": sizes1(ranges=(1, 2))}
 
 
 def options_spherical_shell():
@@ -173,7 +173,7 @@ def options_square_pyramid():
 
 
 def options_tower():
-    return {"height": sizes1(ranges=(1, 20)), "base": sizes1(ranges=(-3, 4))}
+    return {"height": sizes1(ranges=(1, 2)), "base": sizes1(ranges=(1, 2))}
 
 
 def options_ellipsoid():
@@ -185,7 +185,7 @@ def options_dome():
 
 
 def options_arch():
-    return {"size": sizes1(), "distance": 2 * sizes1(ranges=(2, 5)) + 1}
+    return {"size": sizes1(), "distance": 2 * sizes1(ranges=(1, 2)) + 1}
 
 
 def options_hollow_triangle():

--- a/droidlet/lowlevel/minecraft/small_scenes_with_shapes.py
+++ b/droidlet/lowlevel/minecraft/small_scenes_with_shapes.py
@@ -94,7 +94,7 @@ def parse_and_execute_mob_config(args):
 
 def bid(nowhite=True):
     if nowhite:
-        return (35, np.random.randint(2)+1)
+        return (35, np.random.randint(2) + 1)
     else:
         return (35, np.random.randint(2))
 
@@ -276,7 +276,7 @@ def build_shape_scene(args):
         opts["bid"] = bid()
         S = SHAPE_FNS[shape](**opts)
         m = np.round(np.mean([l for l, idm in S], axis=0)).astype("int32")
-        offsets = (0,0,0)
+        offsets = (0, 0, 0)
         inst_seg = []
         in_box = in_box_builder(0, 0, 0, args.SL, args.H, args.SL)
         record_shape(S, in_box, offsets, blocks, inst_seg, occupied_by_shapes)
@@ -300,7 +300,7 @@ def build_shape_scene(args):
         m = np.round(np.mean([l for l, idm in S], axis=0)).astype("int32")
         miny = min([l[1] for l, idm in S])
         maxy = max([l[1] for l, idm in S])
-        offsets = (0,0,0)
+        offsets = (0, 0, 0)
         inst_seg = []
         in_box = in_box_builder(mL, 0, mL, ML, args.GROUND_DEPTH, ML)
         record_shape(S, in_box, offsets, blocks, inst_seg, occupied_by_shapes)
@@ -340,7 +340,7 @@ def build_extra_simple_shape_scene(args):
         opts["bid"] = bid()
         S = SHAPE_FNS[shape](**opts)
         m = np.round(np.mean([l for l, idm in S], axis=0)).astype("int32")
-        offsets = (0,0,0)
+        offsets = (0, 0, 0)
         inst_seg = []
         in_box = in_box_builder(0, 0, 0, args.SL, args.H, args.SL)
         record_shape(S, in_box, offsets, blocks, inst_seg, occupied_by_shapes)

--- a/droidlet/lowlevel/minecraft/small_scenes_with_shapes.py
+++ b/droidlet/lowlevel/minecraft/small_scenes_with_shapes.py
@@ -94,13 +94,13 @@ def parse_and_execute_mob_config(args):
 
 def bid(nowhite=True):
     if nowhite:
-        return (35, np.random.randint(15) + 1)
+        return (35, np.random.randint(2)+1)
     else:
-        return (35, np.random.randint(16))
+        return (35, np.random.randint(2))
 
 
 def red():
-    return (35, 14)
+    return (35, 2)
 
 
 def white():
@@ -276,7 +276,7 @@ def build_shape_scene(args):
         opts["bid"] = bid()
         S = SHAPE_FNS[shape](**opts)
         m = np.round(np.mean([l for l, idm in S], axis=0)).astype("int32")
-        offsets = np.random.randint((args.SL, args.H, args.SL)) - m
+        offsets = (0,0,0)
         inst_seg = []
         in_box = in_box_builder(0, 0, 0, args.SL, args.H, args.SL)
         record_shape(S, in_box, offsets, blocks, inst_seg, occupied_by_shapes)
@@ -300,11 +300,7 @@ def build_shape_scene(args):
         m = np.round(np.mean([l for l, idm in S], axis=0)).astype("int32")
         miny = min([l[1] for l, idm in S])
         maxy = max([l[1] for l, idm in S])
-        offsets = np.random.randint((args.SL, args.H, args.SL))
-        offsets[0] -= m[0]
-        offsets[2] -= m[2]
-        # offset miny to GROUND_DEPTH - radius of shape
-        offsets[1] = args.GROUND_DEPTH - maxy // 2 - 1
+        offsets = (0,0,0)
         inst_seg = []
         in_box = in_box_builder(mL, 0, mL, ML, args.GROUND_DEPTH, ML)
         record_shape(S, in_box, offsets, blocks, inst_seg, occupied_by_shapes)
@@ -344,22 +340,7 @@ def build_extra_simple_shape_scene(args):
         opts["bid"] = bid()
         S = SHAPE_FNS[shape](**opts)
         m = np.round(np.mean([l for l, idm in S], axis=0)).astype("int32")
-        offsets = np.random.randint(
-            (0, args.GROUND_DEPTH, 0),
-            (args.SL - CUBE_SIZE, args.H - CUBE_SIZE, args.SL - CUBE_SIZE),
-        )
-        count = 0
-        while (
-            abs(old_offset[0] - offsets[0]) + abs(old_offset[2] - offsets[2])
-            < CUBE_SIZE + SPHERE_RADIUS
-        ):
-            offsets = np.random.randint(
-                (0, args.GROUND_DEPTH, 0),
-                (args.SL - CUBE_SIZE, args.H - CUBE_SIZE, args.SL - CUBE_SIZE),
-            )
-            count += 1
-            assert count < 100, "Is world too small? can't place shapes"
-        old_offset = offsets
+        offsets = (0,0,0)
         inst_seg = []
         in_box = in_box_builder(0, 0, 0, args.SL, args.H, args.SL)
         record_shape(S, in_box, offsets, blocks, inst_seg, occupied_by_shapes)


### PR DESCRIPTION
# Description

When testing small (11x11) gridworlds, we need smaller shape sizes. The current shape sizes extend past this grid. 

This PR changes the max shape sizes as well as the grid offsets.


NOTE: Should all shape sizes in an 11x11 gridworld be size 1x1?

Fixes # (issue)

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

If this PR introduces a change or fixes a bug, please add before and after screenshots (if this is causes a UX change) or before and after examples(this could be plain text, videos etc ) to demonstrate the change.

If this PR introduces a new feature, please also add examples or screenshots demonstrating the feature.

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
