### PR TITLE
[Polymetis] Fix memory leak when loading controllers

### DIFF
--- a/polymetis/polymetis/include/polymetis/polymetis_server.hpp
+++ b/polymetis/polymetis/include/polymetis/polymetis_server.hpp
@@ -60,7 +60,7 @@ struct CustomControllerContext {
   uint timestep = 0;
   ControllerStatus status = UNINITIALIZED;
   std::mutex controller_mtx;
-  TorchScriptedController *custom_controller = nullptr;
+  std::unique_ptr<TorchScriptedController> custom_controller;
 
   ~CustomControllerContext() { delete custom_controller; }
 };

--- a/polymetis/polymetis/include/polymetis/polymetis_server.hpp
+++ b/polymetis/polymetis/include/polymetis/polymetis_server.hpp
@@ -61,8 +61,6 @@ struct CustomControllerContext {
   ControllerStatus status = UNINITIALIZED;
   std::mutex controller_mtx;
   std::unique_ptr<TorchScriptedController> custom_controller;
-
-  ~CustomControllerContext() { delete custom_controller; }
 };
 
 /**

--- a/polymetis/polymetis/src/polymetis_server.cpp
+++ b/polymetis/polymetis/src/polymetis_server.cpp
@@ -187,7 +187,7 @@ PolymetisControllerServerImpl::ControlUpdate(ServerContext *context,
   // Select controller
   TorchScriptedController *controller;
   if (custom_controller_context_.status == RUNNING) {
-    controller = custom_controller_context_.custom_controller;
+    controller = custom_controller_context_.custom_controller.get();
   } else {
     controller = robot_client_context_.default_controller;
   }

--- a/polymetis/polymetis/src/polymetis_server.cpp
+++ b/polymetis/polymetis/src/polymetis_server.cpp
@@ -234,6 +234,8 @@ Status PolymetisControllerServerImpl::SetController(
     ServerContext *context, ServerReader<ControllerChunk> *stream,
     LogInterval *interval) {
   std::lock_guard<std::mutex> service_lock(service_mtx_);
+
+  TorchScriptedController *new_controller, *old_controller;
   int orig_prio = setThreadPriority(RT_LOW_PRIO);
 
   interval->set_start(-1);
@@ -253,7 +255,7 @@ Status PolymetisControllerServerImpl::SetController(
 
   try {
     // Load new controller
-    auto new_controller = new TorchScriptedController(
+    new_controller = new TorchScriptedController(
         controller_model_buffer_.data(), controller_model_buffer_.size(),
         *torch_robot_state_);
 
@@ -261,7 +263,7 @@ Status PolymetisControllerServerImpl::SetController(
     custom_controller_context_.controller_mtx.lock();
 
     resetControllerContext();
-    auto old_controller = custom_controller_context_.custom_controller;
+    old_controller = custom_controller_context_.custom_controller;
     custom_controller_context_.custom_controller = new_controller;
     custom_controller_context_.status = READY;
 

--- a/polymetis/polymetis/src/polymetis_server.cpp
+++ b/polymetis/polymetis/src/polymetis_server.cpp
@@ -261,11 +261,14 @@ Status PolymetisControllerServerImpl::SetController(
     custom_controller_context_.controller_mtx.lock();
 
     resetControllerContext();
+    auto old_controller = custom_controller_context_.custom_controller;
     custom_controller_context_.custom_controller = new_controller;
     custom_controller_context_.status = READY;
 
     custom_controller_context_.controller_mtx.unlock();
     spdlog::info("Loaded new controller.");
+
+    delete old_controller;
 
   } catch (const std::exception &e) {
     std::string error_msg =


### PR DESCRIPTION
# Description

Remove cause of memory leak when re-assigning pointers that point to old controllers.

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

If this PR introduces a change or fixes a bug, please add before and after screenshots (if this is causes a UX change) or before and after examples(this could be plain text, videos etc ) to demonstrate the change.

If this PR introduces a new feature, please also add examples or screenshots demonstrating the feature.

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
