### PR TITLE
 [eyehandcal] Wrist camera support 

### DIFF
--- a/perception/sandbox/eyehandcal/readme.md
+++ b/perception/sandbox/eyehandcal/readme.md
@@ -1,8 +1,14 @@
 # Eye Hand Calibraton 
 A minimal version of eyehand calibration feature for a franka + realsense setup. With a marker attached to end effector of a robot, the tool controls the robot via polymetis and collect marker keypoint on multiple cameras simultaneously and finally outputs
 
+## Settings
+  ### world camera and hand marker  (default)
   * the camera poses in robot base frame
   * the marker position in robot end-effector frame
+
+  ### hand camera and world marker 
+  * the camera poses in robot end-effector frame
+  * the marker position in robot base frame
 
 ## Prerequisite
 * Using a realsense camera
@@ -77,7 +83,8 @@ Run `collect_data_and_cal.py` to run the calibration process by sampling from th
 
 ```bash
 $ collect_data_and_cal.py --help
-usage: collect_data_and_cal.py [-h] [--ip IP] [--datafile DATAFILE] [--overwrite] [--marker-id MARKER_ID] [--calibration-file CALIBRATION_FILE] [--points-file POINTS_FILE] [--num-points NUM_POINTS] [--time-to-go TIME_TO_GO] [--imagedir IMAGEDIR]
+usage: collect_data_and_cal.py [-h] [--seed SEED] [--ip IP] [--datafile DATAFILE] [--overwrite] [--marker-id MARKER_ID] [--calibration-file CALIBRATION_FILE] [--points-file POINTS_FILE] [--num-points NUM_POINTS]
+[--time-to-go TIME_TO_GO] [--imagedir IMAGEDIR] [--pixel-tolerance PIXEL_TOLERANCE] [--proj-func {hand_marker_proj_world_camera,world_marker_proj_hand_camera}]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -95,6 +102,9 @@ optional arguments:
   --time-to-go TIME_TO_GO
                         time_to_go in seconds for each movement
   --imagedir IMAGEDIR   folder to save debug images
+  --pixel-tolerance PIXEL_TOLERANCE
+                        folder to save debug images
+  --proj-func {hand_marker_proj_world_camera,world_marker_proj_hand_camera}
   ```
   
 Proper convergence should have very small loss (i.e., < 5).
@@ -108,7 +118,7 @@ A larger loss indicate
 * inaccurate robot forward kinematics
 * temporal misalignment between image and robot kinematics capture
 
