### PR TITLE
Fix nowhere bug

### DIFF
--- a/agents/craftassist/craftassist_agent.py
+++ b/agents/craftassist/craftassist_agent.py
@@ -18,7 +18,7 @@ from copy import deepcopy
 # also used as a standalone script and invoked via `python craftassist_agent.py`
 from droidlet.interpreter.craftassist import default_behaviors, inventory, dance
 from droidlet.memory.craftassist import mc_memory
-from droidlet.memory.memory_nodes import ChatNode
+from droidlet.memory.memory_nodes import ChatNode, SelfNode
 from droidlet.shared_data_struct import rotation
 from droidlet.lowlevel.minecraft.craftassist_mover import (
     CraftassistMover,
@@ -39,7 +39,6 @@ from droidlet.dialog.dialogue_task import build_question_json
 from droidlet.base_util import Pos, Look, npy_to_blocks_list
 from droidlet.shared_data_struct.craftassist_shared_utils import Player, Item
 from agents.droidlet_agent import DroidletAgent
-from droidlet.memory.memory_nodes import PlayerNode
 from droidlet.perception.semantic_parsing.nsp_querier import NSPQuerier
 from agents.argument_parser import ArgumentParser
 from droidlet.dialog.craftassist.mc_dialogue_task import MCBotCapabilities
@@ -326,7 +325,8 @@ class CraftAssistAgent(DroidletAgent):
                     ybad = y >= pt[1] and y <= pt[4]
                     zbad = z >= pt[2] and z <= pt[5]
                     if xbad and ybad and zbad:
-                        if b in safe_blocks: safe_blocks.remove(b)
+                        if b in safe_blocks:
+                            safe_blocks.remove(b)
         else:
             safe_blocks = blocks
         return safe_blocks
@@ -379,7 +379,9 @@ class CraftAssistAgent(DroidletAgent):
             chat_text = chat
 
         logging.info("Sending chat: {}".format(chat_text))
-        self.memory.nodes[ChatNode.NODE_TYPE].create(self.memory, self.memory.self_memid, chat_text)
+        self.memory.nodes[ChatNode.NODE_TYPE].create(
+            self.memory, self.memory.self_memid, chat_text
+        )
 
         if chat_json:
             chat_json["chat_memid"] = chat_memid
@@ -390,7 +392,6 @@ class CraftAssistAgent(DroidletAgent):
             sio.emit("showAssistantReply", {"agent_reply": "Agent: {}".format(chat_text)})
 
         return self.cagent.send_chat(chat_text)
-
 
     def update_agent_pos_dashboard(self):
         agent_pos = self.get_player().pos
@@ -499,7 +500,7 @@ class CraftAssistAgent(DroidletAgent):
             p = self.get_player()
         except:  # this is for test/test_agent
             return
-        PlayerNode.create(self.memory, p, memid=self.memory.self_memid)
+        SelfNode.update(self.memory, p, memid=self.memory.self_memid)
 
 
 if __name__ == "__main__":

--- a/agents/locobot/locobot_agent.py
+++ b/agents/locobot/locobot_agent.py
@@ -79,8 +79,13 @@ class LocobotAgent(DroidletAgent):
         self.no_default_behavior = opts.no_default_behavior
         self.last_chat_time = -1000000000000
         self.name = name
-        self.player = Player(100, name, Pos(0, 0, 0), Look(0, 0))
+
+        # FIXME these should only be stored in memory, not here
+        self.pitch = 0.0
+        self.yaw = 0.0
         self.pos = Pos(0, 0, 0)
+        self.player = Player(100, name, self.pos, Look(self.yaw, self.pitch))
+
         self.uncaught_error_count = 0
         self.last_task_memid = None
         self.point_targets = []

--- a/agents/locobot/self_perception.py
+++ b/agents/locobot/self_perception.py
@@ -21,7 +21,7 @@ class SelfPerception:
             # FIXME! agent pose memory type+data structure
             self.agent.pos = np.array(base_pos[:2], dtype="float32")
             self.agent.base_yaw = float(base_pos[2])
-            # TODO get rid of this:
+            # FIXME get rid of this:
             self.agent.yaw = float(base_pos[2] + pan)
             self.agent.pan = float(pan)
             self.agent.pitch = float(tilt)

--- a/agents/locobot/self_perception.py
+++ b/agents/locobot/self_perception.py
@@ -9,7 +9,6 @@ class SelfPerception:
         self.agent = agent
         self.memory = agent.memory
         self.perceive_freq = perceive_freq
-        self.update_self_memory()
 
     def perceive(self, force=False):
         # FIXME (low pri) remove these in code, get from sql

--- a/agents/locobot/self_perception.py
+++ b/agents/locobot/self_perception.py
@@ -9,24 +9,7 @@ class SelfPerception:
         self.agent = agent
         self.memory = agent.memory
         self.perceive_freq = perceive_freq
-        self.add_self_memory_node()
-
-    def add_self_memory_node(self):
-        # clean this up!  FIXME!!!!! put in base_agent_memory?
-        # how/when to, memory is initialized before physical interfaces...
-        # currently use self_memid for eid
-        self.memory.db_write(
-            "INSERT INTO ReferenceObjects(uuid, eid, name, ref_type, x, y, z, pitch, yaw) VALUES (?,?,?,?,?,?,?,?,?)",
-            self.memory.self_memid,
-            self.memory.self_memid,
-            self.agent.name,
-            "player",
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-        )
+        self.update_self_memory()
 
     def perceive(self, force=False):
         # FIXME (low pri) remove these in code, get from sql
@@ -47,6 +30,8 @@ class SelfPerception:
 
     def update_self_memory(self):
         memid = self.agent.memory.self_memid
+        # FIXME use SelfNode update
+        # FIXME put all of this in perception
         cmd = "UPDATE ReferenceObjects SET eid=?, name=?, x=?,  y=?, z=?, pitch=?, yaw=? WHERE "
         cmd = cmd + "uuid=?"
         # using self_memid as eid too

--- a/droidlet/interpreter/robot/tests/fake_agent.py
+++ b/droidlet/interpreter/robot/tests/fake_agent.py
@@ -322,11 +322,6 @@ class FakeMover:
         self.turn = Turn(self, agent)
         self.gripper_state = "open"  # open, closed, occupied
 
-        # FIXME these should only be stored in memory, not here
-        self.pitch = 0.0
-        self.yaw = 0.0
-        self.pos = Pos(0, 0, 0)
-
     #        self.set_joint_positions = SetJointPositions(agent)
     #        self.set_pan = SetPan(agent)
     #        self.set_pan_tilt = SetPanTilt(agent)

--- a/droidlet/interpreter/robot/tests/fake_agent.py
+++ b/droidlet/interpreter/robot/tests/fake_agent.py
@@ -6,7 +6,7 @@ import numpy as np
 import re
 import logging
 import math
-from droidlet.base_util import Look, to_player_struct
+from droidlet.base_util import Pos, Look, to_player_struct
 from droidlet.interpreter import InterpreterBase
 from droidlet.interpreter.robot import dance
 from droidlet.memory.memory_nodes import PlayerNode
@@ -321,6 +321,11 @@ class FakeMover:
         self.drop = Drop(self, agent)
         self.turn = Turn(self, agent)
         self.gripper_state = "open"  # open, closed, occupied
+
+        # FIXME these should only be stored in memory, not here
+        self.pitch = 0.0
+        self.yaw = 0.0
+        self.pos = Pos(0, 0, 0)
 
     #        self.set_joint_positions = SetJointPositions(agent)
     #        self.set_pan = SetPan(agent)

--- a/droidlet/interpreter/tests/test_interpret_attribute.py
+++ b/droidlet/interpreter/tests/test_interpret_attribute.py
@@ -15,7 +15,7 @@ from droidlet.shared_data_structs import ErrorWithResponse
 from droidlet.interpreter.interpret_attributes import AttributeInterpreter
 from droidlet.interpreter.tests import all_test_commands
 from droidlet.memory.memory_filters import MemorySearcher
-from droidlet.memory.memory_nodes import PlayerNode, AttentionNode
+from droidlet.memory.memory_nodes import SelfNode, PlayerNode, AttentionNode
 from droidlet.base_util import Pos, Look, Player
 
 
@@ -68,7 +68,7 @@ def dummy_specify_locations(interpreter, speaker, mems, steps, reldir):
 class BasicSearchWithAttributesTest(unittest.TestCase):
     def test_linear_extent_search(self):
         self.memory = AgentMemory()
-        PlayerNode.create(
+        SelfNode.update(
             self.memory,
             Player(0, "self", Pos(-1, 0, -1), Look(0, 0)),
             memid=self.memory.self_memid,

--- a/droidlet/memory/craftassist/mc_memory.py
+++ b/droidlet/memory/craftassist/mc_memory.py
@@ -10,6 +10,7 @@ from droidlet.memory.sql_memory import AgentMemory, DEFAULT_PIXELS_PER_UNIT
 from droidlet.base_util import diag_adjacent, IDM, XYZ, Block, npy_to_blocks_list
 from droidlet.memory.memory_nodes import (  # noqa
     TaskNode,
+    SelfNode,
     PlayerNode,
     MemoryNode,
     ChatNode,
@@ -172,11 +173,6 @@ class MCAgentMemory(AgentMemory):
         # 3. Update agent's current position and attributes in memory
         if perception_output.agent_attributes:
             agent_player = perception_output.agent_attributes
-            memid = (
-                self.nodes[PlayerNode.NODE_TYPE]
-                .get_player_by_eid(self, agent_player.entityId)
-                .memid
-            )
             cmd = (
                 "UPDATE ReferenceObjects SET eid=?, name=?, x=?,  y=?, z=?, pitch=?, yaw=? WHERE "
             )
@@ -190,11 +186,11 @@ class MCAgentMemory(AgentMemory):
                 agent_player.pos.z,
                 agent_player.look.pitch,
                 agent_player.look.yaw,
-                memid,
+                self.self_memid,
             )
             ap = (agent_player.pos.x, agent_player.pos.y, agent_player.pos.z)
             self.place_field.update_map(
-                [{"pos": ap, "is_obstacle": True, "memid": memid, "is_move": True}]
+                [{"pos": ap, "is_obstacle": True, "memid": self.self_memid, "is_move": True}]
             )
 
         # 4. Update other in-game players in agent's memory

--- a/droidlet/memory/memory_filters.py
+++ b/droidlet/memory/memory_filters.py
@@ -510,14 +510,7 @@ class MemorySearcher:
         else:
             # queries with no WHERE clause will not return archived/snapshotted memories.
             # to get a snapshot or to get all mems snapshotted or not use explicit WHERE.
-            node_types = agent_memory.node_children.get(memtype, [])
-            memids = [
-                m[0]
-                for nt in node_types
-                for m in agent_memory._db_read(
-                    "SELECT uuid FROM Memories WHERE node_type=? AND is_snapshot=?", nt, 0
-                )
-            ]
+            memids = get_all_memids_of_node_type(agent_memory, memtype)
         memids = self.handle_selector(agent_memory, query, memids)
         if self.ignore_self:
             try:

--- a/droidlet/memory/memory_filters.py
+++ b/droidlet/memory/memory_filters.py
@@ -508,11 +508,15 @@ class MemorySearcher:
         if query.get("where_clause"):
             memids = self.handle_where(agent_memory, query["where_clause"], memtype)
         else:
+            # queries with no WHERE clause will not return archived/snapshotted memories.
+            # to get a snapshot or to get all mems snapshotted or not use explicit WHERE.
             node_types = agent_memory.node_children.get(memtype, [])
             memids = [
                 m[0]
                 for nt in node_types
-                for m in agent_memory._db_read("SELECT uuid FROM Memories WHERE node_type=?", nt)
+                for m in agent_memory._db_read(
+                    "SELECT uuid FROM Memories WHERE node_type=? AND is_snapshot=?", nt, 0
+                )
             ]
         memids = self.handle_selector(agent_memory, query, memids)
         if self.ignore_self:

--- a/droidlet/memory/memory_nodes.py
+++ b/droidlet/memory/memory_nodes.py
@@ -686,6 +686,7 @@ class PlayerNode(ReferenceObjectNode):
             >>> create(memory, player_struct)
         """
         memid = memid or cls.new(memory)
+
         memory.db_write(
             "INSERT INTO ReferenceObjects(uuid, eid, name, x, y, z, pitch, yaw, ref_type) VALUES (?,?,?,?,?,?,?,?,?)",
             memid,
@@ -763,7 +764,7 @@ class PlayerNode(ReferenceObjectNode):
 
 
 class SelfNode(PlayerNode):
-    """This class is a special PLayerNode for representing the
+    """This class is a special PlayerNode for representing the
     agent's self
 
     Args:
@@ -783,6 +784,36 @@ class SelfNode(PlayerNode):
 
     TABLE_COLUMNS = ["uuid", "eid", "name", "x", "y", "z", "pitch", "yaw", "ref_type"]
     NODE_TYPE = "Self"
+
+    @classmethod
+    def create(cls, memory, player_struct=None, memid=None) -> str:
+        """Creates a new entry into the ReferenceObjects table
+
+        Returns:
+            string: memid of the entry
+
+        """
+        memid = memid or cls.new(memory)
+        if player_struct is None:
+            eid, name, x, y, z, pitch, yaw = None, None, None, None, None, None, None
+        else:
+            eid, name = player_struct.entityId, player_struct.name
+            x, y, z = player_struct.pos
+            yaw, pitch = player_struct.look
+        cmd = "INSERT INTO ReferenceObjects(uuid, eid, name, x, y, z, pitch, yaw, ref_type) VALUES (?,?,?,?,?,?,?,?,?)"
+        memory.db_write(cmd, memid, eid, name, x, y, z, pitch, yaw, "self")
+        memory.nodes[TripleNode.NODE_TYPE].tag(memory, memid, "AGENT")
+        memory.nodes[TripleNode.NODE_TYPE].tag(memory, memid, "SELF")
+        memory.nodes[TripleNode.NODE_TYPE].tag(memory, memid, "_physical_object")
+        memory.nodes[TripleNode.NODE_TYPE].tag(memory, memid, "_animate")
+        # this is a hack until memory_filters does "not"
+        memory.nodes[TripleNode.NODE_TYPE].tag(memory, memid, "_not_location")
+
+        if name is not None:
+            memory.nodes[TripleNode.NODE_TYPE].create(
+                memory, subj=memid, pred_text="has_name", obj_text=player_struct.name
+            )
+        return memid
 
 
 # locations should always be archives?

--- a/droidlet/memory/sql_memory.py
+++ b/droidlet/memory/sql_memory.py
@@ -23,6 +23,7 @@ from droidlet.memory.place_field import PlaceField, EmptyPlaceField
 from droidlet.memory.memory_nodes import (  # noqa
     TaskNode,
     TripleNode,
+    SelfNode,
     PlayerNode,
     ProgramNode,
     MemoryNode,
@@ -143,10 +144,8 @@ class AgentMemory:
         self.db_write(
             "INSERT INTO Memories VALUES (?,?,?,?,?,?)", self.self_memid, "Self", 0, 0, -1, False
         )
-
-        self.nodes[TripleNode.NODE_TYPE].tag(self, self.self_memid, "_physical_object")
-        self.nodes[TripleNode.NODE_TYPE].tag(self, self.self_memid, "_animate")
-        self.nodes[TripleNode.NODE_TYPE].tag(self, self.self_memid, "_not_location")
+        player_struct = None
+        SelfNode.create(self, player_struct, memid=self.self_memid)
         self.nodes[TripleNode.NODE_TYPE].tag(self, self.self_memid, "AGENT")
         self.nodes[TripleNode.NODE_TYPE].tag(self, self.self_memid, "SELF")
 

--- a/droidlet/memory/tests/test_low_level_memory.py
+++ b/droidlet/memory/tests/test_low_level_memory.py
@@ -227,10 +227,9 @@ class BasicTest(unittest.TestCase):
     # TODO: expand these
     def test_sql_form(self):
         self.memory = AgentMemory()
-        # FIXME? should this be in memory init?
-        # FIXME!! in agents use SelfNode instead of PlayerNode
-        self_memid = SelfNode.create(
-            self.memory, Player(1, "robot", Pos(0, 0, 0), Look(0, 0)), memid=self.memory.self_memid
+        self_mem = self.memory.get_mem_by_id(self.memory.self_memid)
+        SelfNode.update(
+            self.memory, Player(1, "robot", Pos(0, 0, 0), Look(0, 0)), self.memory.self_memid
         )
         rachel_memid = PlayerNode.create(
             self.memory, Player(10, "rachel", Pos(1, 0, 1), Look(0, 0))
@@ -370,6 +369,9 @@ class BasicTest(unittest.TestCase):
             self.memory.nodes[PlayerNode.NODE_TYPE].get_player_by_eid(self.memory, 10).name
             == "joey"
         )
+
+        # Test empty WHERE clause:
+        _, memnodes = self.memory.basic_search("SELECT MEMORY FROM ReferenceObject")
 
         # Test basic_search to get player by name
         _, memnode = self.memory.basic_search(


### PR DESCRIPTION
# Description

Corrects basic search queries with no WHERE clause.   Previous bug was due to archives being returned along with active memories despite not having an entry in the relevant table.  along the way this PR defaults agent memory to build a SelfNode (not doing so was breaking the tests).

Fixes # (issue)
https://github.com/facebookresearch/fairo/issues/1192


## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [x] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [x] I have added tests that show that the PR is functional.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
