### PR TITLE
[Hello] Add optional ROS driver, hook up Hector SLAM for base odometry

### DIFF
--- a/droidlet/lowlevel/hello_robot/hello_robot_mover.py
+++ b/droidlet/lowlevel/hello_robot/hello_robot_mover.py
@@ -217,7 +217,7 @@ class HelloRobotMover(MoverInterface):
         """reset the camera to 0 pan and tilt."""
         return self.bot.reset()
 
-    def move_relative(self, xyt_positions, blocking=True):
+    def move_relative(self, xyt_positions, blocking=True, distance_threshold=None, angle_threshold=None):
         """Command to execute a relative move.
 
         Args:
@@ -229,11 +229,11 @@ class HelloRobotMover(MoverInterface):
             xyt_positions = [xyt_positions]
         for xyt in xyt_positions:
             self.nav_result.wait()
-            self.nav_result = safe_call(self.nav.go_to_relative, xyt)
+            self.nav_result = safe_call(self.nav.go_to_relative, xyt, 10000000000, distance_threshold, angle_threshold)
             if blocking:
                 self.nav_result.wait()
 
-    def move_absolute(self, xzt_positions, blocking=True):
+    def move_absolute(self, xzt_positions, blocking=True, distance_threshold=None, angle_threshold=None):
         """Command to execute a move to an absolute position.
 
         It receives positions in canonical world coordinates and converts them to pyrobot's coordinates
@@ -250,7 +250,7 @@ class HelloRobotMover(MoverInterface):
             logging.info("Move absolute in canonical coordinates {}".format(xzt))
             self.nav_result.wait()
             robot_coords = base_canonical_coords_to_pyrobot_coords(xzt)
-            self.nav_result = self.nav.go_to_absolute(robot_coords)
+            self.nav_result = self.nav.go_to_absolute(robot_coords, 10000000000, distance_threshold, angle_threshold)
             if blocking:
                 self.nav_result.wait()
         return "finished"

--- a/droidlet/lowlevel/hello_robot/hello_robot_mover.py
+++ b/droidlet/lowlevel/hello_robot/hello_robot_mover.py
@@ -225,6 +225,14 @@ class HelloRobotMover(MoverInterface):
         Args:
             xzt_positions: a list of relative (x,y,yaw) positions for the bot to execute.
             x,y,yaw are in the pyrobot's coordinates.
+            distance_threshold: the distance resolution (in metres) for the move to be deemed successful
+                                If distance_threshold=0.1, and you ask the robot to move 0.5, then
+                                if the robot moves 0.4 or 0.6, it still
+                                exits the navigation with a success
+            angle_threshold: the angle resolution (in degrees) for the move to be deemed successful
+                                If angle_threshold=5, and you ask the robot to rotate 30 degrees, then
+                                if the robot rotates 25 or 35 degrees, it still
+                                exits the navigation with a success
         """
         if not isinstance(next(iter(xyt_positions)), Iterable):
             # single xyt position given
@@ -232,7 +240,9 @@ class HelloRobotMover(MoverInterface):
         for xyt in xyt_positions:
             self.nav_result.wait()
             self.nav_result = safe_call(
-                self.nav.go_to_relative, xyt, 10000000000, distance_threshold, angle_threshold
+                self.nav.go_to_relative, goal=xyt,
+                distance_threshold=distance_threshold,
+                angle_threshold=angle_threshold
             )
             if blocking:
                 self.nav_result.wait()
@@ -257,7 +267,9 @@ class HelloRobotMover(MoverInterface):
             self.nav_result.wait()
             robot_coords = base_canonical_coords_to_pyrobot_coords(xzt)
             self.nav_result = self.nav.go_to_absolute(
-                robot_coords, 10000000000, distance_threshold, angle_threshold
+                goal=robot_coords,
+                distance_threshold=distance_threshold,
+                angle_threshold=angle_threshold
             )
             if blocking:
                 self.nav_result.wait()

--- a/droidlet/lowlevel/hello_robot/hello_robot_mover.py
+++ b/droidlet/lowlevel/hello_robot/hello_robot_mover.py
@@ -240,9 +240,10 @@ class HelloRobotMover(MoverInterface):
         for xyt in xyt_positions:
             self.nav_result.wait()
             self.nav_result = safe_call(
-                self.nav.go_to_relative, goal=xyt,
+                self.nav.go_to_relative,
+                goal=xyt,
                 distance_threshold=distance_threshold,
-                angle_threshold=angle_threshold
+                angle_threshold=angle_threshold,
             )
             if blocking:
                 self.nav_result.wait()
@@ -269,7 +270,7 @@ class HelloRobotMover(MoverInterface):
             self.nav_result = self.nav.go_to_absolute(
                 goal=robot_coords,
                 distance_threshold=distance_threshold,
-                angle_threshold=angle_threshold
+                angle_threshold=angle_threshold,
             )
             if blocking:
                 self.nav_result.wait()

--- a/droidlet/lowlevel/hello_robot/hello_robot_mover.py
+++ b/droidlet/lowlevel/hello_robot/hello_robot_mover.py
@@ -217,7 +217,9 @@ class HelloRobotMover(MoverInterface):
         """reset the camera to 0 pan and tilt."""
         return self.bot.reset()
 
-    def move_relative(self, xyt_positions, blocking=True, distance_threshold=None, angle_threshold=None):
+    def move_relative(
+        self, xyt_positions, blocking=True, distance_threshold=None, angle_threshold=None
+    ):
         """Command to execute a relative move.
 
         Args:
@@ -229,11 +231,15 @@ class HelloRobotMover(MoverInterface):
             xyt_positions = [xyt_positions]
         for xyt in xyt_positions:
             self.nav_result.wait()
-            self.nav_result = safe_call(self.nav.go_to_relative, xyt, 10000000000, distance_threshold, angle_threshold)
+            self.nav_result = safe_call(
+                self.nav.go_to_relative, xyt, 10000000000, distance_threshold, angle_threshold
+            )
             if blocking:
                 self.nav_result.wait()
 