-##  Sample Run
+##  Sample Run (world camera hand marker setting)
 ```
 $ collect_data_and_cal.py 
 Config: Namespace(calibration_file='calibration.pkl', datafile='caldata.pkl', imagedir=None, ip='100.96.135.68', overheadcam=False, overwrite=False, target_marker_id=9)

--- a/perception/sandbox/eyehandcal/scripts/collect_data_and_cal.py
+++ b/perception/sandbox/eyehandcal/scripts/collect_data_and_cal.py
@@ -129,7 +129,9 @@ if __name__ == '__main__':
     parser.add_argument('--imagedir', default=None, help="folder to save debug images")
     parser.add_argument('--pixel-tolerance', default=2.0, type=float, help="mean pixel error tolerance (stage 2)")
     proj_funcs = {'hand_marker_proj_world_camera' :hand_marker_proj_world_camera, 
-                  'world_marker_proj_hand_camera' :world_marker_proj_hand_camera}
+                  'world_marker_proj_hand_camera' :world_marker_proj_hand_camera,
+                  'wrist_camera': world_marker_proj_hand_camera,
+                  'world_camera': hand_marker_proj_world_camera}
     parser.add_argument('--proj-func', choices=list(proj_funcs.keys()), default = list(proj_funcs.keys())[0])
 
     args=parser.parse_args()

--- a/perception/sandbox/eyehandcal/scripts/collect_data_and_cal.py
+++ b/perception/sandbox/eyehandcal/scripts/collect_data_and_cal.py
@@ -6,6 +6,7 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
+from argparse import ArgumentError
 from math import pi
 import time
 import os 
@@ -20,7 +21,8 @@ from torchcontrol.transform import Rotation as R
 from polymetis import RobotInterface
 from realsense_wrapper import RealsenseAPI
 
-from eyehandcal.utils import detect_corners, quat2rotvec, build_proj_matrix, mean_loss, find_parameter, rotmat, dist_in_hull
+from eyehandcal.utils import detect_corners, quat2rotvec, build_proj_matrix, mean_loss, find_parameter, rotmat, dist_in_hull, \
+    hand_marker_proj_world_camera, world_marker_proj_hand_camera
 
 
 def realsense_images(max_pixel_diff=200):
@@ -125,10 +127,15 @@ if __name__ == '__main__':
     parser.add_argument('--num-points', default=20, type=int, help="number of points to sample from convex hull")
     parser.add_argument('--time-to-go', default=3, type=float, help="time_to_go in seconds for each movement")
     parser.add_argument('--imagedir', default=None, help="folder to save debug images")
-    parser.add_argument('--pixel-tolerance', default=2.0, help="mean pixel error tolerance (stage 2)")
+    parser.add_argument('--pixel-tolerance', default=2.0, type=float, help="mean pixel error tolerance (stage 2)")
+    proj_funcs = {'hand_marker_proj_world_camera' :hand_marker_proj_world_camera, 
+                 'world_marker_proj_hand_camera' :world_marker_proj_hand_camera}
+    parser.add_argument('--proj-func', choices=list(proj_funcs.keys()), default = list(proj_funcs.keys())[0])
 
     args=parser.parse_args()
     print(f"Config: {args}")
+
+    proj_func = proj_funcs[args.proj_func]
 
     np.random.seed(args.seed)
     torch.manual_seed(args.seed)
@@ -185,19 +192,24 @@ if __name__ == '__main__':
             continue
 
         # stage 1 - assuming marker is attach to EE origin, solve camera pose first
-        p3d = torch.stack([p[1] for p in obs_data_std]).detach().numpy()
+        if args.proj_func == "hand_marker_proj_world_camera":
+            p3d = torch.stack([p[1] for p in obs_data_std]).detach().numpy()
+        elif args.proj_func == "world_marker_proj_hand_camera":
+            p3d = torch.stack([rotmat(-p[2]).matmul(-p[1]) for p in obs_data_std]).detach().numpy()
+
         p2d = torch.stack([p[0] for p in obs_data_std]).detach().numpy()
         retval, rvec, tvec = cv2.solvePnP(p3d, p2d, K.numpy(), distCoeffs=None, flags=cv2.SOLVEPNP_SQPNP)
         rvec_cam = torch.tensor(-rvec.reshape(-1))
         tvec_cam = -rotmat(rvec_cam).matmul(torch.tensor(tvec.reshape(-1)))
-        pixel_error = mean_loss(obs_data_std, torch.cat([rvec_cam, tvec_cam, torch.zeros(3)]), K).item()
+        pixel_error = mean_loss(obs_data_std, torch.cat([rvec_cam, tvec_cam, torch.zeros(3)]), K, proj_func).item()
         print('stage 1 mean pixel error', pixel_error)
 
         # stage 2 - allow marker to move, joint optimize camera pose and marker
-        while pixel_error > args.pixel_tolerance:
+        while True :
             marker_max_displacement = 0.1 #meter
-            param=torch.tensor(torch.cat([rvec_cam, tvec_cam, torch.randn(3)*marker_max_displacement]).detach(), requires_grad=True)
-            L = lambda param: mean_loss(obs_data_std, param, K)
+            param=torch.cat([rvec_cam, tvec_cam, torch.randn(3)*marker_max_displacement]).clone().detach()
+            param.requires_grad=True
+            L = lambda param: mean_loss(obs_data_std, param, K, proj_func)
             try:
                 param_star=find_parameter(param, L)
             except Exception as e:
@@ -208,6 +220,8 @@ if __name__ == '__main__':
             print('stage 2 mean pixel error', pixel_error)
             if pixel_error > args.pixel_tolerance:
                 print(f"Try again because of poor solution {pixel_error} > {args.pixel_tolerance}")
+            else:
+                break
             
 
         print(f"Good solution {pixel_error} <= {args.pixel_tolerance}")
@@ -216,14 +230,26 @@ if __name__ == '__main__':
     with torch.no_grad():
         param_list = []
         for i, param in enumerate(params):
-            camera_base_ori_rotvec = param[:3]
-            camera_base_ori = rotmat(camera_base_ori_rotvec)
-            result = {
-                "camera_base_ori": camera_base_ori.cpu().numpy().tolist(),
-                "camera_base_ori_rotvec": camera_base_ori_rotvec.cpu().numpy().tolist(),
-                "camera_base_pos": param[3:6].cpu().numpy().tolist(),
-                "p_marker_ee": param[6:9].cpu().numpy().tolist(),
-            }
+            if args.proj_func == "world_marker_proj_hand_camera":
+                result = {
+                    "proj_func": args.proj_func,
+                    "camera_ee_ori_rotvec": param[:3].numpy().tolist(),
+                    "camera_ee_pos" : param[3:6].numpy().tolist(),
+                    "marker_base_pos": param[6:9].numpy().tolist()
+                }
+            elif args.proj_func == "hand_marker_proj_world_camera":
+                camera_base_ori_rotvec = param[:3]
+                camera_base_ori = rotmat(camera_base_ori_rotvec)
+                result = {
+                    "proj_func": args.proj_func,
+                    "camera_base_ori": camera_base_ori.cpu().numpy().tolist(),
+                    "camera_base_ori_rotvec": camera_base_ori_rotvec.cpu().numpy().tolist(),
+                    "camera_base_pos": param[3:6].cpu().numpy().tolist(),
+                    "p_marker_ee": param[6:9].cpu().numpy().tolist(),
+                }
+            else:
+                raise ArgumentError("shouldn't reach here")
+
             param_list.append(result)
             print(f"Camera {i} calibration: {result}")
         

--- a/perception/sandbox/eyehandcal/scripts/collect_data_and_cal.py
+++ b/perception/sandbox/eyehandcal/scripts/collect_data_and_cal.py
@@ -129,7 +129,7 @@ if __name__ == '__main__':
     parser.add_argument('--imagedir', default=None, help="folder to save debug images")
     parser.add_argument('--pixel-tolerance', default=2.0, type=float, help="mean pixel error tolerance (stage 2)")
     proj_funcs = {'hand_marker_proj_world_camera' :hand_marker_proj_world_camera, 
-                 'world_marker_proj_hand_camera' :world_marker_proj_hand_camera}
+                  'world_marker_proj_hand_camera' :world_marker_proj_hand_camera}
     parser.add_argument('--proj-func', choices=list(proj_funcs.keys()), default = list(proj_funcs.keys())[0])
 
     args=parser.parse_args()

--- a/perception/sandbox/eyehandcal/src/eyehandcal/utils.py
+++ b/perception/sandbox/eyehandcal/src/eyehandcal/utils.py
@@ -65,7 +65,7 @@ def build_proj_matrix(fx, fy, ppx, ppy, coeff=None):
                                 [0., 0.,  1.]])
 
 
-def marker_proj(param, pos_ee_base, ori_ee_base, K):
+def hand_marker_proj_world_camera(param, pos_ee_base, ori_ee_base, K):
     camera_base_ori = param[:3]
     camera_base_pos = param[3:6]
     p_marker_ee = param[6:9]
@@ -74,21 +74,29 @@ def marker_proj(param, pos_ee_base, ori_ee_base, K):
     p_marker_image = K.matmul(p_marker_camera)
     return p_marker_image[:2]/p_marker_image[2]
 
+def world_marker_proj_hand_camera(param, pos_ee_base, ori_ee_base, K):
+    ori_camera_ee = param[:3]
+    pos_camera_ee = param[3:6]
+    pos_marker_base = param[6:9]
+    pos_marker_camera = rotmat(-ori_camera_ee).matmul(
+            (rotmat(-ori_ee_base).matmul(pos_marker_base - pos_ee_base)-pos_camera_ee))
+    pos_marker_image = K.matmul(pos_marker_camera)
+    return pos_marker_image[:2]/pos_marker_image[2]
 
 
-def pointloss(param, obs_marker_2d, pos_ee_base, ori_ee_base, K):
-    proj_marker_2d = marker_proj(param, pos_ee_base, ori_ee_base, K)
+def pointloss(param, obs_marker_2d, pos_ee_base, ori_ee_base, K, proj_func):
+    proj_marker_2d = proj_func(param, pos_ee_base, ori_ee_base, K)
     return (obs_marker_2d - proj_marker_2d).norm()
 
 
 
-def mean_loss(data, param, K):
+def mean_loss(data, param, K, proj_func=hand_marker_proj_world_camera):
     losses = []
     for d in data:
         corner = d[0]
         ee_base_pos = d[1]
         ee_base_ori = d[2]
-        ploss = pointloss(param, corner, ee_base_pos, ee_base_ori, K)
+        ploss = pointloss(param, corner, ee_base_pos, ee_base_ori, K, proj_func)
         losses.append(ploss)
     return torch.stack(losses).mean()
 

--- a/perception/sandbox/eyehandcal/tests/test_cal.py
+++ b/perception/sandbox/eyehandcal/tests/test_cal.py
@@ -10,7 +10,7 @@ import torch
 import pickle
 torch.set_printoptions(linewidth=160)
 from eyehandcal.utils import detect_corners, build_proj_matrix, sim_data, mean_loss, \
-    quat2rotvec, find_parameter, marker_proj, rotmat
+    quat2rotvec, find_parameter, rotmat, hand_marker_proj_world_camera
 
 import pytest
 import cv2
@@ -125,7 +125,7 @@ def test_plot_reproj_error(params_from_data, collected_data):
         err=[]
         for obs_marker, pos_ee_base, ori_ee_base in obs_data_std:
             with torch.no_grad():
-                proj_marker = marker_proj(params_from_data[camera_index], pos_ee_base, ori_ee_base, K)
+                proj_marker = hand_marker_proj_world_camera(params_from_data[camera_index], pos_ee_base, ori_ee_base, K)
             
             err.append((proj_marker-obs_marker).norm())
             plt.plot((obs_marker[0], proj_marker[0]),


### PR DESCRIPTION
# Description

Support a new setting for eyehand calibration: wrist camera calibration using a fixed marker in robot base frame.

* Add a new command line option `--proj-func {hand_marker_proj_world_camera,world_marker_proj_hand_camera}` to specify the `world_marker_proj_hand_camera` use case.
* The output calibration.json now contain 
  * a "proj_func" field indicating the setting used during calibration
  * a "pixel_error" field indicating the quality of the calibration for this camera

* Add testcases for collect_data_and_cal.py from realworld data.

## Sample execution result
```
(eyehandcal) tingfan@perception:~/github/fairo/perception/sandbox/eyehandcal$ collect_data_and_cal.py  --datafile caldataNew.pkl --marker-id 1 --proj-func world_marker_proj_hand_camera
Config: Namespace(calibration_file='calibration.json', datafile='caldataNew.pkl', imagedir=None, ip='100.96.135.68', marker_id=1, num_points=20, overwrite=False, pixel_tolerance=2.0, points_file='calibration_points.json', proj_func='world_marker_proj_hand_camera', seed=0, time_to_go=3)
Warning: datafile caldataNew.pkl already exists. Loading data instead of collecting data...
Done. Data has 100 poses.
Solve camera 0/1 pose
number of images with keypoint 99
stage 1 mean pixel error 28.687245439629173
stage 2 mean pixel error 1.2076883491182768
Good solution 1.2076883491182768 <= 2.0
Camera 0 calibration: {'proj_func': 'world_marker_proj_hand_camera', 'camera_ee_ori_rotvec': [-0.0533591361279038, -0.02723116674277641, 0.8119656021495493], 'camera_ee_pos': [0.03316384837244427, -0.08234773892713702, 0.027100460893550952], 'marker_base_pos': [0.5556270121252427, 0.0012146942266407848, 0.003037030620487715]}
Saving calibrated parameters to calibration.json
```

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

If this PR introduces a change or fixes a bug, please add before and after screenshots (if this is causes a UX change) or before and after examples(this could be plain text, videos etc ) to demonstrate the change.

If this PR introduces a new feature, please also add examples or screenshots demonstrating the feature.

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
