### PR TITLE
mrp install sssd best effort

### DIFF
--- a/mrp/setup.py
+++ b/mrp/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="mrp",
-    version="0.1.8",
+    version="0.1.9",
     author="Leonid Shamis",
     package_dir={"": "src"},
     packages=find_packages(

--- a/mrp/src/mrp/runtime/docker.py
+++ b/mrp/src/mrp/runtime/docker.py
@@ -259,15 +259,19 @@ class Docker(BaseRuntime):
         if uses_ldap or nfs_mounts:
             dockerfile = [f"FROM {self.image}"]
             if uses_ldap:
-                dockerfile.append(
-                    " && ".join(
-                        [
-                            "RUN apt update",
-                            "DEBIAN_FRONTEND=noninteractive apt install -y sssd",
-                            "rm -rf /var/lib/apt/lists/*",
-                        ]
-                    )
+                # We try to inject sssd to allow the container to communicate with the ldap server.
+                # We assume the docker container provides apt. If there is no apt, we skip this step. The user id and group ids will still correctly match the active user, but the user and group names will not be fetchable.
+                apt_install_sssd_cmd = " && ".join(
+                    [
+                        "apt update",
+                        "DEBIAN_FRONTEND=noninteractive apt install -y sssd",
+                        "rm -rf /var/lib/apt/lists/*",
+                    ]
                 )
+                try_apt_install_sssd_cmd = (
+                    f"if [ $(which apt) ] ; then $({apt_install_sssd_cmd}) ; fi"
+                )
+                dockerfile.append(f"RUN {try_apt_install_sssd_cmd}")
             for nfs_mount in nfs_mounts:
                 relpath = os.path.relpath(nfs_mount["host"], nfs_mount["host_nfs_root"])
                 container_fullpath = os.path.join(


### PR DESCRIPTION
# Description

MRP attempts to runs processes as the executing user. When user accounts are defined off machine, such as in the case of ldap, MRP tries to inject sssd into the container. It currently tries using the in-container apt to perform this operation.
However, not all docker images are debian based or provide apt.

This PR is a temporary stop-gap that skips the install of sssd if there is no in-container apt.
Without sssd, users that are defined in active directory services will not see their names, but will be assigned the correct user/group ids.
Files created in mounted directories will have proper permissions.

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Before:
MRP docker runtime required debian based images if the user was an ldap.

After:
MRP docker runtime provides ldap user names in debian based images.

# Testing

Example 05 using an ldap account.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
