### PR TITLE
Twitchy bugfix

### DIFF
--- a/droidlet/base_util.py
+++ b/droidlet/base_util.py
@@ -77,10 +77,10 @@ def shasum_file(path):
     """Return shasum of the file at a given path"""
     sha = hashlib.sha1()
     with open(path, "rb") as f:
-        block = f.read(2**16)
+        block = f.read(2 ** 16)
         while len(block) != 0:
             sha.update(block)
-            block = f.read(2**16)
+            block = f.read(2 ** 16)
     return binascii.hexlify(sha.digest())
 
 
@@ -140,7 +140,7 @@ def prepend_a_an(name):
 
 def to_block_pos(array):
     """Convert array to block position"""
-    return np.floor(array).astype("int32")
+    return np.round(array).astype("int32")
 
 
 def to_block_center(array):

--- a/droidlet/lowlevel/minecraft/craftassist_mover.py
+++ b/droidlet/lowlevel/minecraft/craftassist_mover.py
@@ -18,19 +18,25 @@ Item = namedtuple("Item", "id, meta")
 ItemStack = namedtuple("ItemStack", "item, pos, entityId")
 
 
-def flip_x(struct):
-    return Pos(-struct.x, struct.y, struct.z)
+def flip_x(struct, floor=False):
+    x, y, z = struct.x, struct.y, struct.z
+    if floor:
+        x = float(np.floor(x))
+        y = float(np.floor(y))
+        z = float(np.floor(z))
+    return Pos(-x, y, z)
 
 
 def flip_look(struct):
     return Look(-struct.yaw, -struct.pitch)
 
 
-def maybe_flip_x_or_look(struct):
+def maybe_flip_x_or_look(struct, floor=False):
     """
     struct is either a Mob, a Player, a Pos, or a Look
     we make a copy with the x negated if the struct is or has a Pos
     and with the yaw and pitch negated if the struct is or has a Look
+    if floor=True, will also floor pos in cagent world.
     """
     if getattr(struct, "x", None):
         return flip_x(struct)
@@ -46,7 +52,7 @@ def maybe_flip_x_or_look(struct):
         return Player(
             struct.entityId,
             struct.name,
-            flip_x(struct.pos),
+            flip_x(struct.pos, floor=floor),
             flip_look(struct.look),
             struct.mainHand,
             struct,
@@ -108,10 +114,12 @@ class CraftassistMover:
         self.get_line_of_sight = struct_transform(self.cagent.get_line_of_sight)
         self.get_item_stacks = struct_transform(self.cagent.get_item_stacks)
         self.get_item_stack = struct_transform(self.cagent.get_item_stack)
-        self.get_player = struct_transform(self.cagent.get_player)
         self.get_mobs = struct_transform(self.cagent.get_mobs)
         self.get_other_players = struct_transform(self.cagent.get_other_players)
         self.get_other_player_by_name = struct_transform(self.cagent.get_other_player_by_name)
+
+    def get_player(self):
+        return maybe_flip_x_or_look(self.cagent.get_player(), floor=True)
 
     @struct_transform
     def get_player_line_of_sight(self, player_struct):

--- a/droidlet/lowlevel/minecraft/craftassist_mover.py
+++ b/droidlet/lowlevel/minecraft/craftassist_mover.py
@@ -134,10 +134,10 @@ class CraftassistMover:
             return self.cagent.get_player_line_of_sight(player_struct)
 
     def dig(self, x, y, z):
-        self.cagent.dig(-x, y, z)
+        return self.cagent.dig(-x, y, z)
 
     def place_block(self, x, y, z):
-        self.cagent.place_block(-x, y, z)
+        return self.cagent.place_block(-x, y, z)
 
     def get_changed_blocks(self):
         blocks = self.cagent.get_changed_blocks()

--- a/droidlet/lowlevel/minecraft/craftassist_mover.py
+++ b/droidlet/lowlevel/minecraft/craftassist_mover.py
@@ -134,7 +134,7 @@ class CraftassistMover:
             return self.cagent.get_player_line_of_sight(player_struct)
 
     def dig(self, x, y, z):
-        self.cagent.place_block(-x, y, z)
+        self.cagent.dig(-x, y, z)
 
     def place_block(self, x, y, z):
         self.cagent.place_block(-x, y, z)


### PR DESCRIPTION
# Description
I introduced several bugs in craftassist agent when wrapping cagent in craftassist_mover.  this fixes these:
1: sneaky rounding bug- because x is flipped in cuberite, rounding down in cuberite is rounding up in droidlet
2: fix dig to use cagent dig instead cagent place 0 block
3: forgot to return the result of cagent dig and cagent block place, so constructions weren't getting tagged 

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [x] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
