### PR TITLE
Enable memory_2d map for Craftassist Agent

### DIFF
--- a/agents/argument_parser.py
+++ b/agents/argument_parser.py
@@ -98,6 +98,10 @@ class ArgumentParser:
             default=False,
             help="run thenearby_airtouching_blocks heuristic?",
         )
+        mc_parser.add_argument(
+            "--draw_map", 
+            default="memory", 
+            help='"" for no map in dashboard, "memory" to draw from agent memory')        
         mc_parser.add_argument("--port", type=int, default=25565)
 
     def add_loco_parser(self):

--- a/agents/craftassist/craftassist_agent.py
+++ b/agents/craftassist/craftassist_agent.py
@@ -22,7 +22,9 @@ from droidlet.memory.memory_nodes import ChatNode
 from droidlet.shared_data_struct import rotation
 from droidlet.lowlevel.minecraft.craftassist_mover import (
     CraftassistMover,
+    from_minecraft_look_to_droidlet,
     from_minecraft_xyz_to_droidlet,
+    Look,
 )
 
 from droidlet.lowlevel.minecraft.shapes import SPECIAL_SHAPE_FNS
@@ -289,7 +291,10 @@ class CraftAssistAgent(DroidletAgent):
             sem_seg_perception_output = self.perception_modules["semseg"].perceive()
             self.memory.update(sem_seg_perception_output)
         self.areas_to_perceive = []
+        # 5. update dashboard world and map
         self.update_dashboard_world()
