### PR TITLE
[MRP] Default to calling wait after down command

### DIFF
--- a/mrp/src/mrp/cmd/down.py
+++ b/mrp/src/mrp/cmd/down.py
@@ -33,5 +33,5 @@ def cli(*cmd_procs, procs=None, all=False, wait=True):
         click.echo(f"stopping {proc}...")
         life_cycle.set_ask(proc, life_cycle.Ask.DOWN)
 
-    if wait:
+    if wait and down_procs:
         wait_cmd(procs=list(down_procs))

--- a/mrp/src/mrp/cmd/down.py
+++ b/mrp/src/mrp/cmd/down.py
@@ -34,4 +34,4 @@ def cli(*cmd_procs, procs=None, all=False, wait=True):
         life_cycle.set_ask(proc, life_cycle.Ask.DOWN)
 
     if wait and down_procs:
-        mrp.cmd.wait(procs=list(down_procs))
+        mrp.cmd.wait(*down_procs)

--- a/mrp/src/mrp/cmd/down.py
+++ b/mrp/src/mrp/cmd/down.py
@@ -1,7 +1,7 @@
 from mrp import life_cycle
 from mrp import process_def
+from mrp import cmd
 from mrp.cmd import _autocomplete
-from mrp.cmd import wait as wait_cmd
 import click
 
 
@@ -34,4 +34,4 @@ def cli(*cmd_procs, procs=None, all=False, wait=True):
         life_cycle.set_ask(proc, life_cycle.Ask.DOWN)
 
     if wait and down_procs:
-        wait_cmd(procs=list(down_procs))
+        cmd.wait(procs=list(down_procs))

--- a/mrp/src/mrp/cmd/down.py
+++ b/mrp/src/mrp/cmd/down.py
@@ -1,6 +1,6 @@
+import mrp
 from mrp import life_cycle
 from mrp import process_def
-from mrp import cmd
 from mrp.cmd import _autocomplete
 import click
 
@@ -34,4 +34,4 @@ def cli(*cmd_procs, procs=None, all=False, wait=True):
         life_cycle.set_ask(proc, life_cycle.Ask.DOWN)
 
     if wait and down_procs:
-        cmd.wait(procs=list(down_procs))
+        mrp.cmd.wait(procs=list(down_procs))

--- a/mrp/src/mrp/cmd/down.py
+++ b/mrp/src/mrp/cmd/down.py
@@ -1,13 +1,15 @@
 from mrp import life_cycle
 from mrp import process_def
 from mrp.cmd import _autocomplete
+from mrp.cmd import wait as wait_cmd
 import click
 
 
 @click.command()
 @click.option("--all", is_flag=True)
+@click.option("--wait/--nowait", is_flag=True)
 @click.argument("procs", nargs=-1, shell_complete=_autocomplete.defined_processes)
-def cli(*cmd_procs, all=False, procs=None):
+def cli(*cmd_procs, procs=None, all=False, wait=True):
     procs = procs or []
 
     # Get all MRP procs running in the system
@@ -30,3 +32,6 @@ def cli(*cmd_procs, all=False, procs=None):
     for proc in down_procs:
         click.echo(f"stopping {proc}...")
         life_cycle.set_ask(proc, life_cycle.Ask.DOWN)
+
+    if wait:
+        wait_cmd(procs=list(down_procs))

