### PR TITLE
Lighter memory

### DIFF
--- a/agents/craftassist/tests/fake_agent.py
+++ b/agents/craftassist/tests/fake_agent.py
@@ -75,7 +75,9 @@ class FakeAgent(DroidletAgent):
         prebuilt_perception=None,
         low_level_data=None,
         use_place_field=True,
+        prebuilt_db=None,
     ):
+        self.prebuilt_db = prebuilt_db
         self.use_place_field = use_place_field
         self.mark_airtouching_blocks = do_heuristic_perception
         self.head_height = HEAD_HEIGHT
@@ -430,6 +432,7 @@ class FakePlayer(FakeAgent):
         active=True,
         low_level_data=None,
         use_place_field=False,
+        prebuilt_db=None,
     ):
         class NubWorld:
             def __init__(self):
@@ -441,6 +444,7 @@ class FakePlayer(FakeAgent):
             do_heuristic_perception=do_heuristic_perception,
             low_level_data=low_level_data,
             use_place_field=use_place_field,
+            prebuilt_db=prebuilt_db,
         )
         # if active is set to false, the fake player's step is passed.
         self.active = active

--- a/agents/craftassist/tests/fake_agent.py
+++ b/agents/craftassist/tests/fake_agent.py
@@ -74,7 +74,9 @@ class FakeAgent(DroidletAgent):
         do_heuristic_perception=False,
         prebuilt_perception=None,
         low_level_data=None,
+        use_place_field=True,
     ):
+        self.use_place_field = use_place_field
         self.mark_airtouching_blocks = do_heuristic_perception
         self.head_height = HEAD_HEIGHT
         self.world = world
@@ -133,13 +135,15 @@ class FakeAgent(DroidletAgent):
         T = FakeMCTime(self.world)
         low_level_data = self.low_level_data.copy()
         low_level_data["check_inside"] = heuristic_perception.check_inside
-
-        self.memory = MCAgentMemory(
-            load_minecraft_specs=False,
-            coordinate_transforms=self.coordinate_transforms,
-            agent_time=T,
-            agent_low_level_data=low_level_data,
-        )
+        kwargs = {
+            "load_minecraft_specs": False,
+            "coordinate_transforms": self.coordinate_transforms,
+            "agent_time": T,
+            "agent_low_level_data": low_level_data,
+        }
+        if not self.use_place_field:
+            kwargs["place_field_pixels_per_unit"] = -1
+        self.memory = MCAgentMemory(**kwargs)
         # Add dances to memory
         dance.add_default_dances(self.memory)
 
@@ -424,12 +428,20 @@ class FakePlayer(FakeAgent):
         get_world_pos=False,
         name="",
         active=True,
+        low_level_data=None,
+        use_place_field=False,
     ):
         class NubWorld:
             def __init__(self):
                 self.count = 0
 
-        super().__init__(NubWorld(), opts=opts, do_heuristic_perception=do_heuristic_perception)
+        super().__init__(
+            NubWorld(),
+            opts=opts,
+            do_heuristic_perception=do_heuristic_perception,
+            low_level_data=low_level_data,
+            use_place_field=use_place_field,
+        )
         # if active is set to false, the fake player's step is passed.
         self.active = active
         self.get_world_pos = get_world_pos

--- a/agents/craftassist/tests/fake_agent.py
+++ b/agents/craftassist/tests/fake_agent.py
@@ -145,6 +145,8 @@ class FakeAgent(DroidletAgent):
         }
         if not self.use_place_field:
             kwargs["place_field_pixels_per_unit"] = -1
+        if self.prebuilt_db is not None:
+            kwargs["copy_from_backup"] = self.prebuilt_db
         self.memory = MCAgentMemory(**kwargs)
         # Add dances to memory
         dance.add_default_dances(self.memory)

--- a/droidlet/lowlevel/minecraft/pyworld/fake_mobs.py
+++ b/droidlet/lowlevel/minecraft/pyworld/fake_mobs.py
@@ -101,9 +101,9 @@ class SimpleMob:
     def step(self):
         # check if falling:
         x, y, z = self.world.to_world_coords(self.pos)
