### PR TITLE
mrp.main always sys.exit

### DIFF
--- a/mrp/src/mrp/__init__.py
+++ b/mrp/src/mrp/__init__.py
@@ -6,6 +6,7 @@ from mrp.util import NoEscape
 from importlib.machinery import SourceFileLoader
 import click
 import os
+import sys
 
 
 @click.group()
@@ -16,14 +17,10 @@ def cli():
 def main(*args):
     try:
         cli(*args)
-    except SystemExit as sys_exit:
-        if sys_exit.code == 0:
-            return
-        raise RuntimeError(
-            f"mrp.main failed with exit code {sys_exit.code}"
-        ) from sys_exit
     except Exception as ex:
         click.echo(ex, err=True)
+        sys.exit(1)
+    sys.exit(0)
 
 
 class cmd:

--- a/mrp/src/mrp/tool/__init__.py
+++ b/mrp/src/mrp/tool/__init__.py
@@ -16,7 +16,6 @@ def main():
     # Show help even if there is no msetup.py.
     if not os.path.exists(msetup_path):
         mrp.main()
-        return
 
     # Run the entrypoint file.
     sys.path.append(os.path.dirname(msetup_path))


### PR DESCRIPTION
# Description

Bug fix. The `mrp` cli would previously print a stack trace if an error occurred.
Now `mrp.main` is always a terminating command that cannot be caught and can't be proceeded in scripts.

Fixes # (issue)

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

If this PR introduces a change or fixes a bug, please add before and after screenshots (if this is causes a UX change) or before and after examples(this could be plain text, videos etc ) to demonstrate the change.

If this PR introduces a new feature, please also add examples or screenshots demonstrating the feature.

# Testing

Manual testing.
```
mrp kekwn
mrp up --kekwn
mrp up kekwn
```

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
