### PR TITLE
hacks to fix radians/degrees bug

### DIFF
--- a/agents/craftassist/craftassist_agent.py
+++ b/agents/craftassist/craftassist_agent.py
@@ -357,11 +357,12 @@ class CraftAssistAgent(DroidletAgent):
     ###FIXME!!
     #    self.get_incoming_chats = self.get_chats
 
+    # WARNING!! this is in degrees.  agent's memory stores looks in radians.
+    # FIXME: normalize, switch in DSL to radians.
     def relative_head_pitch(self, angle):
         """Converts assistant's current pitch and yaw
         into a pitch and yaw relative to the angle."""
-        # warning: pitch is flipped!
-        new_pitch = self.get_player().look.pitch - angle
+        new_pitch = np.rad2deg(self.get_player().look.pitch) - angle
         self.set_look(self.get_player().look.yaw, new_pitch)
 
     def send_chat(self, chat: str):
@@ -370,7 +371,9 @@ class CraftAssistAgent(DroidletAgent):
         chat_json = False
         try:
             chat_json = json.loads(chat)
-            chat_text = list(filter(lambda x: x["id"] == "text", chat_json["content"]))[0]["content"]
+            chat_text = list(filter(lambda x: x["id"] == "text", chat_json["content"]))[0][
+                "content"
+            ]
         except:
             chat_text = chat
 
@@ -379,7 +382,7 @@ class CraftAssistAgent(DroidletAgent):
 
         if chat_json:
             chat_json["chat_memid"] = chat_memid
-            chat_json["timestamp"] = round(datetime.timestamp(datetime.now())*1000)
+            chat_json["timestamp"] = round(datetime.timestamp(datetime.now()) * 1000)
             # Send the socket event to show this reply on dashboard
             sio.emit("showAssistantReply", chat_json)
         else:

--- a/droidlet/documents/logical_form_specification/agent_dsl.md
+++ b/droidlet/documents/logical_form_specification/agent_dsl.md
@@ -275,7 +275,7 @@ Note: for "relative_direction" == 'BETWEEN' the location dict will have two chil
 </pre>
 
 The specificatition sets positive yaw to be rotations to the left and negative yaw to be rotations to the right;
-and positive pitch up (90) and negative pitch down (-90).
+and positive pitch up (90) and negative pitch down (-90).  TODO switch all angular fixed values to radians.
 	
 #### DanceType ####
 <pre>

--- a/droidlet/interpreter/craftassist/interpret_facing.py
+++ b/droidlet/interpreter/craftassist/interpret_facing.py
@@ -25,8 +25,8 @@ def number_from_span(span):
     return degrees
 
 
-# WARNING: everything here is in degrees. In the Task they will be switched to
-# radians.  TODO: change fixed values in DSL to be radians
+# WARNING: everything here is in degrees.
+# TODO: change fixed values in DSL to be radians
 class FacingInterpreter:
     def __call__(self, interpreter, speaker, d):
         self_mem = interpreter.memory.get_mem_by_id(interpreter.memory.self_memid)

--- a/droidlet/interpreter/craftassist/interpret_facing.py
+++ b/droidlet/interpreter/craftassist/interpret_facing.py
@@ -1,6 +1,7 @@
 """
 Copyright (c) Facebook, Inc. and its affiliates.
 """
+import numpy as np
 from droidlet.shared_data_structs import ErrorWithResponse
 from droidlet.interpreter import interpret_relative_direction
 from droidlet.interpreter.facing_utils import number_from_span, interpret_relative_yaw
@@ -24,10 +25,15 @@ def number_from_span(span):
     return degrees
 
 
+# WARNING: everything here is in degrees. In the Task they will be switched to
+# radians.  TODO: change fixed values in DSL to be radians
 class FacingInterpreter:
     def __call__(self, interpreter, speaker, d):
         self_mem = interpreter.memory.get_mem_by_id(interpreter.memory.self_memid)
         current_yaw, current_pitch = self_mem.get_yaw_pitch()
+        # WARNING:
+        current_yaw = np.rad2deg(current_yaw)
+        current_pitch = np.rad2deg(current_pitch)
         if d.get("yaw_pitch"):
             span = d["yaw_pitch"]
             # for now assumed in (yaw, pitch) or yaw, pitch or yaw pitch formats

--- a/droidlet/interpreter/craftassist/tasks.py
+++ b/droidlet/interpreter/craftassist/tasks.py
@@ -101,6 +101,9 @@ class DanceMove(Task):
         agent = self.agent
         if self.finished:
             return
+        # WARNING: these are in degrees to match MC and DSL;
+        # memory stores angles in radians; but these are give by interpreter in angles
+        # FIXME change DSL to use radians for fixed values and convert everything to radians
         if self.relative_yaw:
             agent.turn_angle(self.relative_yaw)
         if self.relative_pitch:
@@ -108,8 +111,7 @@ class DanceMove(Task):
         if self.head_xyz is not None:
             agent.look_at(self.head_xyz[0], self.head_xyz[1], self.head_xyz[2])
         elif self.head_yaw_pitch is not None:
-            # warning: pitch is flipped!  client uses -pitch for up,
-            agent.set_look(self.head_yaw_pitch[0], -self.head_yaw_pitch[1])
+            agent.set_look(self.head_yaw_pitch[0], self.head_yaw_pitch[1])
 
         if self.translate:
             step = self.STEP_FNS[self.translate]

--- a/droidlet/lowlevel/minecraft/craftassist_mover.py
+++ b/droidlet/lowlevel/minecraft/craftassist_mover.py
@@ -28,7 +28,9 @@ def flip_x(struct, floor=False):
 
 
 def flip_look(struct):
-    return Look(-struct.yaw, -struct.pitch)
+    yaw = -np.deg2rad(struct.yaw)
+    pitch = -np.deg2rad(struct.pitch)
+    return Look(yaw, pitch)
 
 
 def maybe_flip_x_or_look(struct, floor=False):
@@ -148,12 +150,11 @@ class CraftassistMover:
 
     # FIXME!! turn_angle is broken in the cagent; should be swapping here,
     # but cagent actually has it backwards
-    # turn_angle isn't being used in other parts of agent.
     def turn_angle(self, yaw):
         self.cagent.turn_angle(yaw)
 
     def set_look(self, yaw, pitch):
-        self.cagent.set_look(-yaw, pitch)
+        self.cagent.set_look(-yaw, -pitch)
 
     def look_at(self, x, y, z):
         self.cagent.look_at(-x, y, z)
@@ -257,8 +258,8 @@ def from_droidlet_xyz_to_minecraft(xyz):
 
 
 def from_minecraft_look_to_droidlet(look):
-    return Look(-look.yaw, look.pitch)
+    return Look(-look.yaw, -look.pitch)
 
 
 def from_droidlet_look_to_craftassist(look):
-    return Look(-look.yaw, look.pitch)
+    return Look(-look.yaw, -look.pitch)


### PR DESCRIPTION
# Description
craftassist used degrees internally; and when I switched to the shared rotations file between craftassist and robot I missed some degree/radian conversions.  droidlet should be using radians internally now.   In the future, we should probably update the DSL to output fixed values of the form "-PI", "-3PI/4", ... etc. instead of named degrees. 
 
Fixes # (issue)
several issues with question answering and otherwise subselecting reference objects based on SPEAKER_LOOK

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

If this PR introduces a change or fixes a bug, please add before and after screenshots (if this is causes a UX change) or before and after examples(this could be plain text, videos etc ) to demonstrate the change.

If this PR introduces a new feature, please also add examples or screenshots demonstrating the feature.

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
