### PR TITLE
bug fix for tokenizer, change _convert_token_to_id to convert_tokens_…

### DIFF
--- a/droidlet/perception/semantic_parsing/nsp_transformer_model/caip_dataset.py
+++ b/droidlet/perception/semantic_parsing/nsp_transformer_model/caip_dataset.py
@@ -123,6 +123,7 @@ class CAIPDataset(Dataset):
         text, tree = tokenize_linearize(
             p_text, p_tree, self.tokenizer, self.full_tree, self.word_noise
         )
+
         text_idx_ls = self.tokenizer.convert_tokens_to_ids(text.split()) 
         tree_idx_ls = [
             [
@@ -145,14 +146,14 @@ class CAIPDataset(Dataset):
         ]
         if self.tree_to_text:
             stripped_tree_tokens = []
-            for w, bi, ei in tree:
+            for w, _, _, _, _, _ in tree:
                 tree_node = w.lower()
                 tree_node_processed = re.sub("[^0-9a-zA-Z]+", " ", tree_node)
                 tree_tokens = tree_node_processed.split(" ")
                 stripped_tree_tokens += [x for x in tree_tokens if x != ""]
 
             extended_tree = ["[CLS]"] + stripped_tree_tokens + ["[SEP]"]
-            tree_idx_ls = [self.tokenizer._convert_token_to_id(w) for w in extended_tree]
+            tree_idx_ls =  self.tokenizer.convert_tokens_to_ids(extended_tree)
         return (text_idx_ls, tree_idx_ls, (text, p_text, p_tree))
 
     def add_hard_example(self, exple):

--- a/droidlet/perception/semantic_parsing/nsp_transformer_model/caip_dataset.py
+++ b/droidlet/perception/semantic_parsing/nsp_transformer_model/caip_dataset.py
@@ -123,7 +123,7 @@ class CAIPDataset(Dataset):
         text, tree = tokenize_linearize(
             p_text, p_tree, self.tokenizer, self.full_tree, self.word_noise
         )
-        text_idx_ls = [self.tokenizer._convert_token_to_id(w) for w in text.split()]
+        text_idx_ls = self.tokenizer.convert_tokens_to_ids(text.split()) 
         tree_idx_ls = [
             [
                 self.tree_idxs[w],


### PR DESCRIPTION
# Description

The method of ```_convert_token_to_id``` has been deprecated and changes to ```convert_tokens_to_ids ``` in the newer version of transformer. ```__getitem__``` in ```CAIPDataset``` hasn't been updated to this change.

Fixes # (issue)

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

**Before**
<img width="1228" alt="Screen Shot 2022-05-20 at 2 58 28 PM" src="https://user-images.githubusercontent.com/27162640/169617889-44ebd3b6-3fed-4c95-ae91-8a484a444ceb.png">
**After**
<img width="965" alt="Screen Shot 2022-05-20 at 3 00 54 PM" src="https://user-images.githubusercontent.com/27162640/169618063-a9672348-11b9-4786-a438-ed6e05f205c0.png">



# Testing
If you don't have datasets under ```droidlet/artifacts```, you should run ```python agents/craftassist/craftassist_agent.py``` which will automatically download the dataset. 

Then under the root folder, run 
```
python tools/nsp_scripts/train_model.py --data_dir droidlet/artifacts/datasets/annotated_data/ --dtype_samples 'templated:.35;templated_filters:.05;annotated:.6' --tree_voc_file droidlet/artifacts/models/nlu/ttad_bert_updated/caip_test_model_tree.json --output_dir PATH_SAVING_MODELS
```
The training of NLU should be working now. 16GB memory might not be enough. In my case, reduce batch_size to 28 will address the issue of OUT_OF_CUDA_MEMORY.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
