### PR TITLE
Two stage solver for eyehandcal

### DIFF
--- a/perception/sandbox/eyehandcal/caldata_analysis.py
+++ b/perception/sandbox/eyehandcal/caldata_analysis.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+import os
+
+import pickle 
+import numpy as np
+from PIL import Image
+from eyehandcal.utils import detect_corners
+
+with open('caldata_jay.pkl', 'rb') as f:
+    data = pickle.load(f)    
+
+caldata = 'caldata_imgs'
+os.makedirs(caldata, exist_ok=True)
+corner_data = detect_corners(data, target_idx=0)
+for i, d in enumerate(data):
+    for j,img in enumerate(d['imgs']):
+        img_pil = Image.fromarray(img.astype(np.uint8), mode='RGB')
+        fname = f'{caldata}/shot_{i}_cam_{j}.jpg'
+        img_pil.save(fname)
+        print(fname, corner_data[i]['corners'][j])
+

--- a/perception/sandbox/eyehandcal/scripts/collect_data_and_cal.py
+++ b/perception/sandbox/eyehandcal/scripts/collect_data_and_cal.py
@@ -71,14 +71,12 @@ def robot_poses(ip_address, pose_generator, time_to_go=3):
     # Get reference state
     robot.go_home()
     for i, (pos_sampled, ori_sampled) in enumerate(pose_generator):
-        while True:
             print( f"Moving to pose ({i}): pos={pos_sampled}, quat={ori_sampled.as_quat()}")
 
             state_log = robot.move_to_ee_pose(position=pos_sampled,orientation=ori_sampled.as_quat(),time_to_go = time_to_go)
             print(f"Length of state_log: {len(state_log)}")
             if len(state_log) != time_to_go * robot.hz:
-                print(f"State log incorrect length. Trying again...")
-            else:
+            print(f"warning: log incorrect length. {len(state_log)} != {time_to_go * robot.hz}")
                 while True:
                     pos0, quat0 = robot.get_ee_pose()
                     time.sleep(1)
@@ -90,7 +88,6 @@ def robot_poses(ip_address, pose_generator, time_to_go=3):
 
                 print(f"Current pose  pos={pos0}, quat={quat0}")
                 yield pos1, quat1
-                break
     robot.go_home()
 
 

--- a/perception/sandbox/eyehandcal/scripts/collect_data_and_cal.py
+++ b/perception/sandbox/eyehandcal/scripts/collect_data_and_cal.py
@@ -209,7 +209,8 @@ if __name__ == '__main__':
 
             pixel_error = L(param_star).item()
             print('stage 2 mean pixel error', pixel_error)
-            print(f"Try again because of poor solution {pixel_error} > {args.pixel_tolerance}")
+            if pixel_error > args.pixel_tolerance:
+                print(f"Try again because of poor solution {pixel_error} > {args.pixel_tolerance}")
             
 
         print(f"Good solution {pixel_error} <= {args.pixel_tolerance}")

--- a/perception/sandbox/eyehandcal/scripts/collect_data_and_cal.py
+++ b/perception/sandbox/eyehandcal/scripts/collect_data_and_cal.py
@@ -125,7 +125,7 @@ if __name__ == '__main__':
     parser.add_argument('--num-points', default=20, type=int, help="number of points to sample from convex hull")
     parser.add_argument('--time-to-go', default=3, type=float, help="time_to_go in seconds for each movement")
     parser.add_argument('--imagedir', default=None, help="folder to save debug images")
-    parser.add_argument('--pixel-tolerance', default=2.0, help="folder to save debug images")
+    parser.add_argument('--pixel-tolerance', default=2.0, help="mean pixel error tolerance (stage 2)")
 
     args=parser.parse_args()
     print(f"Config: {args}")

--- a/perception/sandbox/eyehandcal/src/eyehandcal/utils.py
+++ b/perception/sandbox/eyehandcal/src/eyehandcal/utils.py
@@ -92,15 +92,15 @@ def mean_loss(data, param, K):
         losses.append(ploss)
     return torch.stack(losses).mean()
 
-def find_parameter(param, obs_data_std, K):
+def find_parameter(param, L):
     optimizer=torch.optim.LBFGS([param], max_iter=1000, lr=1, line_search_fn='strong_wolfe')
     def closure():
         optimizer.zero_grad()
-        loss=mean_loss(obs_data_std, param, K)
+        loss=L(param)
         loss.backward()
         return loss
     
-    L=optimizer.step(closure)
+    optimizer.step(closure)
     return param.detach()
 
 

--- a/perception/sandbox/eyehandcal/tests/test_cal.py
+++ b/perception/sandbox/eyehandcal/tests/test_cal.py
@@ -30,7 +30,7 @@ def test_with_sim_data():
     param=torch.zeros(9, dtype=torch.float64, requires_grad=True)
     L = lambda param: mean_loss(obs_data_std, param, K)
     print('init param  loss', L(param).item())
