### PR TITLE
[Polymetis] Fix dependency update that broke CI

### DIFF
--- a/polymetis/polymetis/conda/conda_recipe/meta.yaml
+++ b/polymetis/polymetis/conda/conda_recipe/meta.yaml
@@ -41,7 +41,7 @@ requirements:
     - dash
     - doxygen
     - grpc-cpp ==1.41.1
-    - grpcio
+    - grpcio ==1.46.0
     - habitat-sim=0.2.1=py3.8_bullet_linux_fc7fb11ccec407753a73ab810d1dbb5f57d0f9b9
     - hydra-core==1.0.6
     - myst-parser

--- a/polymetis/polymetis/environment.yml
+++ b/polymetis/polymetis/environment.yml
@@ -32,7 +32,7 @@ dependencies:
     - boost-cpp ==1.72.0
     - breathe
     - dash
-    - grpcio
+    - grpcio ==1.46.0
     - habitat-sim=0.2.1=py3.8_bullet_linux_fc7fb11ccec407753a73ab810d1dbb5f57d0f9b9
     - hydra-core==1.0.6
     - myst-parser


### PR DESCRIPTION
# Description

The newest [grpcio](https://anaconda.org/conda-forge/grpcio) uses a newer version of `GLIBCXX` (3.4.30), which is not pre-installed on the ubuntu image we are currently using in CI.

Fixes issue where CI tests are breaking on `main`.

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

If this PR introduces a change or fixes a bug, please add before and after screenshots (if this is causes a UX change) or before and after examples(this could be plain text, videos etc ) to demonstrate the change.

If this PR introduces a new feature, please also add examples or screenshots demonstrating the feature.

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
