### PR TITLE
[Polymetis] Make EE link name optional for robot client metadata

### DIFF
--- a/polymetis/polymetis/python/polymetis/robot_interface.py
+++ b/polymetis/polymetis/python/polymetis/robot_interface.py
@@ -285,11 +285,7 @@ class RobotInterface(BaseRobotInterface):
 
         with tempfile.NamedTemporaryFile("w+") as urdf_file:
             urdf_file.write(self.metadata.urdf_file)
-            if self.metadata.ee_link_name:
-                self.set_robot_model(urdf_file.name, self.metadata.ee_link_name)
-            else:
-                # ee link name is empty string
-                self.set_robot_model(urdf_file.name, None)
+            self.set_robot_model(urdf_file.name, self.metadata.ee_link_name)
 
         self.set_home_pose(torch.Tensor(self.metadata.rest_pose))
 

--- a/polymetis/polymetis/python/polymetis/robot_interface.py
+++ b/polymetis/polymetis/python/polymetis/robot_interface.py
@@ -285,9 +285,10 @@ class RobotInterface(BaseRobotInterface):
 
         with tempfile.NamedTemporaryFile("w+") as urdf_file:
             urdf_file.write(self.metadata.urdf_file)
-            if hasattr(self.metadata, "ee_link_name"):
+            if self.metadata.ee_link_name:
                 self.set_robot_model(urdf_file.name, self.metadata.ee_link_name)
             else:
+                # ee link name is empty string
                 self.set_robot_model(urdf_file.name, None)
 
         self.set_home_pose(torch.Tensor(self.metadata.rest_pose))

--- a/polymetis/polymetis/python/polymetis/robot_interface.py
+++ b/polymetis/polymetis/python/polymetis/robot_interface.py
@@ -285,7 +285,10 @@ class RobotInterface(BaseRobotInterface):
 
         with tempfile.NamedTemporaryFile("w+") as urdf_file:
             urdf_file.write(self.metadata.urdf_file)
-            self.set_robot_model(urdf_file.name, self.metadata.ee_link_name)
+            if hasattr(self.metadata, "ee_link_name"):
+                self.set_robot_model(urdf_file.name, self.metadata.ee_link_name)
+            else:
+                self.set_robot_model(urdf_file.name, None)
 
         self.set_home_pose(torch.Tensor(self.metadata.rest_pose))
 

--- a/polymetis/polymetis/python/torchcontrol/models/torchscript_pinocchio.py
+++ b/polymetis/polymetis/python/torchcontrol/models/torchscript_pinocchio.py
@@ -42,19 +42,19 @@ class RobotModelPinocchio(torch.nn.Module):
                                       by default.
     """
 
-    def __init__(self, urdf_filename: str, ee_link_name: str = None):
+    def __init__(self, urdf_filename: str, ee_link_name: str = ""):
         super().__init__()
         self.model = torch.classes.torchscript_pinocchio.RobotModelPinocchio(
             urdf_filename, False
         )
-        self.ee_link_name = None
+        self.ee_link_name = ""
         self.ee_link_idx = None
         self.set_ee_link(ee_link_name)
 
-    def set_ee_link(self, ee_link_name):
+    def set_ee_link(self, ee_link_name: str = ""):
         """Sets the `ee_link_name`, `ee_link_idx` using pinocchio::ModelTpl::getBodyId."""
         self.ee_link_name = ee_link_name
-        if self.ee_link_name is not None:
+        if self.ee_link_name:
             self.ee_link_idx = self.model.get_link_idx_from_name(self.ee_link_name)
         else:
             self.ee_link_idx = None

--- a/polymetis/polymetis/python/torchcontrol/models/torchscript_pinocchio.py
+++ b/polymetis/polymetis/python/torchcontrol/models/torchscript_pinocchio.py
@@ -35,7 +35,7 @@ class RobotModelPinocchio(torch.nn.Module):
 
     Args:
         urdf_filename (str): path to the urdf file.
-        ee_link_name (str, optional): name of the end-effector link. Defaults to None,
+        ee_link_name (str, optional): name of the end-effector link. Defaults to "",
                                       which would require you to specify link_name
                                       when using methods which require a link frame;
                                       otherwise, the end-effector link will be used

--- a/polymetis/polymetis/python/torchcontrol/models/torchscript_pinocchio.py
+++ b/polymetis/polymetis/python/torchcontrol/models/torchscript_pinocchio.py
@@ -35,11 +35,11 @@ class RobotModelPinocchio(torch.nn.Module):
 
     Args:
         urdf_filename (str): path to the urdf file.
-        ee_link_name (str, optional): name of the end-effector link. Defaults to "",
-                                      which would require you to specify link_name
-                                      when using methods which require a link frame;
-                                      otherwise, the end-effector link will be used
-                                      by default.
+        ee_link_name (str, optional): name of the end-effector link. Defaults to None.
+                                      Having a value of either None or "" would require
+                                      you to specify link_name when using methods which
+                                      require a link frame; otherwise, the end-effector
+                                      link will be used by default.
     """
 
     def __init__(self, urdf_filename: str, ee_link_name: Optional[str] = None):