-    param_star=find_parameter(param, obs_data_std, K)
+    param_star=find_parameter(param, L)
 
     assert L(param_star) < noise_sigma * 2
 
@@ -108,7 +108,7 @@ def params_from_data(data_with_corners):
         print('number of image with marker', len(obs_data_std))
         param=torch.zeros(9, dtype=torch.float64, requires_grad=True)
         L = lambda param: mean_loss(obs_data_std, param, K)
-        param_star=find_parameter(param, obs_data_std, K)
+        param_star=find_parameter(param, L)
         print('found param_star loss', L(param_star).item())
         params.append(param_star)
 


### PR DESCRIPTION
# Description

* Improve converegene using two stage solver.
  - Stage 1 assuming marker at EE origin, optimize camera pose (via OpenCV cv2.SolvePnP SQPNP global optimum solver)
  - Stage 2 initialize from stage 1, joint optimize camera/marker pose
* Add caldata.pkl analysis tool
* Make move_to_ee error to warning avoid infinite loop.
* Add pixel error tolerance option (default 2px)

## Sample Output
```
(eyehandcal) tingfan@perception:~/github/fairo/perception/sandbox/eyehandcal$ collect_data_and_cal.py --datafile caldata_jay.pkl --marker-id 0
Config: Namespace(calibration_file='calibration.json', datafile='caldata_jay.pkl', imagedir=None, ip='100.96.135.68', marker_id=0, num_points=20, overwrite=False, pixel_tolerance=2.0, points_file='calibration_points.json', seed=0, time_to_go=3)
Warning: datafile caldata_jay.pkl already exists. Loading data instead of collecting data...
Done. Data has 80 poses.
Solve camera 0/3 pose
number of images with keypoint 63
stage 1 mean pixel error 58.14839607143064
/home/tingfan/github/fairo/perception/sandbox/eyehandcal/scripts/collect_data_and_cal.py:199: UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).
  param=torch.tensor(torch.cat([rvec_cam, tvec_cam, torch.randn(3)*marker_max_displacement]).clone().detach(), requires_grad=True)
stage 2 mean pixel error 1.2835218941580095
Good solution 1.2835218941580095 <= 2.0
Solve camera 1/3 pose
number of images with keypoint 55
stage 1 mean pixel error 40.0480724105125
stage 2 mean pixel error 1.6889199780591908
Good solution 1.6889199780591908 <= 2.0
Solve camera 2/3 pose
number of images with keypoint 60
stage 1 mean pixel error 20.80285908825372
stage 2 mean pixel error 0.8825087847420576
Good solution 0.8825087847420576 <= 2.0
Camera 0 calibration: {'camera_base_ori': [[0.013048133951459111, -0.9964336517807136, 0.08336500344470933], [-0.999912203569455, -0.01319519228672731, -0.0012132820747365375], [0.002308972338806926, -0.08334185322794296, -0.9965183410992847]], 'camera_base_ori_rotvec': [-2.1938913004578717, 2.165240658590727, -0.09292216338789079], 'camera_base_pos': [0.4323047027664822, -0.006948483963882776, 0.9544815289583146], 'p_marker_ee': [0.03962615643723768, 0.05928517654049172, -0.04111599017830855]}
Camera 1 calibration: {'camera_base_ori': [[-0.9423714787031575, 0.189909896838137, 0.2754455067880989], [0.3345635791594879, 0.5393145728676955, 0.7727916944381122], [-0.0017909848736385864, 0.8204108864315873, -0.5717716063234685]], 'camera_base_ori_rotvec': [0.4490433036915795, 2.6143070662918113, 1.364066979751176], 'camera_base_pos': [0.42231626306438147, -0.7065548055123207, 0.5370501123877425], 'p_marker_ee': [0.03656451807400134, 0.06003780289208401, -0.037174545646631446]}
Camera 2 calibration: {'camera_base_ori': [[0.9906014737473084, 0.0354450137826797, 0.13210742298450848], [0.12022304454817227, -0.6862475757383885, -0.717363704373697], [0.065231432371445, 0.7265038993640229, -0.6840591673529711]], 'camera_base_ori_rotvec': [2.325587540019355, 0.1077148417857593, 0.1365490378101322], 'camera_base_pos': [0.3771764569827584, 0.689649005409921, 0.7562025299971935], 'p_marker_ee': [0.041673644711621084, 0.05846750569688469, -0.035321026148501314]}
Saving calibrated parameters to calibration.json
```

## Type of change

Please check the options that are relevant.

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

If this PR introduces a change or fixes a bug, please add before and after screenshots (if this is causes a UX change) or before and after examples(this could be plain text, videos etc ) to demonstrate the change.

If this PR introduces a new feature, please also add examples or screenshots demonstrating the feature.

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