-        fy = int(np.floor(y))
-        rx = int(np.round(x))
-        rz = int(np.round(z))
+        fy = min(max(int(np.floor(y)), 0), self.world.blocks.shape[1])
+        rx = min(max(int(np.round(x)), 0), self.world.blocks.shape[0] - 1)
+        rz = min(max(int(np.round(z)), 0), self.world.blocks.shape[2] - 1)
         if y > 0:
             if self.world.blocks[rx, fy - 1, rz, 0] == 0:
                 self.pos = (self.pos[0], self.pos[1] - FALL_SPEED, self.pos[2])

--- a/droidlet/memory/craftassist/mc_memory.py
+++ b/droidlet/memory/craftassist/mc_memory.py
@@ -84,6 +84,7 @@ class MCAgentMemory(AgentMemory):
         self.perception_range = preception_range
         if copy_from_backup is not None:
             copy_from_backup.backup(self.db)
+            self.make_self_mem()
         else:
             self._load_schematics(
                 schematics=agent_low_level_data.get("schematics", {}),

--- a/droidlet/memory/craftassist/mc_memory.py
+++ b/droidlet/memory/craftassist/mc_memory.py
@@ -6,7 +6,7 @@ import os
 import random
 from collections import namedtuple
 from typing import Optional, List
-from droidlet.memory.sql_memory import AgentMemory
+from droidlet.memory.sql_memory import AgentMemory, DEFAULT_PIXELS_PER_UNIT
 from droidlet.base_util import diag_adjacent, IDM, XYZ, Block, npy_to_blocks_list
 from droidlet.memory.memory_nodes import (  # noqa
     TaskNode,
@@ -63,6 +63,8 @@ class MCAgentMemory(AgentMemory):
         agent_time=None,
         coordinate_transforms=None,
         agent_low_level_data={},
+        place_field_pixels_per_unit=DEFAULT_PIXELS_PER_UNIT,
+        copy_from_backup=None,
     ):
         super(MCAgentMemory, self).__init__(
             db_file=db_file,
@@ -71,30 +73,33 @@ class MCAgentMemory(AgentMemory):
             nodelist=NODELIST,
             agent_time=agent_time,
             coordinate_transforms=coordinate_transforms,
+            place_field_pixels_per_unit=place_field_pixels_per_unit,
         )
         self.low_level_block_data = agent_low_level_data.get("block_data", {})
         self.banned_default_behaviors = []  # FIXME: move into triple store?
         self._safe_pickle_saved_attrs = {}
         self.schematics = {}
         self.check_inside_perception = agent_low_level_data.get("check_inside", None)
-
-        self._load_schematics(
-            schematics=agent_low_level_data.get("schematics", {}),
-            block_data=agent_low_level_data.get("block_data", {}),
-            load_minecraft_specs=load_minecraft_specs,
-        )
-        self._load_block_types(
-            block_data=agent_low_level_data.get("block_data", {}),
-            color_data=agent_low_level_data.get("color_data", {}),
-            block_property_data=agent_low_level_data.get("block_property_data", {}),
-            load_block_types=load_block_types,
-        )
-        self._load_mob_types(
-            mobs=agent_low_level_data.get("mobs", {}),
-            mob_property_data=agent_low_level_data.get("mob_property_data", {}),
-        )
         self.dances = {}
         self.perception_range = preception_range
+        if copy_from_backup is not None:
+            copy_from_backup.backup(self.db)
+        else:
+            self._load_schematics(
+                schematics=agent_low_level_data.get("schematics", {}),
+                block_data=agent_low_level_data.get("block_data", {}),
+                load_minecraft_specs=load_minecraft_specs,
+            )
+            self._load_block_types(
+                block_data=agent_low_level_data.get("block_data", {}),
+                color_data=agent_low_level_data.get("color_data", {}),
+                block_property_data=agent_low_level_data.get("block_property_data", {}),
+                load_block_types=load_block_types,
+            )
+            self._load_mob_types(
+                mobs=agent_low_level_data.get("mobs", {}),
+                mob_property_data=agent_low_level_data.get("mob_property_data", {}),
+            )
 
     ############################################
     ### Update world with perception updates ###

--- a/droidlet/memory/place_field.py
+++ b/droidlet/memory/place_field.py
@@ -320,6 +320,24 @@ class PlaceField:
         return val
 
 
+class EmptyPlaceField:
+    """
+    this will be used as a dummy instead of regular PlaceField
+    """
+
+    def sync_traversible(self, locs, h=0):
+        pass
+
+    def update_map(self, changes):
+        pass
+
+    def get_closest(self):
+        return None
+
+    def get_obstacle_list(self):
+        return []
+
+
 if __name__ == "__main__":
     W = {0: {0: {0: True}, 1: {2: {3: True}}}, 1: {5: True}}
     idxs = [0, 1, 2, 3]

--- a/droidlet/memory/sql_memory.py
+++ b/droidlet/memory/sql_memory.py
@@ -18,7 +18,7 @@ from droidlet.shared_data_structs import Time
 from droidlet.memory.memory_filters import MemorySearcher
 from droidlet.event import dispatch
 from droidlet.memory.memory_util import parse_sql, format_query
-from droidlet.memory.place_field import PlaceField
+from droidlet.memory.place_field import PlaceField, EmptyPlaceField
 
 from droidlet.memory.memory_nodes import (  # noqa
     TaskNode,
@@ -137,7 +137,10 @@ class AgentMemory:
         self.tag(self.self_memid, "SELF")
 
         self.searcher = MemorySearcher()
-        self.place_field = PlaceField(self, pixels_per_unit=place_field_pixels_per_unit)
+        if place_field_pixels_per_unit > 0:
+            self.place_field = PlaceField(self, pixels_per_unit=place_field_pixels_per_unit)
+        else:
+            self.place_field = EmptyPlaceField()
 
     def __del__(self):
         """Close the database file"""

--- a/droidlet/memory/sql_memory.py
+++ b/droidlet/memory/sql_memory.py
@@ -124,17 +124,7 @@ class AgentMemory:
                 if node in possible_child.__mro__:
                     self.node_children[node.NODE_TYPE].append(possible_child.NODE_TYPE)
 
-        # create a "self" memory to reference in Triples
-        self.self_memid = "0" * len(uuid.uuid4().hex)
-        self.db_write(
-            "INSERT INTO Memories VALUES (?,?,?,?,?,?)", self.self_memid, "Self", 0, 0, -1, False
-        )
-        self.tag(self.self_memid, "_physical_object")
-        self.tag(self.self_memid, "_animate")
-        # this is a hack until memory_filters does "not"
-        self.tag(self.self_memid, "_not_location")
-        self.tag(self.self_memid, "AGENT")
-        self.tag(self.self_memid, "SELF")
+        self.make_self_mem()
 
         self.searcher = MemorySearcher()
         if place_field_pixels_per_unit > 0:
@@ -146,6 +136,18 @@ class AgentMemory:
         """Close the database file"""
         if getattr(self, "_db_log_file", None):
             self._db_log_file.close()
+
+    def make_self_mem(self):
+        # create a "self" memory to reference in Triples
+        self.self_memid = "0" * len(uuid.uuid4().hex)
+        self.db_write(
+            "INSERT INTO Memories VALUES (?,?,?,?,?,?)", self.self_memid, "Self", 0, 0, -1, False
+        )
+        self.tag(self.self_memid, "_physical_object")
+        self.tag(self.self_memid, "_animate")
+        self.tag(self.self_memid, "_not_location")
+        self.tag(self.self_memid, "AGENT")
+        self.tag(self.self_memid, "SELF")
 
     def init_time_interface(self, agent_time=None):
         """Initialiaze the current time in memory


### PR DESCRIPTION
# Description

several bundled changes to allow fake agent in craftassist to take less time on init for nsm project and simulations

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After
Several pieces of memory (the place field, the block info etc.) are made optional.  also some machinery is added to directly replace the sql db with one given at init

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