-    def move_absolute(self, xzt_positions, blocking=True, distance_threshold=None, angle_threshold=None):
+    def move_absolute(
+        self, xzt_positions, blocking=True, distance_threshold=None, angle_threshold=None
+    ):
         """Command to execute a move to an absolute position.
 
         It receives positions in canonical world coordinates and converts them to pyrobot's coordinates
@@ -250,7 +256,9 @@ class HelloRobotMover(MoverInterface):
             logging.info("Move absolute in canonical coordinates {}".format(xzt))
             self.nav_result.wait()
             robot_coords = base_canonical_coords_to_pyrobot_coords(xzt)
-            self.nav_result = self.nav.go_to_absolute(robot_coords, 10000000000, distance_threshold, angle_threshold)
+            self.nav_result = self.nav.go_to_absolute(
+                robot_coords, 10000000000, distance_threshold, angle_threshold
+            )
             if blocking:
                 self.nav_result.wait()
         return "finished"

--- a/droidlet/lowlevel/hello_robot/remote/README.md
+++ b/droidlet/lowlevel/hello_robot/remote/README.md
@@ -20,6 +20,29 @@ popd
 
 ## 3. Start the services
 
+### Without ROS (i.e. directly using base API)
+
 ```bash
+# export LOCOBOT_IP=[your network ip]
+# example when using tailscale:
+# export LOCOBOT_IP=$(tailscale ip --4)
+
 ./launch.sh
+```
+
+### With ROS (i.e. better odometry using hector_slam, etc.)
+
+```bash
+# in fresh terminal
+deactivate
+./launch_ros.sh
+
+# in another terminal
+. droidlet/bin/activate
+
+# export LOCOBOT_IP=[your network ip]
+# example when using tailscale:
+# export LOCOBOT_IP=$(tailscale ip --4)
+
+./launch.sh --ros
 ```

--- a/droidlet/lowlevel/hello_robot/remote/README.md
+++ b/droidlet/lowlevel/hello_robot/remote/README.md
@@ -2,12 +2,14 @@
 
 On the Hello Robot Stretch, run the following from the directory where the readme exists
 
-## 1. Install venv and requirements
+## 1. Install venv and requirements and hector slam
 
 ```bash
 python3 -m venv droidlet
 . droidlet/bin/activate
 pip install -r requirements.txt
+
+sudo apt install ros-noetic-hector-slam -y
 ```
 
 ## 2. Install droidlet in develop mode

--- a/droidlet/lowlevel/hello_robot/remote/kill.sh
+++ b/droidlet/lowlevel/hello_robot/remote/kill.sh
@@ -10,5 +10,6 @@ kill_pattern python planning_service.py
 kill_pattern python slam_service.py
 kill_pattern python remote_hello_realsense.py
 kill_pattern python remote_hello_robot.py
+kill_pattern python remote_hello_robot_ros.py
 kill_pattern python remote_hello_saver.py
 kill_pattern python Pyro4.naming

--- a/droidlet/lowlevel/hello_robot/remote/launch.sh
+++ b/droidlet/lowlevel/hello_robot/remote/launch.sh
@@ -61,6 +61,8 @@ trap 'echo "Killing $BGPID"; kill $BGPID2; exit' INT
 timeout 20s bash -c "until python check_connected.py hello_realsense $ip; do sleep 0.5; done;" || true
 
 python3 ./remote_hello_saver.py --ip $ip &
+BGPID3=$!
+trap 'echo "Killing $BGPID"; kill $BGPID3; exit' INT
 timeout 10s bash -c "until python check_connected.py hello_data_logger $ip; do sleep 0.5; done;" || true
 
 ./launch_navigation.sh

--- a/droidlet/lowlevel/hello_robot/remote/launch.sh
+++ b/droidlet/lowlevel/hello_robot/remote/launch.sh
@@ -49,7 +49,7 @@ else
 fi
 BGPID=$!
 trap 'echo "Killing $BGPID"; kill $BGPID; exit' INT
-timeout 50s bash -c "until python check_connected.py hello_robot $ip; do sleep 0.5; done;" || true
+timeout --foreground 50s bash -c "until python check_connected.py hello_robot $ip; do sleep 0.5; done;" || true
 
 if [[ $USE_ROS -eq 1 ]]; then
     python3 ./remote_hello_realsense.py --ip $ip --ros &
@@ -58,11 +58,11 @@ else
 fi
 BGPID2=$!
 trap 'echo "Killing $BGPID"; kill $BGPID2; exit' INT
-timeout 20s bash -c "until python check_connected.py hello_realsense $ip; do sleep 0.5; done;" || true
+timeout --foreground 20s bash -c "until python check_connected.py hello_realsense $ip; do sleep 0.5; done;" || true
 
 python3 ./remote_hello_saver.py --ip $ip &
 BGPID3=$!
 trap 'echo "Killing $BGPID"; kill $BGPID3; exit' INT
-timeout 10s bash -c "until python check_connected.py hello_data_logger $ip; do sleep 0.5; done;" || true
+timeout --foreground 10s bash -c "until python check_connected.py hello_data_logger $ip; do sleep 0.5; done;" || true
 
 ./launch_navigation.sh

--- a/droidlet/lowlevel/hello_robot/remote/launch_ros.sh
+++ b/droidlet/lowlevel/hello_robot/remote/launch_ros.sh
@@ -1,0 +1,12 @@
+#!/bin/env bash
+set -e
+
+if $(which python | grep fairo >/dev/null); then
+    echo "droidlet virtualenv needs to be deactivated before running this script. Run 'deactivate' in the terminal before running this"
+    exit 0
+fi
+roslaunch stretch_laser_odom_base.launch &
+BGPID=$!
+trap 'echo "Killing $BGPID"; kill $BGPID; exit' INT
+sleep 5
+roslaunch stretch_hector_slam.launch

--- a/droidlet/lowlevel/hello_robot/remote/lidar.py
+++ b/droidlet/lowlevel/hello_robot/remote/lidar.py
@@ -3,6 +3,7 @@ import sys
 import threading
 import time
 import traceback
+
 if __name__ == "__main__":
     from lidar_abc import LidarABC
 else:

--- a/droidlet/lowlevel/hello_robot/remote/lidar.py
+++ b/droidlet/lowlevel/hello_robot/remote/lidar.py
@@ -3,9 +3,13 @@ import sys
 import threading
 import time
 import traceback
+if __name__ == "__main__":
+    from lidar_abc import LidarABC
+else:
+    from .lidar_abc import LidarABC
 
 
-class Lidar:
+class Lidar(LidarABC):
     def __init__(self):
         self._lidar = RPLidar("/dev/hello-lrf")
         self._lock = threading.Lock()

--- a/droidlet/lowlevel/hello_robot/remote/lidar_abc.py
+++ b/droidlet/lowlevel/hello_robot/remote/lidar_abc.py
@@ -1,0 +1,11 @@
+from abc import ABC, abstractmethod
+
+class LidarABC(ABC):
+
+    @abstractmethod
+    def __init__(self):
+        pass
+
+    @abstractmethod
+    def get_latest_scan(self):
+        pass

--- a/droidlet/lowlevel/hello_robot/remote/lidar_abc.py
+++ b/droidlet/lowlevel/hello_robot/remote/lidar_abc.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 
-class LidarABC(ABC):
 
+class LidarABC(ABC):
     @abstractmethod
     def __init__(self):
         pass

--- a/droidlet/lowlevel/hello_robot/remote/lidar_ros_driver.py
+++ b/droidlet/lowlevel/hello_robot/remote/lidar_ros_driver.py
@@ -1,0 +1,55 @@
+import math
+import sys
+import threading
+import time
+import traceback
+import rospy
+from sensor_msgs.msg import LaserScan
+
+
+class Lidar:
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._thread = None
+        self.latest_scan = None
+
+    def start(self):
+        try:
+            rospy.init_node("droidlet_lidar_node")
+        except:
+            pass
+        self._thread = threading.Thread(target=self.lidar_loop, daemon=True)
+        self._thread.start()
+
+    def get_latest_scan(self):
+        with self._lock:
+            return self.latest_scan
+
+    def _scan_callback(self, scan):
+        with self._lock:
+            in_mm = [s * 1000 for s in scan.ranges]
+            angle_min = scan.angle_min
+            angle_max = scan.angle_max
+            angle_inc = scan.angle_increment
+            angles = []
+            for i in range(len(in_mm)):
+                radians = angle_min + angle_inc * i
+                angles.append(math.degrees(radians) + 180)
+            quality = scan.intensities
+            lscan = []
+            for i in range(len(in_mm)):
+                lscan.append((quality[i], angles[i], in_mm[i]))
+            self.latest_scan = (scan.header.stamp.secs, lscan)
+
+    def lidar_loop(self):
+        rospy.Subscriber("scan_filtered", LaserScan, self._scan_callback, queue_size=1)
+        rate = rospy.Rate(20)
+        while not rospy.is_shutdown():
+            rate.sleep()
+
+
+if __name__ == "__main__":
+    rospy.init_node("droidlet_lidar_node")
+    Lidar()
+    while not rospy.is_shutdown():
+        time.sleep(10)

--- a/droidlet/lowlevel/hello_robot/remote/lidar_ros_driver.py
+++ b/droidlet/lowlevel/hello_robot/remote/lidar_ros_driver.py
@@ -6,8 +6,13 @@ import traceback
 import rospy
 from sensor_msgs.msg import LaserScan
 
+if __name__ == "__main__":
+    from lidar_abc import LidarABC
+else:
+    from .lidar_abc import LidarABC
 
-class Lidar:
+
+class Lidar(LidarABC):
     def __init__(self):
         self._lock = threading.Lock()
         self._thread = None

--- a/droidlet/lowlevel/hello_robot/remote/remote_hello_realsense.py
+++ b/droidlet/lowlevel/hello_robot/remote/remote_hello_realsense.py
@@ -250,7 +250,9 @@ class RemoteHelloRealsense(object):
 
     def calibrate_tilt(self):
         if self.use_ros is True:
-            print("NOT CALIBRATING CAMERA because we are using ROS driver which already calibrates")
+            print(
+                "NOT CALIBRATING CAMERA because we are using ROS driver which already calibrates"
+            )
             return
         self.bot.set_tilt(math.radians(-60))
         time.sleep(2)
@@ -277,8 +279,8 @@ if __name__ == "__main__":
         type=str,
         default="0.0.0.0",
     )
-    parser.add_argument('--ros', action='store_true')
-    parser.add_argument('--no-ros', dest='ros', action='store_false')
+    parser.add_argument("--ros", action="store_true")
+    parser.add_argument("--no-ros", dest="ros", action="store_false")
     parser.set_defaults(ros=False)
 
     args = parser.parse_args()

--- a/droidlet/lowlevel/hello_robot/remote/remote_hello_realsense.py
+++ b/droidlet/lowlevel/hello_robot/remote/remote_hello_realsense.py
@@ -16,7 +16,6 @@ import numpy as np
 import cv2
 import open3d as o3d
 from droidlet.lowlevel.hello_robot.remote.utils import transform_global_to_base, goto
-from droidlet.lowlevel.hello_robot.remote.lidar import Lidar
 from slam_pkg.utils import depth_util as du
 import obstacle_utils
 from obstacle_utils import is_obstacle
@@ -40,8 +39,14 @@ Pyro4.config.ITER_STREAMING = True
 class RemoteHelloRealsense(object):
     """Hello Robot interface"""
 
-    def __init__(self, bot):
+    def __init__(self, bot, use_ros=False):
         self.bot = bot
+        if use_ros:
+            self.use_ros = True
+            from droidlet.lowlevel.hello_robot.remote.lidar_ros_driver import Lidar
+        else:
+            self.use_ros = False
+            from droidlet.lowlevel.hello_robot.remote.lidar import Lidar
         self._lidar = Lidar()
         self._lidar.start()
         self._done = True
@@ -244,6 +249,9 @@ class RemoteHelloRealsense(object):
         return rgb, depth, base2cam_rot, base2cam_trans
 
     def calibrate_tilt(self):
+        if self.use_ros is True:
+            print("NOT CALIBRATING CAMERA because we are using ROS driver which already calibrates")
+            return
         self.bot.set_tilt(math.radians(-60))
         time.sleep(2)
         pcd = self.get_open3d_pcd()
@@ -269,6 +277,9 @@ if __name__ == "__main__":
         type=str,
         default="0.0.0.0",
     )
+    parser.add_argument('--ros', action='store_true')
+    parser.add_argument('--no-ros', dest='ros', action='store_false')
+    parser.set_defaults(ros=False)
 
     args = parser.parse_args()
 
@@ -276,7 +287,7 @@ if __name__ == "__main__":
 
     with Pyro4.Daemon(args.ip) as daemon:
         bot = Pyro4.Proxy("PYRONAME:hello_robot@" + args.ip)
-        robot = RemoteHelloRealsense(bot)
+        robot = RemoteHelloRealsense(bot, use_ros=args.ros)
         robot_uri = daemon.register(robot)
         with Pyro4.locateNS() as ns:
             ns.register("hello_realsense", robot_uri)

--- a/droidlet/lowlevel/hello_robot/remote/remote_hello_realsense.py
+++ b/droidlet/lowlevel/hello_robot/remote/remote_hello_realsense.py
@@ -249,11 +249,6 @@ class RemoteHelloRealsense(object):
         return rgb, depth, base2cam_rot, base2cam_trans
 
     def calibrate_tilt(self):
-        if self.use_ros is True:
-            print(
-                "NOT CALIBRATING CAMERA because we are using ROS driver which already calibrates"
-            )
-            return
         self.bot.set_tilt(math.radians(-60))
         time.sleep(2)
         pcd = self.get_open3d_pcd()

--- a/droidlet/lowlevel/hello_robot/remote/remote_hello_robot.py
+++ b/droidlet/lowlevel/hello_robot/remote/remote_hello_robot.py
@@ -76,6 +76,9 @@ class RemoteHelloRobot(object):
         print(Style.RESET_ALL)
 
     def pull_status(self):
+        """
+        Force the Robot API to pull the latest status of all sensors immediately (instead of waiting for the next update)
+        """
         self._robot.pull_status()
 
     def _load_urdf(self):
@@ -154,6 +157,12 @@ class RemoteHelloRobot(object):
         self._robot.head.move_to("head_tilt", tilt)
 
     def reset_camera(self):
+        """
+        Sets the camera facing the forward, i.e.
+        90 degrees from looking at the ground.
+        If the robot base's front is facing a wall,
+        the camera should be directly looking at the wall
+        """
         self.set_pan(0)
         self.set_tilt(0)
 

--- a/droidlet/lowlevel/hello_robot/remote/remote_hello_robot_ros.py
+++ b/droidlet/lowlevel/hello_robot/remote/remote_hello_robot_ros.py
@@ -224,6 +224,7 @@ class RemoteHelloRobot(object):
     def stop(self):
         self._robot.stop()
 
+
 if __name__ == "__main__":
     import argparse
 

--- a/droidlet/lowlevel/hello_robot/remote/remote_hello_robot_ros.py
+++ b/droidlet/lowlevel/hello_robot/remote/remote_hello_robot_ros.py
@@ -104,6 +104,9 @@ class RemoteHelloRobot(object):
         return self._robot.get_slam_pose()
 
     def pull_status(self):
+        """
+        A no-op in the ROS backend. Only there for API compatibility
+        """
         pass
 
     def is_base_moving(self):
@@ -124,6 +127,12 @@ class RemoteHelloRobot(object):
         self._robot.send_command("joint_head_tilt", tilt)
 
     def reset_camera(self):
+        """
+        Sets the camera facing the forward, i.e.
+        90 degrees from looking at the ground.
+        If the robot base's front is facing a wall,
+        the camera should be directly looking at the wall
+        """
         self.set_pan(0)
         self.set_tilt(0)
 

--- a/droidlet/lowlevel/hello_robot/remote/remote_hello_robot_ros.py
+++ b/droidlet/lowlevel/hello_robot/remote/remote_hello_robot_ros.py
@@ -15,6 +15,7 @@ import numpy as np
 from droidlet.lowlevel.hello_robot.remote.utils import transform_global_to_base, goto
 from stretch_ros_move_api import MoveNode as Robot
 from droidlet.lowlevel.pyro_utils import safe_call
+import traceback
 
 
 Pyro4.config.SERIALIZER = "pickle"
@@ -174,12 +175,19 @@ class RemoteHelloRobot(object):
             global_xyt = xyt_position
             base_state = self.get_base_state()
             base_xyt = transform_global_to_base(global_xyt, base_state)
+            print(f"go_to_absolute {global_xyt} {base_state} {base_xyt}")
 
             def obstacle_fn():
                 return self.cam.is_obstacle_in_front()
 
-            status = goto(self, list(base_xyt), dryrun=False, obstacle_fn=obstacle_fn)
-            self._done = True
+            try:
+                status = goto(self, list(base_xyt), dryrun=False, obstacle_fn=obstacle_fn)
+                self._done = True
+            except Exception as e:
+                print(e)
+                print(traceback.format_exc())
+                self._done = True
+                raise e
         return status
 
     def go_to_relative(self, xyt_position):
@@ -197,12 +205,21 @@ class RemoteHelloRobot(object):
             def obstacle_fn():
                 return safe_call(self.cam, is_obstacle_in_front)
 
-            status = goto(self, list(xyt_position), dryrun=False, obstacle_fn=obstacle_fn)
-            self._done = True
+            try:
+                status = goto(self, list(xyt_position), dryrun=False, obstacle_fn=obstacle_fn)
+                self._done = True
+            except Exception as e:
+                print(e)
+                print(traceback.format_exc())
+                self._done = True
+                raise e
         return status
 
     def is_moving(self):
         return not self._done
+
+    def is_busy(self):
+        return not self.is_moving()
 
     def stop(self):
         self._robot.stop()

--- a/droidlet/lowlevel/hello_robot/remote/remote_hello_robot_ros.py
+++ b/droidlet/lowlevel/hello_robot/remote/remote_hello_robot_ros.py
@@ -198,7 +198,7 @@ class RemoteHelloRobot(object):
                         break
                     except:
                         print("obstacle exception")
-                
+
                 return result
 
             try:

--- a/droidlet/lowlevel/hello_robot/remote/requirements.txt
+++ b/droidlet/lowlevel/hello_robot/remote/requirements.txt
@@ -9,3 +9,8 @@ scikit-image
 torch
 torchvision
 rich
+blosc
+open3d
+yacs
+rospy
+rospkg

--- a/droidlet/lowlevel/hello_robot/remote/stretch_hector_mapping.launch
+++ b/droidlet/lowlevel/hello_robot/remote/stretch_hector_mapping.launch
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+
+<launch>
+  <arg name="tf_map_scanmatch_transform_frame_name" default="scanmatcher_frame"/>
+  <arg name="base_frame" default="base_link"/>
+  <arg name="odom_frame" default="odom"/>
+  <arg name="pub_map_odom_transform" default="true"/>
+  <arg name="scan_subscriber_queue_size" default="5"/>
+  <arg name="scan_topic" default="scan"/>
+  <arg name="map_size" default="2048"/>
+  
+  <node pkg="hector_mapping" type="hector_mapping" name="hector_mapping" output="screen">
+    
+    <!-- Frame names -->
+    <param name="map_frame" value="map" />
+    <param name="base_frame" value="$(arg base_frame)" />
+    <param name="odom_frame" value="$(arg odom_frame)" />
+    
+    <!-- Tf use -->
+    <param name="use_tf_scan_transformation" value="true"/>
+    <param name="use_tf_pose_start_estimate" value="false"/>
+    <param name="pub_map_odom_transform" value="$(arg pub_map_odom_transform)"/>
+    
+    <!-- Map size / start point -->
+    <param name="map_resolution" value="0.050"/>
+    <param name="map_size" value="$(arg map_size)"/>
+    <param name="map_start_x" value="0.5"/>
+    <param name="map_start_y" value="0.5" />
+    <param name="map_multi_res_levels" value="2" />
+    
+    <!-- Map update parameters -->
+    <param name="update_factor_free" value="0.4"/>
+    <param name="update_factor_occupied" value="0.9" />    
+    <param name="map_update_distance_thresh" value="0.4"/>
+    <param name="map_update_angle_thresh" value="0.06" />
+    <param name="laser_z_min_value" value = "-1.0" />
+    <param name="laser_z_max_value" value = "1.0" />
+    
+    <!-- Advertising config --> 
+    <param name="advertise_map_service" value="true"/>
+    
+    <param name="scan_subscriber_queue_size" value="$(arg scan_subscriber_queue_size)"/>
+    <param name="scan_topic" value="$(arg scan_topic)"/>
+    
+    <!-- Debug parameters -->
+    <!--
+      <param name="output_timing" value="false"/>
+      <param name="pub_drawings" value="true"/>
+      <param name="pub_debug_output" value="true"/>
+    -->
+    <param name="tf_map_scanmatch_transform_frame_name" value="$(arg tf_map_scanmatch_transform_frame_name)" />
+  </node>
+  
+  <!-- <node pkg="tf" type="static_transform_publisher" name="map_base_link" args="0 0 0 0 0 0 map base_link 100"/> -->
+</launch>
+  
+  

--- a/droidlet/lowlevel/hello_robot/remote/stretch_hector_slam.launch
+++ b/droidlet/lowlevel/hello_robot/remote/stretch_hector_slam.launch
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+
+<launch>
+
+  <arg name="geotiff_map_file_path" default="$(find hector_geotiff)/maps"/>
+
+  <param name="/use_sim_time" value="false"/>
+
+  <!-- <node pkg="rviz" type="rviz" name="rviz" -->
+  <!--   args="-d $(find hector_slam_launch)/rviz_cfg/mapping_demo.rviz"/> -->
+
+  <include file="stretch_hector_mapping.launch"/>
+
+  <include file="$(find hector_geotiff_launch)/launch/geotiff_mapper.launch">
+    <arg name="trajectory_source_frame_name" value="scanmatcher_frame"/>
+    <arg name="map_file_path" value="$(arg geotiff_map_file_path)"/>
+  </include>
+
+</launch>

--- a/droidlet/lowlevel/hello_robot/remote/stretch_laser_odom_base.launch
+++ b/droidlet/lowlevel/hello_robot/remote/stretch_laser_odom_base.launch
@@ -1,0 +1,19 @@
+<launch>
+
+  <arg name="rviz"            default="true"                           doc="whether to show Rviz" />
+
+  <!-- STRETCH DRIVER -->
+  <param name="/stretch_driver/broadcast_odom_tf" type="bool" value="false"/>
+  <param name="/stretch_driver/fail_out_of_range_goal" type="bool" value="false"/>
+  <include file="$(find stretch_core)/launch/stretch_driver.launch" pass_all_args="true"/>
+  <!-- -->
+
+  <!-- LASER RANGE FINDER -->
+  <include file="$(find stretch_core)/launch/rplidar.launch" />
+  <!-- -->
+  
+  <!-- LASER SCAN MATCHER FOR ODOMETRY -->
+  <include file="$(find stretch_core)/launch/stretch_scan_matcher.launch" />
+  <!-- -->
+    
+</launch>

--- a/droidlet/lowlevel/hello_robot/remote/stretch_ros_move_api.py
+++ b/droidlet/lowlevel/hello_robot/remote/stretch_ros_move_api.py
@@ -13,8 +13,8 @@ from tf.transformations import euler_from_quaternion
 import collections
 import numpy as np
 
-class MoveNode(hm.HelloNode):
 
+class MoveNode(hm.HelloNode):
     def __init__(self):
         hm.HelloNode.__init__(self)
         self.rate = 10.0
@@ -42,7 +42,9 @@ class MoveNode(hm.HelloNode):
     def _odom_callback(self, pose):
         with self._lock:
             self._odom = pose
-            self._linear_movement.append(max(abs(pose.twist.twist.linear.x), abs(pose.twist.twist.linear.y)))
+            self._linear_movement.append(
+                max(abs(pose.twist.twist.linear.x), abs(pose.twist.twist.linear.y))
+            )
             self._angular_movement.append(abs(pose.twist.twist.angular.z))
 
     def is_moving(self):
@@ -65,9 +67,7 @@ class MoveNode(hm.HelloNode):
                 ]
             )
             euler = euler_from_quaternion(quat)
-            return (pose.pose.pose.position.x,
-                    pose.pose.pose.position.y,
-                    euler[2])
+            return (pose.pose.pose.position.x, pose.pose.pose.position.y, euler[2])
         else:
             return (0.0, 0.0, 0.0)
 
@@ -89,9 +89,7 @@ class MoveNode(hm.HelloNode):
             ]
         )
         euler = euler_from_quaternion(quat)
-        return (pose.pose.position.x,
-                pose.pose.position.y,
-                euler[2])
+        return (pose.pose.position.x, pose.pose.position.y, euler[2])
 
     def get_joint_state(self, name=None):
         with self._lock:
@@ -99,10 +97,10 @@ class MoveNode(hm.HelloNode):
         if joint_state is None:
             return joint_state
         if name is not None:
-            joint_index = joint_state.name.index('joint_' + name)
+            joint_index = joint_state.name.index("joint_" + name)
             joint_value = joint_state.position[joint_index]
             return joint_value
-        else:            
+        else:
             return joint_state
 
     def send_command(self, joint_name, increment):
@@ -113,30 +111,36 @@ class MoveNode(hm.HelloNode):
         point = JointTrajectoryPoint()
         point.time_from_start = rospy.Duration(0.0)
         point.positions = [increment]
-            
+
         trajectory_goal = FollowJointTrajectoryGoal()
-        trajectory_goal.goal_time_tolerance = rospy.Time(1.0)            
+        trajectory_goal.goal_time_tolerance = rospy.Time(1.0)
         trajectory_goal.trajectory.joint_names = [joint_name]
         trajectory_goal.trajectory.points = [point]
         trajectory_goal.trajectory.header.stamp = rospy.Time.now()
-            
+
         self.trajectory_client.send_goal(trajectory_goal)
 
-        rospy.loginfo('joint_name = {0}, trajectory_goal = {1}'.format(joint_name, trajectory_goal))
-        rospy.loginfo('Done sending pose.')
+        rospy.loginfo(
+            "joint_name = {0}, trajectory_goal = {1}".format(joint_name, trajectory_goal)
+        )
+        rospy.loginfo("Done sending pose.")
 
     def stop(self):
-        rospy.wait_for_service('stop_the_robot')
-        s = rospy.ServiceProxy('stop_the_robot', Trigger)
+        rospy.wait_for_service("stop_the_robot")
+        s = rospy.ServiceProxy("stop_the_robot", Trigger)
         s_request = TriggerRequest()
         result = s(s_request)
         return result
 
     def background_loop(self):
 
-        rospy.Subscriber("/stretch/joint_states", JointState, self._joint_states_callback, queue_size=1)
+        rospy.Subscriber(
+            "/stretch/joint_states", JointState, self._joint_states_callback, queue_size=1
+        )
         # This comes from hector_slam. It's a transform from src_frame = 'base_link', target_frame = 'map'
-        rospy.Subscriber("/poseupdate", PoseWithCovarianceStamped, self._slam_pose_callback, queue_size=1)
+        rospy.Subscriber(
+            "/poseupdate", PoseWithCovarianceStamped, self._slam_pose_callback, queue_size=1
+        )
         # this comes from lidar matching, i.e. no slam/global-optimization
         rospy.Subscriber("/pose2D", Pose2D, self._scan_matched_pose_callback, queue_size=1)
         # This comes from wheel odometry.
@@ -147,14 +151,16 @@ class MoveNode(hm.HelloNode):
         while not rospy.is_shutdown():
             with self._lock:
                 command = self._command
-                self._command = None                
+                self._command = None
             if command is not None:
                 joint_name, increment = command
                 self._send_command(joint_name, increment)
             rate.sleep()
 
     def start(self):
-        hm.HelloNode.main(self, 'fairo_hello_proxy', 'fairo_hello_proxy', wait_for_first_pointcloud=False)
+        hm.HelloNode.main(
+            self, "fairo_hello_proxy", "fairo_hello_proxy", wait_for_first_pointcloud=False
+        )
         self._thread = threading.Thread(target=self.background_loop, daemon=True)
         self._thread.start()
         # self.send_command('translate_mobile_base', 0.1)
@@ -181,7 +187,7 @@ class MoveNode(hm.HelloNode):
         #     #     y = slam_pose.pose.position.y
         #     #     theta = slam_pose.pose.orientation.z
         #     #     print(x, y, theta)
-            
+
         #     # FORWARD/BACKWARD in metres
         # self.send_command('translate_mobile_base', 0.05)
 

--- a/droidlet/lowlevel/hello_robot/remote/stretch_ros_move_api.py
+++ b/droidlet/lowlevel/hello_robot/remote/stretch_ros_move_api.py
@@ -24,6 +24,7 @@ class MoveNode(hm.HelloNode):
     Actuation:
         It implements base movement
     """
