### PR TITLE
[Polymetis] Allow different libfranka versions in install script

### DIFF
--- a/polymetis/docs/source/installation.md
+++ b/polymetis/docs/source/installation.md
@@ -45,13 +45,11 @@
 1. Build from source:
     - Optionally, build [libfranka](https://frankaemika.github.io/docs/libfranka.html) for use on Franka Panda hardware:
         ```bash
-        # OPTIONAL: checkout custom version of libfranka
-        cd ./polymetis/src/clients/franka_panda_client/libfranka
-        git checkout 0.9.0
-        cd -
-        
         # Build libfranka
         ./scripts/build_libfranka.sh
+
+        # OPTIONAL: Build custom version of libfranka instead
+        ./scripts/build_libfranka.sh <version_tag_or_commit_hash>
         ```
     - Optionally, [install the CUDA-enabled version of PyTorch](https://pytorch.org/get-started/locally/) (by default, only the CPU version is enabled).
     - Build Polymetis from source:

--- a/polymetis/scripts/build_libfranka.sh
+++ b/polymetis/scripts/build_libfranka.sh
@@ -6,17 +6,21 @@
 # LICENSE file in the root directory of this source tree.
 
 GIT_ROOT=$(git rev-parse --show-toplevel)
-
+LIBFRANKA_VER=$1
 LIBFRANKA_PATH="$GIT_ROOT/polymetis/polymetis/src/clients/franka_panda_client/third_party/libfranka"
 
 # Check to make sure directory exists
 [ ! -d $LIBFRANKA_PATH ] && echo "Directory $LIBFRANKA_PATH does not exist" && exit 1
 
-# Ensure submodules exist
+# Update libfranka version & submodules
+cd $LIBFRANKA_PATH
+if [ ! -z "$LIBFRANKA_VER" ]; then git checkout $LIBFRANKA_VER; fi
 git submodule update --init --recursive
+cd -
 
 # Build
 BUILD_PATH="${LIBFRANKA_PATH}/build"
+if [ -d "$BUILD_PATH" ]; then rm -r $BUILD_PATH; fi
 mkdir -p $BUILD_PATH && cd $BUILD_PATH
 echo "Building libfranka at $BUILD_PATH"
 


### PR DESCRIPTION
# Description

Subset of changes contained in #1198 that minimally fixes the problem where the libfranka install script always checks out the polymetis-specifed version of libfranka.

Fixes #1199

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

If this PR introduces a change or fixes a bug, please add before and after screenshots (if this is causes a UX change) or before and after examples(this could be plain text, videos etc ) to demonstrate the change.

If this PR introduces a new feature, please also add examples or screenshots demonstrating the feature.

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
