### PR TITLE
mrp add content-type for stdout

### DIFF
--- a/mrp/setup.py
+++ b/mrp/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="mrp",
-    version="0.1.7",
+    version="0.1.8",
     author="Leonid Shamis",
     package_dir={"": "src"},
     packages=find_packages(

--- a/mrp/src/mrp/util.py
+++ b/mrp/src/mrp/util.py
@@ -29,22 +29,22 @@ def common_env_context(proc_def):
         os.environ.update(old_environ)
 
 
-def stdout_logger():
+def _make_plaintext_logger(logger_callback):
     logger = a0.Logger(a0.env.topic())
 
     def write(msg):
-        logger.info(msg)
+        pkt = a0.Packet([("content-type", "text/plain")], msg)
+        logger_callback(logger, pkt)
 
     return write
+
+
+def stdout_logger():
+    return _make_plaintext_logger(lambda logger, pkt: logger.info(pkt))
 
 
 def stderr_logger():
-    logger = a0.Logger(a0.env.topic())
-
-    def write(msg):
-        logger.err(msg)
-
-    return write
+    return _make_plaintext_logger(lambda logger, pkt: logger.err(pkt))
 
 
 def pid_children(pid):


### PR DESCRIPTION
# Description

MRP add "content-type"="text/plain" to all stdout/stderr logs collected from processes.

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

# Testing

Manually testing + existing unit tests.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
