### PR TITLE
Craftassist bugfixes

### DIFF
--- a/agents/argument_parser.py
+++ b/agents/argument_parser.py
@@ -102,9 +102,10 @@ class ArgumentParser:
             help="run thenearby_airtouching_blocks heuristic?",
         )
         mc_parser.add_argument(
-            "--draw_map", 
-            default="memory", 
-            help='"" for no map in dashboard, "memory" to draw from agent memory')        
+            "--draw_map",
+            default="",
+            help='"" for no map in dashboard, "memory" to draw from agent memory',
+        )
         mc_parser.add_argument("--port", type=int, default=25565)
 
     def add_loco_parser(self):

--- a/agents/craftassist/craftassist_agent.py
+++ b/agents/craftassist/craftassist_agent.py
@@ -384,7 +384,9 @@ class CraftAssistAgent(DroidletAgent):
             chat_text = chat
 
         logging.info("Sending chat: {}".format(chat_text))
-        chat_memid = self.memory.nodes[ChatNode.NODE_TYPE].create(self.memory, self.memory.self_memid, chat_text)
+        chat_memid = self.memory.nodes[ChatNode.NODE_TYPE].create(
+            self.memory, self.memory.self_memid, chat_text
+        )
 
         if chat_json and not isinstance(chat_json, int):
             chat_json["chat_memid"] = chat_memid
@@ -394,7 +396,7 @@ class CraftAssistAgent(DroidletAgent):
         else:
             sio.emit("showAssistantReply", {"agent_reply": "Agent: {}".format(chat_text)})
 
-        return self.send_chat(chat_text)
+        return self.mover.send_chat(chat_text)
 
     def get_detected_objects_for_map(self):
         search_res = self.memory.basic_search("SELECT MEMORY FROM ReferenceObject")
@@ -414,8 +416,8 @@ class CraftAssistAgent(DroidletAgent):
             obstacles = self.memory.place_field.get_obstacle_list()
             # if we are getting obstacles from memory, get detections from memory for map too
             detections_for_map = self.get_detected_objects_for_map()
-        if not xyyaw:            
-            agent_pos = self.get_player().pos   # position of agent's feet
+        if not xyyaw:
+            agent_pos = self.get_player().pos  # position of agent's feet
             agent_look = self.get_player().look
             mc_xyz = agent_pos.x, agent_pos.y, agent_pos.z
             mc_look = Look(agent_look.yaw, agent_look.pitch)

--- a/droidlet/interpreter/interpret_conditions.py
+++ b/droidlet/interpreter/interpret_conditions.py
@@ -24,6 +24,10 @@ class ConditionInterpreter:
         d: logical form from semantic parser
         """
         error_msg = "I thought there was a condition but I don't understand it:"
+        # FIXME! there are some leftover incorrect "condition_type" keys in data
+        if d.get("condition_type") is not None:
+            if d["condition_type"] == "ALWAYS" or d["condition_type"] == "NEVER":
+                d = {"condition": d["condition_type"]}
         if d.get("condition") is None:
             raise ErrorWithResponse(error_msg + " {}".format(d))
         d = d["condition"]

--- a/droidlet/interpreter/interpret_reference_objects.py
+++ b/droidlet/interpreter/interpret_reference_objects.py
@@ -222,8 +222,9 @@ def interpret_reference_object(
             command_type = interpreter.logical_form.get("dialogue_type", None)
 
         # Compare num matches to expected and clarify
+        # for now don't enter into clarification pathway if |candidate_mem| > num_refs, it isn't built out...
         if (
-            (len(candidate_mems) != num_refs)
+            (len(candidate_mems) < num_refs)
             and allow_clarification
             and command_type == "HUMAN_GIVE_COMMAND"
         ):


### PR DESCRIPTION
# Description

Fixes several regressions that crept in to craftassist agent

1: defaults to not updating dashboard memory map, current update is slow
2: agent doesn't send chats properly bc bug in voxel world PR, fixed here
3: check for extra "condition_type" key in NEVER conditions
4: fixes a regression where clarification was getting initiated when more ref objs were found than required, but that clarification pathway isn't built out yet

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