+
     def __init__(self):
         hm.HelloNode.__init__(self)
         self.rate = 10.0
@@ -189,6 +190,7 @@ class MoveNode(hm.HelloNode):
         #     joint_state = self.get_joint_state()
         #     if joint_state is not None:
         #         print(joint_state)
+
 
 if __name__ == "__main__":
     node = MoveNode()

--- a/droidlet/lowlevel/hello_robot/remote/stretch_ros_move_api.py
+++ b/droidlet/lowlevel/hello_robot/remote/stretch_ros_move_api.py
@@ -15,6 +15,15 @@ import numpy as np
 
 
 class MoveNode(hm.HelloNode):
+    """
+    This class implements an interface to the Hello Robot Stretch via it's ROS driver.
+
+    Sensors:
+        It reads joint positions and Lidar
+
+    Actuation:
+        It implements base movement
+    """
     def __init__(self):
         hm.HelloNode.__init__(self)
         self.rate = 10.0
@@ -165,34 +174,21 @@ class MoveNode(hm.HelloNode):
         )
         self._thread = threading.Thread(target=self.background_loop, daemon=True)
         self._thread.start()
+
+        # Code that showcases usage of the Stretch ROS API and is useful for debugging
+        # FORWARD/BACKWARD in metres
         # self.send_command('translate_mobile_base', 0.1)
