### PR TITLE
Reference object interpretation robust to no logical form

### DIFF
--- a/droidlet/interpreter/interpret_reference_objects.py
+++ b/droidlet/interpreter/interpret_reference_objects.py
@@ -216,11 +216,16 @@ def interpret_reference_object(
 
         candidate_mems = apply_memory_filters(interpreter, speaker, filters_d)
 
-        # Compare num matches to expected and clarify
+        # Clarification only enabled for HUMAN_GIVE_COMMAND
+        command_type = None
+        if hasattr(interpreter, "logical_form"):
+            command_type = interpreter.logical_form.get("dialogue_type", None)
+
+        # Compare num matches to expected and clarify        
         if (
             (len(candidate_mems) != num_refs)
             and allow_clarification
-            and interpreter.logical_form["dialogue_type"] == "HUMAN_GIVE_COMMAND"
+            and command_type == "HUMAN_GIVE_COMMAND"
         ):
             # TODO extend clarification to work with more 'dialogue_type's
             clarify_reference_objects(interpreter, speaker, d, candidate_mems, num_refs)

--- a/droidlet/interpreter/interpret_reference_objects.py
+++ b/droidlet/interpreter/interpret_reference_objects.py
@@ -221,7 +221,7 @@ def interpret_reference_object(
         if hasattr(interpreter, "logical_form"):
             command_type = interpreter.logical_form.get("dialogue_type", None)
 
-        # Compare num matches to expected and clarify        
+        # Compare num matches to expected and clarify
         if (
             (len(candidate_mems) != num_refs)
             and allow_clarification


### PR DESCRIPTION
# Description

#1197 assumed that an interpreter would always have a `logical_form` attribute, which is not the case in our unit tests.  I merged too hastily.

## Type of change

Please check the options that are relevant.

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [X] I want a high level review. 
- [ ] I want a deep design review.

# Testing

Unit tests pass, and I tested the clarification pathway to make sure this change is not breaking for that either.

# Checklist:

- [X] I have performed manual end-to-end testing of the feature in my environment.
- [X] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [X] New and existing unit tests pass locally with my changes.
- [X] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