--- a/mrp/src/mrp/cmd/up.py
+++ b/mrp/src/mrp/cmd/up.py
@@ -98,7 +98,7 @@ def down_existing(names: typing.List[str], force: bool):
 @click.option("--reset_logs", is_flag=True, default=False)
 def cli(
     *cmd_procs,
-    procs=[],
+    procs=None,
     verbose=True,
     deps=True,
     build=True,
@@ -107,6 +107,8 @@ def cli(
     force=False,
     reset_logs=False,
 ):
+    procs = procs or []
+
     # Support procs as *args when using cmd syntax.
     procs += cmd_procs
 

--- a/mrp/tests/cmd/test_down.py
+++ b/mrp/tests/cmd/test_down.py
@@ -1,6 +1,7 @@
 import pytest
 
 import mrp
+from mrp.life_cycle import State, Ask
 
 
 @pytest.fixture
@@ -14,12 +15,12 @@ def hanging_proc():
     # Define process to hang.
     mrp.process(
         name="proc",
-        runtime=mrp.Host(run_command=["read"]),
+        runtime=mrp.Host(run_command=["sleep", "999"]),
         env={"foo": "bar"},
     )
 
     # Run proc
-    mrp.cmd.up(procs=["proc"], reset_logs=True)
+    mrp.cmd.up("proc", reset_logs=True)
 
 
 @pytest.fixture
@@ -27,46 +28,53 @@ def hanging_proc_external():
     # Define process to hang.
     mrp.process(
         name="proc_ext",
-        runtime=mrp.Host(run_command=["read"]),
+        runtime=mrp.Host(run_command=["sleep", "999"]),
         env={"foo": "bar"},
     )
 
     # Run proc
-    mrp.cmd.up(procs=["proc_ext"], reset_logs=True)
+    mrp.cmd.up("proc_ext", reset_logs=True)
 
     # HACK Remove from defined processes
     mrp.process_def.defined_processes.pop("proc_ext")
 
 
 def test_down(reset, hanging_proc):
-    mrp.cmd.down()
-
     # proc should be told to go down
-    assert mrp.life_cycle.system_state().procs["proc"].ask == mrp.life_cycle.Ask.DOWN
+    mrp.cmd.down()
+    assert mrp.life_cycle.system_state().procs["proc"].ask == Ask.DOWN
 
 
 def test_down_all(reset, hanging_proc, hanging_proc_external):
-    mrp.cmd.down()
-
     # proc should be told to go down, but not proc_ext
-    assert mrp.life_cycle.system_state().procs["proc"].ask == mrp.life_cycle.Ask.DOWN
-    assert mrp.life_cycle.system_state().procs["proc_ext"].ask == mrp.life_cycle.Ask.UP
-
-    mrp.cmd.down(all=True)
+    mrp.cmd.down()
+    assert mrp.life_cycle.system_state().procs["proc"].ask == Ask.DOWN
+    assert mrp.life_cycle.system_state().procs["proc_ext"].ask == Ask.UP
 
     # proc should be told to go down
-    assert (
-        mrp.life_cycle.system_state().procs["proc_ext"].ask == mrp.life_cycle.Ask.DOWN
-    )
+    mrp.cmd.down(all=True)
+    assert mrp.life_cycle.system_state().procs["proc_ext"].ask == Ask.DOWN
 
 
 def test_down_proc(reset, hanging_proc):
-    mrp.cmd.down("not_proc")
-
     # proc should still be alive
-    assert mrp.life_cycle.system_state().procs["proc"].ask == mrp.life_cycle.Ask.UP
-
-    mrp.cmd.down(procs=["proc"])
+    mrp.cmd.down("not_proc")
+    assert mrp.life_cycle.system_state().procs["proc"].ask == Ask.UP
 
     # proc should be told to go down
-    assert mrp.life_cycle.system_state().procs["proc"].ask == mrp.life_cycle.Ask.DOWN
+    mrp.cmd.down("proc")
+    assert mrp.life_cycle.system_state().procs["proc"].ask == Ask.DOWN
+
+
+def test_wait(reset, hanging_proc):
+    # proc should be told to go down, but down should return immediately with wait=False
+    mrp.cmd.down("proc", wait=False)
+    assert mrp.life_cycle.system_state().procs["proc"].ask == Ask.DOWN
+    assert (
+        mrp.life_cycle.system_state().procs["proc"].state == State.STARTING
+        or State.STARTED
+    )
+
+    # proc should be stopped when expicit wait returns
+    mrp.cmd.wait("proc")
+    assert mrp.life_cycle.system_state().procs["proc"].state == State.STOPPED

--- a/mrp/tests/cmd/test_down.py
+++ b/mrp/tests/cmd/test_down.py
@@ -39,7 +39,7 @@ def hanging_proc_external():
 
 
 def test_down(reset, hanging_proc):
-    mrp.cmd.down()
+    mrp.cmd.down(wait=False)
 
     # proc should be told to go down
     assert mrp.life_cycle.system_state().procs["proc"].ask == mrp.life_cycle.Ask.DOWN
@@ -48,13 +48,13 @@ def test_down(reset, hanging_proc):
 
 
 def test_down_all(reset, hanging_proc, hanging_proc_external):
-    mrp.cmd.down()
+    mrp.cmd.down(wait=False)
 
     # proc should be told to go down, but not proc_ext
     assert mrp.life_cycle.system_state().procs["proc"].ask == mrp.life_cycle.Ask.DOWN
     assert mrp.life_cycle.system_state().procs["proc_ext"].ask == mrp.life_cycle.Ask.UP
 
-    mrp.cmd.down(all=True)
+    mrp.cmd.down(all=True, wait=False)
 
     # proc should be told to go down
     assert (
@@ -65,12 +65,12 @@ def test_down_all(reset, hanging_proc, hanging_proc_external):
 
 
 def test_down_proc(reset, hanging_proc):
-    mrp.cmd.down("not_proc")
+    mrp.cmd.down("not_proc", wait=False)
 
     # proc should still be alive
     assert mrp.life_cycle.system_state().procs["proc"].ask == mrp.life_cycle.Ask.UP
 
-    mrp.cmd.down(procs=["proc"])
+    mrp.cmd.down(procs=["proc"], wait=False)
 
     # proc should be told to go down
     assert mrp.life_cycle.system_state().procs["proc"].ask == mrp.life_cycle.Ask.DOWN

--- a/mrp/tests/cmd/test_down.py
+++ b/mrp/tests/cmd/test_down.py
@@ -39,40 +39,34 @@ def hanging_proc_external():
 
 
 def test_down(reset, hanging_proc):
-    mrp.cmd.down(wait=False)
+    mrp.cmd.down()
 
     # proc should be told to go down
     assert mrp.life_cycle.system_state().procs["proc"].ask == mrp.life_cycle.Ask.DOWN
 
-    mrp.cmd.wait()
-
 
 def test_down_all(reset, hanging_proc, hanging_proc_external):
-    mrp.cmd.down(wait=False)
+    mrp.cmd.down()
 
     # proc should be told to go down, but not proc_ext
     assert mrp.life_cycle.system_state().procs["proc"].ask == mrp.life_cycle.Ask.DOWN
     assert mrp.life_cycle.system_state().procs["proc_ext"].ask == mrp.life_cycle.Ask.UP
 
-    mrp.cmd.down(all=True, wait=False)
+    mrp.cmd.down(all=True)
 
     # proc should be told to go down
     assert (
         mrp.life_cycle.system_state().procs["proc_ext"].ask == mrp.life_cycle.Ask.DOWN
     )
 
-    mrp.cmd.wait()
-
 
 def test_down_proc(reset, hanging_proc):
-    mrp.cmd.down("not_proc", wait=False)
+    mrp.cmd.down("not_proc")
 
     # proc should still be alive
     assert mrp.life_cycle.system_state().procs["proc"].ask == mrp.life_cycle.Ask.UP
 
-    mrp.cmd.down(procs=["proc"], wait=False)
+    mrp.cmd.down(procs=["proc"])
 
     # proc should be told to go down
     assert mrp.life_cycle.system_state().procs["proc"].ask == mrp.life_cycle.Ask.DOWN
-
-    mrp.cmd.wait()

--- a/mrp/tests/cmd/test_down.py
+++ b/mrp/tests/cmd/test_down.py
@@ -14,7 +14,7 @@ def hanging_proc():
     # Define process to hang.
     mrp.process(
         name="proc",
-        runtime=mrp.Host(run_command=["sleep", "999"]),
+        runtime=mrp.Host(run_command=["read"]),
         env={"foo": "bar"},
     )
 
@@ -27,7 +27,7 @@ def hanging_proc_external():
     # Define process to hang.
     mrp.process(
         name="proc_ext",
-        runtime=mrp.Host(run_command=["sleep", "999"]),
+        runtime=mrp.Host(run_command=["read"]),
         env={"foo": "bar"},
     )
 


### PR DESCRIPTION
# Description

Changes:
- Have `down` call `wait` by default.
- Fix default argument issue in `up.py` that was somehow missed in #1143.
- Rearrange `test_down.py` for better readability. Also removed calls to `wait` that are no longer needed.
- Add test that tests the behavior of `down(wait=False)` and `wait()`

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [x] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

If this PR introduces a change or fixes a bug, please add before and after screenshots (if this is causes a UX change) or before and after examples(this could be plain text, videos etc ) to demonstrate the change.

If this PR introduces a new feature, please also add examples or screenshots demonstrating the feature.

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