+        # ROTATE LEFT +ve / RIGHT -ve in radians
         # self.send_command('rotate_mobile_base', math.radians(90))
         # while not rospy.is_shutdown():
-        #     time.sleep(1)
-        #     # self.send_command('rotate_mobile_base', math.radians(90))
-        #     #     self.send_command('rotate_mobile_base', math.radians(6))
-        #     print("")
         #     print('slam_pose', self.get_slam_pose())
         #     print('odom', self.get_odom())
         #     print('scan_matched_pose', self.get_scan_matched_pose())
         #     print("")
-        #     # ROTATE LEFT +ve / RIGHT -ve in radians
-        #     self.send_command('rotate_mobile_base', math.radians(6))
-        #     # print(self.get_joint_state('head_pan'))
-        #     # joint_state = self.get_joint_state()
-        #     # if joint_state is not None:
-        #     #     print(joint_state)
-        #     # slam_pose = self.get_slam_pose()
-        #     # if slam_pose is not None:
-        #     #     # print(slam_pose)
-        #     #     x = slam_pose.pose.position.x
-        #     #     y = slam_pose.pose.position.y
-        #     #     theta = slam_pose.pose.orientation.z
-        #     #     print(x, y, theta)
-
-        #     # FORWARD/BACKWARD in metres
-        # self.send_command('translate_mobile_base', 0.05)
-
+        #     print(self.get_joint_state('head_pan'))
+        #     joint_state = self.get_joint_state()
+        #     if joint_state is not None:
+        #         print(joint_state)
 
 if __name__ == "__main__":
     node = MoveNode()