+        if self.opts.draw_map == "memory":
+            self.draw_map_to_dashboard()
 
     def get_time(self):
         """round to 100th of second, return as
@@ -391,6 +396,43 @@ class CraftAssistAgent(DroidletAgent):
 
         return self.cagent.send_chat(chat_text)
 
+    def get_detected_objects_for_map(self):
+        # FIXME should not be using WHERE clause hack
+        search_res = self.memory.basic_search("SELECT MEMORY FROM ReferenceObject WHERE y>-500")
+        memids, mems = search_res if search_res is not None else [], []
+        detections_for_map = []
+        for mem in mems:
+            if hasattr(mem, "pos"):
+                id_str = "no_id" if not hasattr(mem, "obj_id") else mem.obj_id
+                detections_for_map.append([id_str, list(mem.pos)])
+        return detections_for_map
+
+    def draw_map_to_dashboard(self, obstacles=None, xyyaw=None):
+        detections_for_map = []
+        if not obstacles:
+            obstacles = self.memory.place_field.get_obstacle_list()
+            # if we are getting obstacles from memory, get detections from memory for map too
+            detections_for_map = self.get_detected_objects_for_map()
+        if not xyyaw:            
+            agent_pos = self.get_player().pos   # position of agent's feet
+            agent_look = self.get_player().look
+            mc_xyz = agent_pos.x, agent_pos.y, agent_pos.z
+            mc_look = Look(agent_look.yaw, agent_look.pitch)
+            x, _, z = from_minecraft_xyz_to_droidlet(mc_xyz)
+            yaw, _ = from_minecraft_look_to_droidlet(mc_look)
+            xyyaw = (x, z, yaw)
+
+        sio.emit(
+            "map",
+            {
+                "x": xyyaw[0],
+                "y": xyyaw[1],
+                "yaw": xyyaw[2],
+                "map": obstacles,
+                "draw_map": self.opts.draw_map,
+                "detections_from_memory": detections_for_map,
+            },
+        )
 
     def update_agent_pos_dashboard(self):
         agent_pos = self.get_player().pos

--- a/agents/craftassist/craftassist_agent.py
+++ b/agents/craftassist/craftassist_agent.py
@@ -399,7 +399,9 @@ class CraftAssistAgent(DroidletAgent):
     def get_detected_objects_for_map(self):
         # FIXME should not be using WHERE clause hack
         search_res = self.memory.basic_search("SELECT MEMORY FROM ReferenceObject WHERE y>-500")
-        memids, mems = search_res if search_res is not None else [], []
+        memids, mems = [], []
+        if search_res is not None:
+            memids, mems = search_res
         detections_for_map = []
         for mem in mems:
             if hasattr(mem, "pos"):

--- a/droidlet/dashboard/web/src/StateManager.js
+++ b/droidlet/dashboard/web/src/StateManager.js
@@ -365,10 +365,7 @@ class StateManager {
   }
 
   setLastChatActionDict(res) {
-<<<<<<< HEAD
     console.log("StateManager setLastChatActionDict");
-=======
->>>>>>> main
     this.memory.lastChatActionDict = res.action_dict;
     this.refs.forEach((ref) => {
       if (ref instanceof InteractApp) {
@@ -402,25 +399,19 @@ class StateManager {
   }
 
   showAssistantReply(res) {
-<<<<<<< HEAD
-    console.log(
-      "StateManager showAssistantReply " + JSON.stringify(res.agent_reply)
-    );
-    this.memory.agent_replies.push({
-      msg: res.agent_reply,
-      timestamp: Date.now(),
-    });
-    this.memory.last_reply = res.agent_reply;
-=======
     // TODO handle content types besides plain text
-    
+
     let chat, response_options, isQuestion, questionType;
     try {
-      if (res.content_type === "point") { return }  // Let the minecraft client handle point
+      if (res.content_type === "point") {
+        return;
+      } // Let the minecraft client handle point
       let content = res.content;
-      chat = content.filter(entry => entry["id"] === "text")[0]["content"];
+      chat = content.filter((entry) => entry["id"] === "text")[0]["content"];
       if (res.content_type === "chat_and_text_options") {
-        response_options = content.filter(entry => entry["id"] === "response_option").map(x => x["content"]);
+        response_options = content
+          .filter((entry) => entry["id"] === "response_option")
+          .map((x) => x["content"]);
         isQuestion = true;
         questionType = "clarification";
       } else {
@@ -434,8 +425,7 @@ class StateManager {
       isQuestion = false;
     }
     this.memory.last_reply = chat;
-    
->>>>>>> main
+
     this.refs.forEach((ref) => {
       if (ref instanceof InteractApp) {
         ref.setState({
@@ -443,7 +433,7 @@ class StateManager {
           response_options: response_options,
         });
         ref.addNewAgentReplies({
-          msg: chat, 
+          msg: chat,
           isQuestion: isQuestion,
           questionType: questionType,
           enableBack: false,
@@ -1071,6 +1061,7 @@ class StateManager {
   }
 
   processMap(res) {
+    console.log(JSON.stringify(res));
     this.refs.forEach((ref) => {
       if (ref instanceof Memory2D) {
         ref.setState({

--- a/droidlet/memory/craftassist/mc_memory.py
+++ b/droidlet/memory/craftassist/mc_memory.py
@@ -60,7 +60,7 @@ class MCAgentMemory(AgentMemory):
         schema_paths=SCHEMAS,
         load_minecraft_specs=True,
         load_block_types=True,
-        preception_range=PERCEPTION_RANGE,
+        perception_range=PERCEPTION_RANGE,
         agent_time=None,
         coordinate_transforms=None,
         agent_low_level_data={},
@@ -83,7 +83,7 @@ class MCAgentMemory(AgentMemory):
         self.check_inside_perception = agent_low_level_data.get("check_inside", None)
 
         self.dances = {}
-        self.perception_range = preception_range
+        self.perception_range = perception_range
 
         if copy_from_backup is not None:
             copy_from_backup.backup(self.db)

--- a/polymetis/docs/source/installation.md
+++ b/polymetis/docs/source/installation.md
@@ -45,13 +45,11 @@
 1. Build from source:
     - Optionally, build [libfranka](https://frankaemika.github.io/docs/libfranka.html) for use on Franka Panda hardware:
         ```bash
-        # OPTIONAL: checkout custom version of libfranka
-        cd ./polymetis/src/clients/franka_panda_client/libfranka
-        git checkout 0.9.0
-        cd -
-        
         # Build libfranka
         ./scripts/build_libfranka.sh
+
+        # OPTIONAL: Build custom version of libfranka instead
+        ./scripts/build_libfranka.sh <version_tag_or_commit_hash>
         ```
     - Optionally, [install the CUDA-enabled version of PyTorch](https://pytorch.org/get-started/locally/) (by default, only the CPU version is enabled).
     - Build Polymetis from source:

--- a/polymetis/scripts/build_libfranka.sh
+++ b/polymetis/scripts/build_libfranka.sh
@@ -6,17 +6,21 @@
 # LICENSE file in the root directory of this source tree.
 
 GIT_ROOT=$(git rev-parse --show-toplevel)
-
+LIBFRANKA_VER=$1
 LIBFRANKA_PATH="$GIT_ROOT/polymetis/polymetis/src/clients/franka_panda_client/third_party/libfranka"
 
 # Check to make sure directory exists
 [ ! -d $LIBFRANKA_PATH ] && echo "Directory $LIBFRANKA_PATH does not exist" && exit 1
 
-# Ensure submodules exist
+# Update libfranka version & submodules
+cd $LIBFRANKA_PATH
+if [ ! -z "$LIBFRANKA_VER" ]; then git checkout $LIBFRANKA_VER; fi
 git submodule update --init --recursive
+cd -
 
 # Build
 BUILD_PATH="${LIBFRANKA_PATH}/build"
+if [ -d "$BUILD_PATH" ]; then rm -r $BUILD_PATH; fi
 mkdir -p $BUILD_PATH && cd $BUILD_PATH
 echo "Building libfranka at $BUILD_PATH"
 


### PR DESCRIPTION
# Description

(Fresh version of [earlier PR](https://github.com/facebookresearch/fairo/pull/1180))
The map that displays in the in the memory_2d pane for the Locobot agent was not previously implemented for the Craftassist agent. With this PR, we can now see the agent, obstacles from the obstacle map, and other detected objects as points plotted on the map pane.

Fixes # (issue)

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Before:
<img width="1728" alt="Screen Shot 2022-05-20 at 4 26 50 PM" src="https://user-images.githubusercontent.com/54821527/172488456-fd75a8fc-244e-4073-b48c-c68556b52f14.png">


After:
![Screen Shot 2022-06-07 at 2 49 58 PM](https://user-images.githubusercontent.com/54821527/172489047-55fe4860-09e4-4ff4-9992-ab7c522e458d.png)


# Testing

You can see a map :) And the agent program + dashboard doesn't break when rendering the map after a multitude of test commands. This diff won't affect any of the previously implemented unit tests, and it seems to pass all of the existing ones.

Oftentimes you'll only see the bot marker on the map, you can populate the agent's perceived obstacle map by issuing a command. For example, to produce the 'After' picture, run your cuberite instance with command `python droidlet/lowlevel/minecraft/cuberite_process.py --config really_flat_world` and issue the command `move three steps left`.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [x] I have added Docstrings and comments to the code.
- [x] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
