### PR TITLE
[Polymetis] Fix the Boolean value error when Kq, Kqd are explicitly set.

### DIFF
--- a/polymetis/polymetis/python/polymetis/robot_interface.py
+++ b/polymetis/polymetis/python/polymetis/robot_interface.py
@@ -408,13 +408,16 @@ class RobotInterface(BaseRobotInterface):
             time_to_go=time_to_go,
             hz=self.hz,
         )
-
+        if Kq is None:
+            Kq = self.Kq_default
+        if Kqd is None:
+            Kqd = self.Kqd_default
         # Create & execute policy
         torch_policy = toco.policies.JointTrajectoryExecutor(
             joint_pos_trajectory=[waypoint["position"] for waypoint in waypoints],
             joint_vel_trajectory=[waypoint["velocity"] for waypoint in waypoints],
-            Kp=Kq or self.Kq_default,
-            Kd=Kqd or self.Kqd_default,
+            Kp=Kq,
+            Kd=Kqd,
             robot_model=self.robot_model,
             ignore_gravity=self.use_grav_comp,
         )


### PR DESCRIPTION
# Description

Calling `move_to_joint_positions` method with Kq, Kdq keyword arguments make such an error.
```
  File "/fairo/polymetis/polymetis/python/polymetis/robot_interface.py", line 411, in move_to_joint_positions
    Kp=Kq or self.Kq_default,
RuntimeError: Boolean value of Tensor with more than one value is ambiguous
``` 
This commit fix this issue. 


## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

If this PR introduces a change or fixes a bug, please add before and after screenshots (if this is causes a UX change) or before and after examples(this could be plain text, videos etc ) to demonstrate the change.

If this PR introduces a new feature, please also add examples or screenshots demonstrating the feature.

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