--- a/droidlet/lowlevel/hello_robot/remote/stretch_ros_move_api.py
+++ b/droidlet/lowlevel/hello_robot/remote/stretch_ros_move_api.py
@@ -67,7 +67,8 @@ class MoveNode(hm.HelloNode):
                 ]
             )
             euler = euler_from_quaternion(quat)
-            return (pose.pose.pose.position.x, pose.pose.pose.position.y, euler[2])
+            yaw = euler[2] + math.pi
+            return (pose.pose.pose.position.x, pose.pose.pose.position.y, yaw)
         else:
             return (0.0, 0.0, 0.0)
 
@@ -89,7 +90,8 @@ class MoveNode(hm.HelloNode):
             ]
         )
         euler = euler_from_quaternion(quat)
-        return (pose.pose.position.x, pose.pose.position.y, euler[2])
+        yaw = euler[2] + math.pi
+        return (pose.pose.position.x, pose.pose.position.y, yaw)
 
     def get_joint_state(self, name=None):
         with self._lock:

--- a/droidlet/lowlevel/hello_robot/remote/stretch_ros_move_api.py
+++ b/droidlet/lowlevel/hello_robot/remote/stretch_ros_move_api.py
@@ -1,0 +1,192 @@
+import time
+import math
+import threading
+import rospy
+from std_srvs.srv import Trigger, TriggerRequest
+from sensor_msgs.msg import JointState
+from control_msgs.msg import FollowJointTrajectoryGoal
+from trajectory_msgs.msg import JointTrajectoryPoint
+from geometry_msgs.msg import PoseStamped, Pose2D, PoseWithCovarianceStamped
+from nav_msgs.msg import Odometry
+import hello_helpers.hello_misc as hm
+from tf.transformations import euler_from_quaternion
+import collections
+import numpy as np
+
+class MoveNode(hm.HelloNode):
+
+    def __init__(self):
+        hm.HelloNode.__init__(self)
+        self.rate = 10.0
+        self._joint_state = None
+        self._command = None
+        self._slam_pose = None
+        self._odom = None
+        self._linear_movement = collections.deque(maxlen=10)
+        self._angular_movement = collections.deque(maxlen=10)
+        self._scan_matched_pose = None
+        self._lock = threading.Lock()
+
+    def _joint_states_callback(self, joint_state):
+        with self._lock:
+            self._joint_state = joint_state
+
+    def _slam_pose_callback(self, pose):
+        with self._lock:
+            self._slam_pose = pose
+
+    def _scan_matched_pose_callback(self, pose):
+        with self._lock:
+            self._scan_matched_pose = (pose.x, pose.y, pose.theta)
+
+    def _odom_callback(self, pose):
+        with self._lock:
+            self._odom = pose
+            self._linear_movement.append(max(abs(pose.twist.twist.linear.x), abs(pose.twist.twist.linear.y)))
+            self._angular_movement.append(abs(pose.twist.twist.angular.z))
+
+    def is_moving(self):
+        with self._lock:
+            lm, am = self._linear_movement, self._angular_movement
+            max_linear = max(lm)
+            max_angular = max(am)
+        return max_linear >= 0.05 or max_angular >= 0.05
+
+    def get_slam_pose(self):
+        with self._lock:
+            pose = self._slam_pose
+        if pose is not None:
+            quat = np.array(
+                [
+                    pose.pose.pose.orientation.x,
+                    pose.pose.pose.orientation.y,
+                    pose.pose.pose.orientation.z,
+                    pose.pose.pose.orientation.w,
+                ]
+            )
+            euler = euler_from_quaternion(quat)
+            return (pose.pose.pose.position.x,
+                    pose.pose.pose.position.y,
+                    euler[2])
+        else:
+            return (0.0, 0.0, 0.0)
+
+    def get_scan_matched_pose(self):
+        with self._lock:
+            _pose = self._scan_matched_pose
+        return _pose
+
+    def get_odom(self):
+        with self._lock:
+            odom = self._odom
+        pose = odom.pose
+        quat = np.array(
+            [
+                pose.pose.orientation.x,
+                pose.pose.orientation.y,
+                pose.pose.orientation.z,
+                pose.pose.orientation.w,
+            ]
+        )
+        euler = euler_from_quaternion(quat)
+        return (pose.pose.position.x,
+                pose.pose.position.y,
+                euler[2])
+
+    def get_joint_state(self, name=None):
+        with self._lock:
+            joint_state = self._joint_state
+        if joint_state is None:
+            return joint_state
+        if name is not None:
+            joint_index = joint_state.name.index('joint_' + name)
+            joint_value = joint_state.position[joint_index]
+            return joint_value
+        else:            
+            return joint_state
+
+    def send_command(self, joint_name, increment):
+        with self._lock:
+            self._command = [joint_name, increment]
+
+    def _send_command(self, joint_name, increment):
+        point = JointTrajectoryPoint()
+        point.time_from_start = rospy.Duration(0.0)
+        point.positions = [increment]
+            
+        trajectory_goal = FollowJointTrajectoryGoal()
+        trajectory_goal.goal_time_tolerance = rospy.Time(1.0)            
+        trajectory_goal.trajectory.joint_names = [joint_name]
+        trajectory_goal.trajectory.points = [point]
+        trajectory_goal.trajectory.header.stamp = rospy.Time.now()
+            
+        self.trajectory_client.send_goal(trajectory_goal)
+
+        rospy.loginfo('joint_name = {0}, trajectory_goal = {1}'.format(joint_name, trajectory_goal))
+        rospy.loginfo('Done sending pose.')
+
+    def stop(self):
+        rospy.wait_for_service('stop_the_robot')
+        s = rospy.ServiceProxy('stop_the_robot', Trigger)
+        s_request = TriggerRequest()
+        result = s(s_request)
+        return result
+
+    def background_loop(self):
+
+        rospy.Subscriber("/stretch/joint_states", JointState, self._joint_states_callback, queue_size=1)
+        # This comes from hector_slam. It's a transform from src_frame = 'base_link', target_frame = 'map'
+        rospy.Subscriber("/poseupdate", PoseWithCovarianceStamped, self._slam_pose_callback, queue_size=1)
+        # this comes from lidar matching, i.e. no slam/global-optimization
+        rospy.Subscriber("/pose2D", Pose2D, self._scan_matched_pose_callback, queue_size=1)
+        # This comes from wheel odometry.
+        rospy.Subscriber("/odom", Odometry, self._odom_callback, queue_size=1)
+
+        rate = rospy.Rate(self.rate)
+
+        while not rospy.is_shutdown():
+            with self._lock:
+                command = self._command
+                self._command = None                
+            if command is not None:
+                joint_name, increment = command
+                self._send_command(joint_name, increment)
+            rate.sleep()
+
+    def start(self):
+        hm.HelloNode.main(self, 'fairo_hello_proxy', 'fairo_hello_proxy', wait_for_first_pointcloud=False)
+        self._thread = threading.Thread(target=self.background_loop, daemon=True)
+        self._thread.start()
+        # self.send_command('translate_mobile_base', 0.1)
+        # self.send_command('rotate_mobile_base', math.radians(90))
+        # while not rospy.is_shutdown():
+        #     time.sleep(1)
+        #     # self.send_command('rotate_mobile_base', math.radians(90))
+        #     #     self.send_command('rotate_mobile_base', math.radians(6))
+        #     print("")
+        #     print('slam_pose', self.get_slam_pose())
+        #     print('odom', self.get_odom())
+        #     print('scan_matched_pose', self.get_scan_matched_pose())
+        #     print("")
+        #     # ROTATE LEFT +ve / RIGHT -ve in radians
+        #     self.send_command('rotate_mobile_base', math.radians(6))
+        #     # print(self.get_joint_state('head_pan'))
+        #     # joint_state = self.get_joint_state()
+        #     # if joint_state is not None:
+        #     #     print(joint_state)
+        #     # slam_pose = self.get_slam_pose()
+        #     # if slam_pose is not None:
+        #     #     # print(slam_pose)
+        #     #     x = slam_pose.pose.position.x
+        #     #     y = slam_pose.pose.position.y
+        #     #     theta = slam_pose.pose.orientation.z
+        #     #     print(x, y, theta)
+            
+        #     # FORWARD/BACKWARD in metres
+        # self.send_command('translate_mobile_base', 0.05)
+
+
+if __name__ == "__main__":
+    node = MoveNode()
+    node.start()
+    # node.send_command('rotate_mobile_base', math.radians(6))