--- a/polymetis/polymetis/python/torchcontrol/models/torchscript_pinocchio.py
+++ b/polymetis/polymetis/python/torchcontrol/models/torchscript_pinocchio.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 import os
-from typing import Tuple
+from typing import Tuple, Optional
 
 import torch
 from polymetis.utils.data_dir import PKG_ROOT_DIR
@@ -42,21 +42,22 @@ class RobotModelPinocchio(torch.nn.Module):
                                       by default.
     """
 
-    def __init__(self, urdf_filename: str, ee_link_name: str = ""):
+    def __init__(self, urdf_filename: str, ee_link_name: Optional[str] = None):
         super().__init__()
         self.model = torch.classes.torchscript_pinocchio.RobotModelPinocchio(
             urdf_filename, False
         )
-        self.ee_link_name = ""
+        self.ee_link_name = None
         self.ee_link_idx = None
         self.set_ee_link(ee_link_name)
 
-    def set_ee_link(self, ee_link_name: str = ""):
+    def set_ee_link(self, ee_link_name: Optional[str] = None):
         """Sets the `ee_link_name`, `ee_link_idx` using pinocchio::ModelTpl::getBodyId."""
         self.ee_link_name = ee_link_name
-        if self.ee_link_name:
+        if self.ee_link_name is not None and self.ee_link_name:
             self.ee_link_idx = self.model.get_link_idx_from_name(self.ee_link_name)
-        else:
+        else:  # self.ee_link_name = None or ""
+            self.ee_link_name = None
             self.ee_link_idx = None
 
     def _get_link_idx_or_use_ee(self, link_name: str) -> int:

--- a/polymetis/polymetis/python/torchcontrol/models/torchscript_pinocchio.py
+++ b/polymetis/polymetis/python/torchcontrol/models/torchscript_pinocchio.py
@@ -53,11 +53,16 @@ class RobotModelPinocchio(torch.nn.Module):
 
     def set_ee_link(self, ee_link_name: Optional[str] = None):
         """Sets the `ee_link_name`, `ee_link_idx` using pinocchio::ModelTpl::getBodyId."""
-        self.ee_link_name = ee_link_name
-        if self.ee_link_name is not None and self.ee_link_name:
-            self.ee_link_idx = self.model.get_link_idx_from_name(self.ee_link_name)
-        else:  # self.ee_link_name = None or ""
+        # Set ee_link_name
+        if ee_link_name == "":  # also treat an empty string as default value
             self.ee_link_name = None
+        else:
+            self.ee_link_name = ee_link_name
+
+        # Set ee_link_idx
+        if self.ee_link_name is not None:
+            self.ee_link_idx = self.model.get_link_idx_from_name(self.ee_link_name)
+        else:
             self.ee_link_idx = None
 
     def _get_link_idx_or_use_ee(self, link_name: str) -> int:


### PR DESCRIPTION
# Description

The Allegro hand configs do not designate a ee link, which would cause RobotInterface to initialize the robot model with an empty string, triggering an invalid link name error. Change RobotModelPinocchio to default with empty string instead of `None`.

Fixes #1203

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

If this PR introduces a change or fixes a bug, please add before and after screenshots (if this is causes a UX change) or before and after examples(this could be plain text, videos etc ) to demonstrate the change.

If this PR introduces a new feature, please also add examples or screenshots demonstrating the feature.

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
