### PR TITLE
[Polymetis] Resolve communication constraints when loading large policies

### DIFF
--- a/polymetis/polymetis/include/polymetis/polymetis_server.hpp
+++ b/polymetis/polymetis/include/polymetis/polymetis_server.hpp
@@ -29,6 +29,7 @@
 #define MAX_MODEL_BYTES 1048576         // 1 megabyte
 #define THRESHOLD_NS 1000000000         // 1s
 #define SPIN_INTERVAL_USEC 20000        // 0.02s (50hz)
+#define NON_RT_PRIO 40
 
 using grpc::Server;
 using grpc::ServerBuilder;
@@ -90,6 +91,8 @@ public:
   bool validRobotContext();
 
   void resetControllerContext();
+
+  int setThreadPriority(int prio);
 
   // Robot client methods
 

--- a/polymetis/polymetis/include/polymetis/polymetis_server.hpp
+++ b/polymetis/polymetis/include/polymetis/polymetis_server.hpp
@@ -29,7 +29,7 @@
 #define MAX_MODEL_BYTES 1048576         // 1 megabyte
 #define THRESHOLD_NS 1000000000         // 1s
 #define SPIN_INTERVAL_USEC 20000        // 0.02s (50hz)
-#define NON_RT_PRIO 40
+#define RT_LOW_PRIO 40
 
 using grpc::Server;
 using grpc::ServerBuilder;