--- a/droidlet/lowlevel/hello_robot/remote/utils.py
+++ b/droidlet/lowlevel/hello_robot/remote/utils.py
@@ -110,7 +110,7 @@ def is_obstacle_ahead(dist, depth_fn):
 def goto(
     robot,
     xyt_position=None,
-    translation_threshold=0.1,
+    translation_threshold=0.05,
     dryrun=False,
     depth_fn=None,
     optimize_distance=False,

--- a/droidlet/lowlevel/hello_robot/remote/utils.py
+++ b/droidlet/lowlevel/hello_robot/remote/utils.py
@@ -136,22 +136,14 @@ def goto(
         print("translation distance too little," " rotating and exiting", sqrt(x * x + y * y))
         print(f"rotate by {xyt_position[2], rot}")
         if not dryrun:
-            robot.base.rotate_by(rot)
+            robot.rotate_by(rot)
             robot.push_command()
             time.sleep(0.05)
             is_moving = True
             while is_moving:
                 time.sleep(0.1)
                 robot.pull_status()
-                left_wheel_moving = (
-                    robot.base.left_wheel.status["is_moving_filtered"]
-                    or robot.base.left_wheel.status["is_moving"]
-                )
-                right_wheel_moving = (
-                    robot.base.right_wheel.status["is_moving_filtered"]
-                    or robot.base.right_wheel.status["is_moving"]
-                )
-                is_moving = left_wheel_moving or right_wheel_moving
+                is_moving = robot.is_base_moving()
         return status
 
     # robot is at (0, 0) because we're using base-frame
@@ -201,7 +193,7 @@ def goto(
         print("moving right by more than 2pi, so instead moving left by equivalent amount")
     print("rotate by theta_1", theta_1)
     if not dryrun:
-        robot.base.rotate_by(theta_1)
+        robot.rotate_by(theta_1)
         robot.push_command()
         robot.pull_status()
         time.sleep(0.1)
@@ -209,15 +201,7 @@ def goto(
         while is_moving:
             time.sleep(0.1)
             robot.pull_status()
-            left_wheel_moving = (
-                robot.base.left_wheel.status["is_moving_filtered"]
-                or robot.base.left_wheel.status["is_moving"]
-            )
-            right_wheel_moving = (
-                robot.base.right_wheel.status["is_moving_filtered"]
-                or robot.base.right_wheel.status["is_moving"]
-            )
-            is_moving = left_wheel_moving or right_wheel_moving
+            is_moving = robot.is_base_moving()
 
     # move the distance
     print("translate by ", dist)
@@ -227,8 +211,9 @@ def goto(
         if obstacle_fn is not None:
             is_obstacle = obstacle_fn()
         if is_obstacle:
+            print("Found obstacle before translating. Aborting")
             return "FAILED"
-        robot.base.translate_by(dist, v_m=0.1)
+        robot.translate_by(dist)
         robot.push_command()
         time.sleep(2)
         robot.pull_status()
@@ -238,20 +223,12 @@ def goto(
                 is_obstacle = obstacle_fn()
             if is_obstacle:
                 # stop motion
-                robot.base.set_rotational_velocity(v_r=0.0)
-                robot.push_command()
+                print("Found obstacle while translating. Aborting")
+                robot.stop()
                 return "FAILED"
             time.sleep(0.1)
             robot.pull_status()
-            left_wheel_moving = (
-                robot.base.left_wheel.status["is_moving_filtered"]
-                or robot.base.left_wheel.status["is_moving"]
-            )
-            right_wheel_moving = (
-                robot.base.right_wheel.status["is_moving_filtered"]
-                or robot.base.right_wheel.status["is_moving"]
-            )
-            is_moving = left_wheel_moving or right_wheel_moving
+            is_moving = robot.is_base_moving()
 
     # second rotate by theta2
     theta_2 = np.sign(theta_2) * (abs(theta_2) % radians(360))
@@ -261,7 +238,7 @@ def goto(
 
     print("rotate by theta_2", theta_2)
     if not dryrun:
-        robot.base.rotate_by(theta_2)
+        robot.rotate_by(theta_2)
         robot.push_command()
         time.sleep(0.1)
         robot.pull_status()
@@ -269,13 +246,5 @@ def goto(
         while is_moving:
             time.sleep(0.1)
             robot.pull_status()
-            left_wheel_moving = (
-                robot.base.left_wheel.status["is_moving_filtered"]
-                or robot.base.left_wheel.status["is_moving"]
-            )
-            right_wheel_moving = (
-                robot.base.right_wheel.status["is_moving_filtered"]
-                or robot.base.right_wheel.status["is_moving"]
-            )
-            is_moving = left_wheel_moving or right_wheel_moving
+            is_moving = robot.is_base_moving()
     return status

--- a/droidlet/lowlevel/hello_robot/remote/utils.py
+++ b/droidlet/lowlevel/hello_robot/remote/utils.py
@@ -14,7 +14,7 @@ def transform_global_to_base(XYT, current_pose):
     Output:
         XYZ : ...x3
     """
-    XYT = np.asarray(XYT)
+    XYT = np.asarray(XYT, dtype=np.float32)
     new_T = XYT[2] - current_pose[2]
     R = Rotation.from_euler("Z", current_pose[2]).as_matrix()
     XYT[0] = XYT[0] - current_pose[0]
@@ -130,7 +130,7 @@ def goto(
     y = xyt_position[1]  # in meters
     rot = xyt_position[2]  # in radians
 
-    print("goto: ", xyt_position)
+    print("goto: ", xyt_position, " from: ", xyt_position)
 
     if sqrt(x * x + y * y) < translation_threshold:
         print("translation distance too little," " rotating and exiting", sqrt(x * x + y * y))
@@ -138,7 +138,7 @@ def goto(
         if not dryrun:
             robot.rotate_by(rot)
             robot.push_command()
-            time.sleep(0.05)
+            time.sleep(1)
             is_moving = True
             while is_moving:
                 time.sleep(0.1)
@@ -196,7 +196,7 @@ def goto(
         robot.rotate_by(theta_1)
         robot.push_command()
         robot.pull_status()
-        time.sleep(0.1)
+        time.sleep(1)
         is_moving = True
         while is_moving:
             time.sleep(0.1)
@@ -240,7 +240,7 @@ def goto(
     if not dryrun:
         robot.rotate_by(theta_2)
         robot.push_command()
-        time.sleep(0.1)
+        time.sleep(1)
         robot.pull_status()
         is_moving = True
         while is_moving:

--- a/droidlet/lowlevel/locobot/remote/launch_navigation.sh
+++ b/droidlet/lowlevel/locobot/remote/launch_navigation.sh
@@ -2,10 +2,10 @@
 set -ex
 
 python slam_service.py $CAMERA_NAME &
-timeout 10s bash -c "until python check_connected.py slam $PYRO_IP; do sleep 0.5; done;" || true
+timeout --foreground 10s bash -c "until python check_connected.py slam $PYRO_IP; do sleep 0.5; done;" || true
 
 python planning_service.py &
-timeout 10s bash -c "until python check_connected.py planner $PYRO_IP; do sleep 0.5; done;" || true
+timeout --foreground 10s bash -c "until python check_connected.py planner $PYRO_IP; do sleep 0.5; done;" || true
 
 python navigation_service.py $ROBOT_NAME &
-timeout 10s bash -c "until python check_connected.py navigation $PYRO_IP; do sleep 0.5; done;" || true
+timeout --foreground 10s bash -c "until python check_connected.py navigation $PYRO_IP; do sleep 0.5; done;" || true

--- a/droidlet/lowlevel/locobot/remote/launch_pyro_habitat.sh
+++ b/droidlet/lowlevel/locobot/remote/launch_pyro_habitat.sh
@@ -31,7 +31,7 @@ echo $ip
 
 python remote_locobot.py --ip $ip $@ &
 # blocking wait for server to start
-timeout 1m bash -c "until python check_connected.py remotelocobot $ip; do sleep 1; done;" || true
+timeout --foreground 1m bash -c "until python check_connected.py remotelocobot $ip; do sleep 1; done;" || true
 ./launch_navigation.sh
 
 popd

--- a/droidlet/lowlevel/locobot/remote/navigation_service.py
+++ b/droidlet/lowlevel/locobot/remote/navigation_service.py
@@ -63,16 +63,16 @@ class Navigation(object):
         self._stop = True
         self._done_exploring = False
 
-    def go_to_relative(self, goal):
+    def go_to_relative(self, goal, distance_threshold=None, angle_threshold=None):
         robot_loc = self.robot.get_base_state()
         abs_goal = du.get_relative_state(goal, (0.0, 0.0, -robot_loc[2]))
         abs_goal = list(abs_goal)
         abs_goal[0] += robot_loc[0]
         abs_goal[1] += robot_loc[1]
         abs_goal[2] = goal[2] + robot_loc[2]
-        return self.go_to_absolute(abs_goal)
+        return self.go_to_absolute(abs_goal, distance_threshold=distance_threshold, angle_threshold=angle_threshold)
 
-    def go_to_absolute(self, goal, steps=100000000):
+    def go_to_absolute(self, goal, steps=100000000, distance_threshold=None, angle_threshold=None):
         self._busy = True
         self._stop = False
         robot_loc = self.robot.get_base_state()
@@ -80,7 +80,13 @@ class Navigation(object):
         goal_reached = False
         return_code = True
         while (not goal_reached) and steps > 0 and self._stop is False:
-            stg = self.planner.get_short_term_goal(robot_loc, goal)
+            stg = self.planner.get_short_term_goal(
+                robot_loc,
+                goal,
+                distance_threshold=distance_threshold,
+                angle_threshold=angle_threshold,
+            )
+            print(f"[nav] got short-term goal from planner: {stg}")
             if stg == False:
                 # no path to end-goal
                 print(
@@ -90,6 +96,8 @@ class Navigation(object):
                 )
                 return_code = False
                 break
+            robot_loc = self.robot.get_base_state()
+            print(f"[navigation] starting at point {robot_loc} and going to point {stg}")
             status = safe_call(self.robot.go_to_absolute, stg)
             robot_loc = self.robot.get_base_state()
 
@@ -98,7 +106,9 @@ class Navigation(object):
             print(" short-term goal: {}, Reached Location: {}".format(stg, robot_loc))
             print(" Robot Status: {}".format(status))
             if status == "SUCCEEDED":
-                goal_reached = self.planner.goal_within_threshold(robot_loc, goal)
+                goal_reached = self.planner.goal_within_threshold(robot_loc, goal,
+                                                                  distance_threshold,
+                                                                  angle_threshold)
                 self.trackback.update(robot_loc)
             else:
                 # collided with something unexpected.
@@ -108,7 +118,7 @@ class Navigation(object):
                 trackback_loc = self.trackback.get_loc(robot_loc)
 
                 print(f"Collided at {robot_loc}." f"Tracking back to {trackback_loc}")
-                self.robot.go_to_absolute(trackback_loc)
+                safe_call(self.robot.go_to_absolute, trackback_loc)
                 # TODO: if the trackback fails, we're screwed. Handle this robustly.
             steps = steps - 1
 

--- a/droidlet/lowlevel/locobot/remote/navigation_service.py
+++ b/droidlet/lowlevel/locobot/remote/navigation_service.py
@@ -7,6 +7,8 @@ import numpy as np
 import Pyro4
 from slam_pkg.utils import depth_util as du
 from rich import print
+from droidlet.lowlevel.pyro_utils import safe_call
+
 
 random.seed(0)
 Pyro4.config.SERIALIZER = "pickle"
@@ -88,7 +90,7 @@ class Navigation(object):
                 )
                 return_code = False
                 break
-            status = self.robot.go_to_absolute(stg)
+            status = safe_call(self.robot.go_to_absolute, stg)
             robot_loc = self.robot.get_base_state()
 
             print("[navigation] Finished a go_to_absolute")

--- a/droidlet/lowlevel/locobot/remote/navigation_service.py
+++ b/droidlet/lowlevel/locobot/remote/navigation_service.py
@@ -70,7 +70,9 @@ class Navigation(object):
         abs_goal[0] += robot_loc[0]
         abs_goal[1] += robot_loc[1]
         abs_goal[2] = goal[2] + robot_loc[2]
-        return self.go_to_absolute(abs_goal, distance_threshold=distance_threshold, angle_threshold=angle_threshold)
+        return self.go_to_absolute(
+            abs_goal, distance_threshold=distance_threshold, angle_threshold=angle_threshold
+        )
 
     def go_to_absolute(self, goal, steps=100000000, distance_threshold=None, angle_threshold=None):
         self._busy = True
@@ -106,9 +108,9 @@ class Navigation(object):
             print(" short-term goal: {}, Reached Location: {}".format(stg, robot_loc))
             print(" Robot Status: {}".format(status))
             if status == "SUCCEEDED":
-                goal_reached = self.planner.goal_within_threshold(robot_loc, goal,
-                                                                  distance_threshold,
-                                                                  angle_threshold)
+                goal_reached = self.planner.goal_within_threshold(
+                    robot_loc, goal, distance_threshold, angle_threshold
+                )
                 self.trackback.update(robot_loc)
             else:
                 # collided with something unexpected.

--- a/droidlet/lowlevel/locobot/remote/planning_service.py
+++ b/droidlet/lowlevel/locobot/remote/planning_service.py
@@ -20,7 +20,8 @@ class Planner(object):
         self.slam = slam
         self.map_resolution = self.slam.get_map_resolution()
 
-    def get_short_term_goal(self, robot_location, goal, step_size=25):
+    def get_short_term_goal(self, robot_location, goal, step_size=25,
+                            distance_threshold=None, angle_threshold=None):
         """
         robot_location is simply get_base_state
         """
@@ -54,7 +55,7 @@ class Planner(object):
         # against robot initial state (if it wasn't zeros)
         stg_real = self.slam.map2robot(stg)
 
-        if self.goal_within_threshold(stg_real, goal):
+        if self.goal_within_threshold(stg_real, goal, distance_threshold, angle_threshold):
             # is it the final goal? if so,
             # the stg goes to within a 5cm resolution
             # -- related to the SLAM service's 2D map resolution.
@@ -63,6 +64,7 @@ class Planner(object):
             print(
                 "Short-term goal {} is within threshold or target goal {}".format(stg_real, goal)
             )
+            print(f"This is the final goal, so returning the target goal directly {goal}")
             target_goal = goal
         else:
             print(
@@ -76,27 +78,31 @@ class Planner(object):
             target_goal = (stg_real[0], stg_real[1], rotation_angle)
         return target_goal
 
-    def goal_within_threshold(self, robot_location, goal):
-        distance = np.linalg.norm(np.array(robot_location[:2]) - np.array(goal[:2]))
-        # in metres. map_resolution is the resolution of the SLAM's 2D map, so the planner can't
-        # plan anything lower than this
-        threshold = (float(self.map_resolution) - 1e-10) / 100.0
+    def goal_within_threshold(self, robot_location, goal, threshold=None, angle_threshold=None):
+        if threshold is None:
+            # in metres. map_resolution is the resolution of the SLAM's 2D map, so the planner can't
+            # plan anything lower than this
+            threshold = (float(self.map_resolution) - 1e-10) / 100.0
+        if angle_threshold is None:
+            angle_threshold = 1  # in degrees
+
+        diff = np.abs(np.array(robot_location[:2]) - np.array(goal[:2]))
+        distance = np.linalg.norm(diff)
 
         if len(robot_location) == 3 and len(goal) == 3:
-            angle_threshold = 1  # in degrees
             angle = robot_location[2] - goal[2]
             abs_angle = math.fabs(math.degrees(angle)) % 360
 
-            within_threshold = distance < threshold and abs_angle < angle_threshold
+            within_threshold = diff[0] < threshold and diff[1] < threshold and abs_angle < angle_threshold
             print("goal_within_threshold: ", within_threshold)
-            print("Distance: {} < {}".format(distance, threshold))
+            print("Distance: x: {} < {}, y: {} < {}".format(diff[0], threshold, diff[1], threshold))
             print("Angle: {} < {}".format(abs_angle, angle_threshold))
             print("Robot Location: {}".format(robot_location))
             print("Goal:           {}".format(goal))
         else:
-            within_threshold = distance < threshold
+            within_threshold = diff[0] < threshold and diff[1] < threshold
             print("goal_within_threshold: ", within_threshold)
-            print("Distance: {} < {}".format(distance, threshold))
+            print("Distance: x: {} < {}, y: {} < {}".format(diff[0], threshold, diff[1], threshold))
             print("Robot Location: {}".format(robot_location))
             print("Goal:           {}".format(goal))
         return within_threshold

--- a/droidlet/lowlevel/locobot/remote/planning_service.py
+++ b/droidlet/lowlevel/locobot/remote/planning_service.py
@@ -20,8 +20,9 @@ class Planner(object):
         self.slam = slam
         self.map_resolution = self.slam.get_map_resolution()
 
-    def get_short_term_goal(self, robot_location, goal, step_size=25,
-                            distance_threshold=None, angle_threshold=None):
+    def get_short_term_goal(
+        self, robot_location, goal, step_size=25, distance_threshold=None, angle_threshold=None
+    ):
         """
         robot_location is simply get_base_state
         """
@@ -93,16 +94,22 @@ class Planner(object):
             angle = robot_location[2] - goal[2]
             abs_angle = math.fabs(math.degrees(angle)) % 360
 
-            within_threshold = diff[0] < threshold and diff[1] < threshold and abs_angle < angle_threshold
+            within_threshold = (
+                diff[0] < threshold and diff[1] < threshold and abs_angle < angle_threshold
+            )
             print("goal_within_threshold: ", within_threshold)
-            print("Distance: x: {} < {}, y: {} < {}".format(diff[0], threshold, diff[1], threshold))
+            print(
+                "Distance: x: {} < {}, y: {} < {}".format(diff[0], threshold, diff[1], threshold)
+            )
             print("Angle: {} < {}".format(abs_angle, angle_threshold))
             print("Robot Location: {}".format(robot_location))
             print("Goal:           {}".format(goal))
         else:
             within_threshold = diff[0] < threshold and diff[1] < threshold
             print("goal_within_threshold: ", within_threshold)
-            print("Distance: x: {} < {}, y: {} < {}".format(diff[0], threshold, diff[1], threshold))
+            print(
+                "Distance: x: {} < {}, y: {} < {}".format(diff[0], threshold, diff[1], threshold)
+            )
             print("Robot Location: {}".format(robot_location))
             print("Goal:           {}".format(goal))
         return within_threshold

--- a/droidlet/lowlevel/locobot/remote/slam_service.py
+++ b/droidlet/lowlevel/locobot/remote/slam_service.py
@@ -8,6 +8,7 @@ from slam_pkg.utils.map_builder import MapBuilder as mb
 from slam_pkg.utils import depth_util as du
 from skimage.morphology import disk, binary_dilation
 from rich import print
+from droidlet.lowlevel.pyro_utils import safe_call
 
 Pyro4.config.SERIALIZER = "pickle"
 Pyro4.config.SERIALIZERS_ACCEPTED.add("pickle")
@@ -91,7 +92,7 @@ class SLAM(object):
         self.map_builder.add_obstacle(location)
 
     def update_map(self):
-        pcd = self.robot.get_current_pcd()[0]
+        pcd = safe_call(self.robot.get_current_pcd)[0]
         self.map_builder.update_map(pcd)
 
         # explore the map by robot shape


### PR DESCRIPTION
## Effects: 

This PR brings in
-  significantly improved base odometry powered by a global LIDAR scan matcher, combined with a global optimizer that accounts for loop closures
- fixes some bugs in the planner that were making it stuck in-place in rare situations, because the grid map resolution, combined with navigation thresholds made it loop indefinitely

## Infrastructure

This PR adds:

- A ROS driver to
  - the base and joint {movement and statuses}
  - the lidar scans
  - [Hector SLAM](http://wiki.ros.org/hector_slam), a lidar-based SLAM with loop closure

The ROS driver was added for the base/joint/lidar because ROS generally wants to take full control of sensors -- and Hector SLAM is only available via ROS. The base/joint/lidar APIs dont really allow simultaneous usage among two processes.

The ROS driver is fully consistent with the non-ROS API. Userland should notice no difference.


## Code Review

### First commit: ROS drivers

You would want to review the first commit first, it's a large meaty commit.

- `launch.sh` adds in launching of ROS or non-ROS codepath via the `./launch.sh --ros` command-line argument
  - If running the ROS codepath, the user is expected to run `./launch_ros.sh` before-hand in a different terminal (as documented in the README). This launches some of the [stretch_core](https://github.com/hello-robot/stretch_ros/tree/master/stretch_core) ROS Services, and then launches hector_slam ROS Services.
- The ROS driver changes are isolated into four files (apart from `.launch` files):
  - `remote_hello_robot_ros.py` - this gives an API-compatible services as `remote_hello_robot.py`, but in the backend uses the ROS driver
  - `lidar_ros_driver.py` - this is the ROS driver that exposes lidar scans in the exact same format as original driver `lidar.py`
  - `stretch_ros_move_api.py` - this is the ROS driver that exposes move, base odometry, joint states, slam odometry
- `remote_hello_realsense.py` now has an optional `--ros` argument, which enables the ROS codepath for pulling LIDAR scans (and hence imports and uses `lidar_ros_driver.py` if this option is enabled)
- `goto` in `utils.py` which executes base movement for straightline trajectories has been generalized to work for both ROS and non-ROS backends

Other notes for this commit:
- We use the defaults for Hector SLAM (stretch_hector*.launch files), not trying to tune things yet. The defaults work great.

### Second commit:

- A subtle type-promotion bug identified during operation. If you give the XYT to `transform_global_to_base` as `[0, 0, 0]` then it treats it as a numpy int array, and the output transform ends up being wrong. The fix is simple, always cast it to float32 on entry

### Third commit:

The planner has lower resolution than the real world. By default, it has a planning grid with 5cm x 5cm tiles.
So, When the planner gets a given goal in world co-ordinates, it pulls a short-term goal, and it checks if the goal is within planner's resolution bounds.
However, this bounds-checking was incorrect because it used L2 Distance over the side of the grid, didn't account for diagonal / hypotenuse cases. I just simplified it by checking individual dimensions separately.