### PR TITLE
Clarification fails on GET_MEMORY commands

### DIFF
--- a/agents/craftassist/craftassist_agent.py
+++ b/agents/craftassist/craftassist_agent.py
@@ -379,9 +379,9 @@ class CraftAssistAgent(DroidletAgent):
             chat_text = chat
 
         logging.info("Sending chat: {}".format(chat_text))
-        self.memory.nodes[ChatNode.NODE_TYPE].create(self.memory, self.memory.self_memid, chat_text)
+        chat_memid = self.memory.nodes[ChatNode.NODE_TYPE].create(self.memory, self.memory.self_memid, chat_text)
 
-        if chat_json:
+        if chat_json and not isinstance(chat_json, int):
             chat_json["chat_memid"] = chat_memid
             chat_json["timestamp"] = round(datetime.timestamp(datetime.now()) * 1000)
             # Send the socket event to show this reply on dashboard

--- a/droidlet/interpreter/interpret_reference_objects.py
+++ b/droidlet/interpreter/interpret_reference_objects.py
@@ -217,7 +217,12 @@ def interpret_reference_object(
         candidate_mems = apply_memory_filters(interpreter, speaker, filters_d)
 
         # Compare num matches to expected and clarify
-        if (len(candidate_mems) != num_refs) and allow_clarification:
+        if (
+            (len(candidate_mems) != num_refs)
+            and allow_clarification
+            and interpreter.logical_form["dialogue_type"] == "HUMAN_GIVE_COMMAND"
+        ):
+            # TODO extend clarification to work with more 'dialogue_type's
             clarify_reference_objects(interpreter, speaker, d, candidate_mems, num_refs)
             raise NextDialogueStep()
 


### PR DESCRIPTION
# Description

Turk Oncall discovered that clarification contains some fragilities when responding to get_memory commands.  This PR closes the two small bugs that were uncovered: when the agent sends a chat that is just an integer, and when the logical form does not contain an `event_sequence`.

## Type of change

Please check the options that are relevant.

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [X] I want a high level review. 
- [ ] I want a deep design review.

# Testing

One set of commands to test would be:
"build a cube"
"how many cubes are there?"

# Checklist:

- [X] I have performed manual end-to-end testing of the feature in my environment.
- [X] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [X] New and existing unit tests pass locally with my changes.
- [X] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