--- a/polymetis/polymetis/src/polymetis_server.cpp
+++ b/polymetis/polymetis/src/polymetis_server.cpp
@@ -234,7 +234,7 @@ Status PolymetisControllerServerImpl::SetController(
     ServerContext *context, ServerReader<ControllerChunk> *stream,
     LogInterval *interval) {
   std::lock_guard<std::mutex> service_lock(service_mtx_);
-  int orig_prio = setThreadPriority(NON_RT_PRIO);
+  int orig_prio = setThreadPriority(RT_LOW_PRIO);
 
   interval->set_start(-1);
   interval->set_end(-1);
@@ -288,7 +288,7 @@ Status PolymetisControllerServerImpl::UpdateController(
     ServerContext *context, ServerReader<ControllerChunk> *stream,
     LogInterval *interval) {
   std::lock_guard<std::mutex> service_lock(service_mtx_);
-  int orig_prio = setThreadPriority(NON_RT_PRIO);
+  int orig_prio = setThreadPriority(RT_LOW_PRIO);
 
   interval->set_start(-1);
   interval->set_end(-1);


### PR DESCRIPTION
# Description

Lowered thread priorities for non-realtime services like `SetController` and `UpdateController`.

## Debug Process

### Changing realtime thread attributes

3 modifications were found to resolve the communication constraint violations (in a script designed to repro the problem):
1. [Run SetController at lower realtime priority than other realtime processes (ControlUpdate and kernel threads)](https://github.com/facebookresearch/fairo/blob/8020f9ad6abd2cdc69751afbd7efb302b3a03b22/polymetis/polymetis/src/polymetis_server.cpp#L237)
1. Disabling FIFO scheduling policy for Polymetis threads (ControlUpdate and SetController) [here](https://github.com/facebookresearch/fairo/blob/bef6e4623642d37413c5a0dea74beeb04daa5169/polymetis/polymetis/include/real_time.hpp#L100)
1. Run Polymetis threads (ControlUpdate and SetController) at lower realtime priority [here](https://github.com/facebookresearch/fairo/blob/bef6e4623642d37413c5a0dea74beeb04daa5169/polymetis/polymetis/include/real_time.hpp#L106)

However, 2. and 3. both cause the server to be vulnerable to other sources of low priority CPU stress loads -- running `stress --cpu 8` while running the default controller now randomly triggers communication constraints, which was not the case without these changes.

Thus, lowering the priority of the `SetController` thread will prevent it from interfering with communication while loading controllers, but lowering the priority or changing the scheduling policy of other threads too will cause the control loop to be easily staggered by other processes.

### Digging deeper into exact priority values 

Large policies trigger communication constraints only when the SetController thread priority is >50. 49 causes no errors. 51 errors out consistently. This is independent of policy size as long as the size is large enough. If a policy is large enough to trigger communication constraints @ SetController priority = 80, then it will trigger communication constraints @ SetController priority = 51.

Inspection shows that kernel threads are mostly at rt priority 50 and 99:
```
>> ps ax -o rtprio,cmd | grep -v ' - '
RTPRIO CMD
     1 [rcuc/0]
     1 [rcu_preempt]
     1 [rcub/0]
    99 [posixcputmr/0]
    99 [migration/0]
    50 [idle_inject/0]
    50 [idle_inject/1]
    99 [migration/1]
    99 [posixcputmr/1]
     1 [rcuc/1]
    50 [idle_inject/2]
    99 [migration/2]
    99 [posixcputmr/2]
     1 [rcuc/2]
    50 [idle_inject/3]
    99 [migration/3]
    99 [posixcputmr/3]
     1 [rcuc/3]
    50 [idle_inject/4]
    99 [migration/4]
    99 [posixcputmr/4]
     1 [rcuc/4]
    50 [idle_inject/5]
    99 [migration/5]
    99 [posixcputmr/5]
     1 [rcuc/5]
    50 [idle_inject/6]
    99 [migration/6]
    99 [posixcputmr/6]
     1 [rcuc/6]
    50 [idle_inject/7]
    99 [migration/7]
    99 [posixcputmr/7]
     1 [rcuc/7]
    50 [idle_inject/8]
    99 [migration/8]
    99 [posixcputmr/8]
     1 [rcuc/8]
    50 [idle_inject/9]
    99 [migration/9]
    99 [posixcputmr/9]
     1 [rcuc/9]
    50 [idle_inject/10]
    99 [migration/10]
    99 [posixcputmr/10]
     1 [rcuc/10]
    50 [idle_inject/11]
    99 [migration/11]
    99 [posixcputmr/11]
     1 [rcuc/11]
    50 [irq/9-acpi]
    99 [watchdogd]
    50 [irq/122-PCIe PM]
    50 [irq/122-pciehp]
    49 [irq/122-s-pcieh]
    50 [irq/123-PCIe PM]
    50 [irq/125-pciehp]
    49 [irq/125-s-pcieh]
    50 [irq/127-xhci_hc]
    50 [irq/128-xhci_hc]
    50 [irq/8-rtc0]
    50 [irq/143-mmc0]
    49 [irq/143-s-mmc0]
    50 [irq/129-thunder]
    50 [irq/131-thunder]
    50 [irq/133-ahci[00]
    50 [irq/148-mei_me]
    50 [irq/149-iwlwifi]
    49 [irq/149-s-iwlwi]
    50 [irq/150-iwlwifi]
    49 [irq/150-s-iwlwi]
    50 [irq/151-iwlwifi]
    49 [irq/151-s-iwlwi]
    50 [irq/152-iwlwifi]
    49 [irq/152-s-iwlwi]
    50 [irq/153-iwlwifi]
    49 [irq/153-s-iwlwi]
    50 [irq/154-iwlwifi]
    49 [irq/154-s-iwlwi]
    50 [irq/155-iwlwifi]
    49 [irq/155-s-iwlwi]
    50 [irq/156-iwlwifi]
    49 [irq/156-s-iwlwi]
    50 [irq/157-iwlwifi]
    49 [irq/157-s-iwlwi]
    50 [irq/158-iwlwifi]
    49 [irq/158-s-iwlwi]
    50 [irq/159-iwlwifi]
    49 [irq/159-s-iwlwi]
    50 [irq/160-iwlwifi]
    49 [irq/160-s-iwlwi]
    50 [irq/161-iwlwifi]
    49 [irq/161-s-iwlwi]
    50 [irq/162-iwlwifi]
    49 [irq/162-s-iwlwi]
    50 [irq/16-idma64.0]
    50 [irq/16-i2c_desi]
    50 [irq/18-idma64.1]
    50 [irq/18-i2c_desi]
    50 [irq/163-i915]
    50 [irq/164-snd_hda]
    50 [irq/65-i2c-INT3]
    50 [irq/130-eno1]
```
Explanation by @0wu: Thus if `SetController` priority is larger than 50, it may preempt kernel threads such as network IRQ handlers, preventing UDP packets from getting sent out.

### Benchmarks

Benchmarks were performed by sending simple controllers that immediately terminates, but contains a large tensor as a member variable. Dynamically setting the `SetController` service thread priorities to different values, as well as different policy sizes were tested.
Results were averaged over 20 runs for each config.

(note that a 2 second "joint move to" policy is roughly 0.1 MB)

Control latencies across timesteps while loading the controller:
![image](https://user-images.githubusercontent.com/9565466/171210417-71ed92a8-b24b-493f-80f9-f7d014cc5f83.png)
![image](https://user-images.githubusercontent.com/9565466/171210656-9b062c1d-0604-4a42-8b3c-37f04f27de92.png)


Max control latency incurred while loading the controller:
![image](https://user-images.githubusercontent.com/9565466/171210498-e1821cfd-6aef-4425-b1ed-17e1763350eb.png)
![image](https://user-images.githubusercontent.com/9565466/171210691-7fd04d39-2243-4f45-aef4-2dc4a6f44e68.png)


Results show that having the controller loading thread set to priority = 48 significantly reduces the lag spikes induced within the control loop, compared with 50 and 52.


## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [x] I want a deep design review.

## Before and After

If this PR introduces a change or fixes a bug, please add before and after screenshots (if this is causes a UX change) or before and after examples(this could be plain text, videos etc ) to demonstrate the change.

If this PR introduces a new feature, please also add examples or screenshots demonstrating the feature.

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
