### PR TITLE
clean main training script for nlu model

### DIFF
--- a/droidlet/perception/semantic_parsing/nsp_transformer_model/train_model.py
+++ b/droidlet/perception/semantic_parsing/nsp_transformer_model/train_model.py
@@ -1,3 +1,4 @@
+
 """
 Copyright (c) Facebook, Inc. and its affiliates.
 """
@@ -7,116 +8,165 @@ import json
 import logging
 import logging.handlers
 import os
-import pickle
+import math
+import shutil
 from time import time
 
 from os.path import isfile
 from os.path import join as pjoin
 from tqdm import tqdm
 
+import torch
+import torch.utils.tensorboard
 from torch.utils.data import DataLoader, RandomSampler, SequentialSampler
-from transformers import AutoModel, AutoTokenizer, BertConfig
+from torch.optim import Adam
 
-from .utils_parsing import *
-from .utils_caip import *
-from .decoder_with_loss import *
-from .encoder_decoder import *
-from .optimizer_warmup import *
-from .caip_dataset import *
+from droidlet.perception.semantic_parsing.nsp_transformer_model.utils_model import build_model
+from droidlet.perception.semantic_parsing.utils.nsp_logger import NSPLogger
+from droidlet.perception.semantic_parsing.nsp_transformer_model.utils_parsing import (
+    compute_accuracy,
+    beam_search,
+)
+from droidlet.perception.semantic_parsing.nsp_transformer_model.utils_caip import (
+    make_full_tree,
+    process_txt_data,
+    caip_collate,
+)
+from droidlet.perception.semantic_parsing.nsp_transformer_model.optimizer_warmup import (
+    OptimWarmupEncoderDecoder,
+)
+from droidlet.perception.semantic_parsing.nsp_transformer_model.caip_dataset import CAIPDataset
 
 
-class ModelTrainer:
-    """Wrapper Class around training model and data loader"""
+class NLUModelTrainer:
+    """Wrapper Class around NLU model trainer"""
 
-    def __init__(self, args):
+    def __init__(self, args, model, tokenizer, model_identifier, full_tree_voc):
+        # Setup arguments
         self.args = args
+        self.text_span_loss_attenuation_factor = self.args.alpha
+        self.fixed_value_loss_attenuation_factor = self.args.fixed_value_weight
+        self.model_identifier = model_identifier
+        self.full_tree_voc = full_tree_voc
 
-    def train(self, model, dataset, tokenizer, model_identifier, full_tree_voc):
-        """Training loop (all epochs at once)
-
-        Args:
-            model: Decoder to be trained
-            dataset: Training dataset
-            tokenizer: Tokenizer for input
-            model_identifier: Identifier string used when saving the model files
-            full_tree_voc: full tree vocabulary
-
-        Returns:
-            Tuple of (Loss, Accuracy)
-
-        """
-        # make data sampler
-        train_sampler = RandomSampler(dataset)
-        logging.info("Initializing train data sampler: {}".format(train_sampler))
-        model_collate_fn = functools.partial(
-            caip_collate, tokenizer=tokenizer, tree_to_text=self.args.tree_to_text
+        # Initialize logger for machine-readable logs
+        self.train_outputs_logger = NSPLogger(
+            "training_outputs.csv",
+            [
+                "epoch",
+                "iteration",
+                "loss",
+                "accuracy",
+                "text_span_loss",
+                "text_span_accuracy",
+                "time",
+            ],
         )
-        train_dataloader = DataLoader(
-            dataset,
-            sampler=train_sampler,
-            batch_size=self.args.batch_size,
-            collate_fn=model_collate_fn,
+        self.valid_outputs_logger = NSPLogger(
+            "valid_outputs.csv",
+            [
+                "epoch",
+                "data_type",
+                "loss",
+                "accuracy",
+                "text_span_loss",
+                "text_span_accuracy",
+                "time",
+            ],
         )
-        epoch_iterator = tqdm(train_dataloader, desc="Iteration", disable=True)
-        # make optimizer
-        optimizer = OptimWarmupEncoderDecoder(model, self.args)
-        text_span_optimizer = Adam(
+        if self.args.tensorboard_dir:
+            tensorboard_dir = os.path.join(self.args.tensorboard_dir, self.model_identifier)
+            self.tb = torch.utils.tensorboard.SummaryWriter(log_dir=tensorboard_dir)
+        else:
+            self.tb = None
+
+        # Assign model with loss and tokenizer
+        self.model = model
+        self.tokenizer = tokenizer
+
+        # Initialize different optimizers for text span and fixed span heads
+        self.optimizer = OptimWarmupEncoderDecoder(model, self.args)
+        self.text_span_optimizer = Adam(
             [
                 {"params": model.decoder.text_span_start_head.parameters()},
                 {"params": model.decoder.text_span_end_head.parameters()},
             ],
             lr=0.001,
         )
-        fixed_span_optimizer = Adam(
-            [
-                {"params": model.decoder.fixed_span_head.parameters()},
-            ],
-            lr=0.001,
+        self.fixed_span_optimizer = Adam(
+            [{"params": model.decoder.fixed_span_head.parameters()}], lr=0.001
         )
-        text_span_loss_attenuation_factor = self.args.alpha
-        fixed_value_loss_attenuation_factor = self.args.fixed_value_weight
-        # training loop
-        for e in range(self.args.num_epochs):
-            logging.info("Epoch: {}".format(e))
-            loc_steps = 0
-            loc_loss = 0.0
-            loc_int_acc = 0.0
-            loc_span_acc = 0.0
-            loc_full_acc = 0.0
-            text_span_accuracy = 0.0
-            tot_steps = 0
-            tot_loss = 0.0
-            text_span_tot_loss = 0.0
-            text_span_loc_loss = 0.0
-            tot_accuracy = 0.0
-            st_time = time()
-            for step, batch in enumerate(epoch_iterator):
-                batch_examples = batch[-1]
-                batch_tensors = [
-                    t.to(model.decoder.lm_head.predictions.decoder.weight.device)
-                    for t in batch[:4]
-                ]
-                x, x_mask, y, y_mask = batch_tensors
-                if self.args.tree_to_text:
-                    outputs = model(y, y_mask, x, x_mask)
-                else:
-                    outputs = model(x, x_mask, y, y_mask)
-                loss = outputs["loss"]
-                text_span_loss = outputs["text_span_loss"]
-                fixed_span_loss = outputs["fixed_span_loss"]
+
+    def run_epoch(self, phase, epoch, dataset, dataloader):
+        """
+        Model runs through given dataloader for single epoch
+        Args:
+            phase: Running phase, train or validation
+            epoch: The current training epoch
+            dataset: Dataset
+            dataloader: Dataset loader
+        Returns:
+            Tuple of (Loss, Accuracy, Steps, Train Dataset)
+            or
+            (Loss, Int. Accuracy, Span Accuracy, Accuracy, Text Span Accuracy, Text Span Loss)
+        """
+        model = self.model
+        if phase == "train":
+            model.train()
+        else:
+            model.eval()
+
+        epoch_iterator = tqdm(dataloader, desc="Iteration", disable=True)
+        ep_steps = 0
+        ep_loss = 0.0
+        ep_int_acc = 0.0
+        ep_span_acc = 0.0
+        ep_full_acc = 0.0
+        ep_text_span_accuracy = 0.0
+        ep_text_span_loss = 0.0
+
+        loc_steps = 0
+        loc_loss = 0.0
+        loc_int_acc = 0.0
+        loc_span_acc = 0.0
+        loc_full_acc = 0.0
+        loc_text_span_accuracy = 0.0
+        loc_text_span_loss = 0.0
+        st_time = time()
+        for step, batch in enumerate(epoch_iterator):
+            batch_examples = batch[-1]
+            batch_tensors = [
+                t.to(model.decoder.lm_head.predictions.decoder.weight.device) for t in batch[:4]
+            ]
+            x, x_mask, y, y_mask = batch_tensors
+
+            # pass batch data through model
+            if self.args.tree_to_text:
+                outputs = model(y, y_mask, x, x_mask)
+            else:
+                outputs = model(x, x_mask, y, y_mask)
+
+            loss = outputs["loss"]
+            text_span_loss = outputs["text_span_loss"]
+            fixed_span_loss = outputs["fixed_span_loss"]
+
+            # parameter update for training phase only
+            if phase == "train":
+                # set gradients to zero
                 model.zero_grad()
+
                 # backprop
                 # Use separate optimizers for text span and fixed span heads
                 text_span_loss.backward(retain_graph=True)
-                text_span_optimizer.step()
+                self.text_span_optimizer.step()
                 fixed_span_loss.backward(retain_graph=True)
-                fixed_span_optimizer.step()
-
+                self.fixed_span_optimizer.step()
                 loss.backward()
+
                 # Add text span loss gradients
                 model.decoder.bert_final_layer_out.grad = (
                     model.decoder.bert_final_layer_out.grad.add(
-                        text_span_loss_attenuation_factor
+                        self.text_span_loss_attenuation_factor
                         * (
                             model.decoder.text_span_start_hidden_z.grad
                             + model.decoder.text_span_end_hidden_z.grad
@@ -126,168 +176,241 @@ class ModelTrainer:
                 # Add fixed value loss gradients
                 model.decoder.bert_final_layer_out.grad = (
                     model.decoder.bert_final_layer_out.grad.add(
-                        fixed_value_loss_attenuation_factor
+                        self.fixed_value_loss_attenuation_factor
                         * (model.decoder.fixed_span_hidden_z.grad)
                     )
                 )
                 if step % self.args.param_update_freq == 0:
                     torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
-                    optimizer.step()
-                # compute accuracy and add hard examples
-                if self.args.tree_to_text:
-                    full_acc = compute_accuracy(outputs, x)
-                    # hacky
-                    lm_acc = full_acc
-                else:
-                    lm_acc, sp_acc, text_span_acc, full_acc = compute_accuracy(outputs, y)
-                if self.args.hard:
-                    if e > 0 or tot_steps > 2 * self.args.decoder_warmup_steps:
-                        for acc, exple in zip(lm_acc, batch_examples):
-                            if not acc.item():
-                                if step % 400 == 100:
-                                    print("ADDING HE:", step, exple[0])
-                                dataset.add_hard_example(exple)
-                # book-keeping
-                loc_int_acc += lm_acc.sum().item() / lm_acc.shape[0]
-                loc_full_acc += full_acc.sum().item() / full_acc.shape[0]
-                tot_accuracy += full_acc.sum().item() / full_acc.shape[0]
-                text_span_accuracy += text_span_acc.sum().item() / text_span_acc.shape[0]
-                if not self.args.tree_to_text:
-                    loc_span_acc += sp_acc.sum().item() / sp_acc.shape[0]
-                loc_loss += loss.item()
-                loc_steps += 1
-                tot_loss += loss.item()
-                tot_steps += 1
-                text_span_tot_loss += text_span_loss.item()
-                text_span_loc_loss += text_span_loss.item()
-                if step % 400 == 0:
-                    print(
-                        "{:2d} - {:5d} \t L: {:.3f} A: {:.3f} \t {:.2f}".format(
-                            e,
-                            step,
-                            loc_loss / loc_steps,
-                            loc_full_acc / loc_steps,
-                            time() - st_time,
-                        )
+                    self.optimizer.step()
+
+            # compute accuracy and add hard examples
+            if self.args.tree_to_text:
+                full_acc = compute_accuracy(outputs, x)
+                # hacky
+                lm_acc = full_acc
+            else:
+                lm_acc, sp_acc, text_span_acc, full_acc = compute_accuracy(outputs, y)
+
+            # add hard examples into the training dataset
+            if phase == "train" and self.args.hard:
+                if (
+                    epoch > 0
+                    or epoch * len(epoch_iterator) + ep_steps > 2 * self.args.decoder_warmup_steps
+                ):
+                    for acc, exple in zip(lm_acc, batch_examples):
+                        if not acc.item():
+                            if step % self.args.hard_iter == 100:
+                                print("ADDING HE:", step, exple[0])
+                            dataset.add_hard_example(exple)
+
+            # book-keeping
+            # shapes of accuracies are [B]
+            # internal_nodes_accuracy / batch_size
+            loc_int_acc += lm_acc.sum().item() / lm_acc.shape[0]
+            ep_int_acc += lm_acc.sum().item() / lm_acc.shape[0]
+            # weighted_accuracy / batch_size
+            loc_full_acc += full_acc.sum().item() / full_acc.shape[0]
+            ep_full_acc += full_acc.sum().item() / full_acc.shape[0]
+            # text_span_accuracy / batch_size
+            loc_text_span_accuracy += text_span_acc.sum().item() / text_span_acc.shape[0]
+            if not self.args.tree_to_text:
+                loc_span_acc += sp_acc.sum().item() / sp_acc.shape[0]
+                ep_span_acc += sp_acc.sum().item() / sp_acc.shape[0]
+
+            # total loss
+            loc_loss += loss.item()
+            ep_loss += loss.item()
+            # number of iterations
+            loc_steps += 1
+            ep_steps += 1
+            # test span loss
+            loc_text_span_loss += text_span_loss.item()
+            ep_text_span_loss += text_span_loss.item()
+
+            if phase == "train" and step % self.args.log_iter == 0:
+                if self.args.show_samples:
+                    self.show_examples(dataset)
+                if self.tb:
+                    self.tb.add_scalar(
+                        "accuracy",
+                        loc_full_acc / loc_steps,
+                        global_step=epoch * len(epoch_iterator) + ep_steps,
                     )
-                    logging.info(
-                        "{:2d} - {:5d} \t L: {:.3f} A: {:.3f} \t {:.2f}".format(
-                            e,
-                            step,
-                            loc_loss / loc_steps,
-                            loc_full_acc / loc_steps,
-                            time() - st_time,
-                        )
+                    self.tb.add_scalar(
+                        "loss",
+                        loc_loss / loc_steps,
+                        global_step=epoch * len(epoch_iterator) + ep_steps,
                     )
-                    logging.info("text span acc: {:.3f}".format(text_span_accuracy / loc_steps))
-                    logging.info("text span loss: {:.3f}".format(text_span_loc_loss / loc_steps))
-                    loc_loss = 0
-                    loc_steps = 0
-                    loc_int_acc = 0.0
-                    loc_span_acc = 0.0
-                    loc_full_acc = 0.0
-                    text_span_accuracy = 0.0
-                    text_span_loc_loss = 0.0
-            torch.save(
-                model.state_dict(),
-                pjoin(self.args.output_dir, "{}(ep=={}).pth".format(model_identifier, e)),
+                print(
+                    "{:2d} - {:5d} \t L: {:.3f} A: {:.3f} \t {:.2f}".format(
+                        epoch,
+                        step,
+                        loc_loss / loc_steps,
+                        loc_full_acc / loc_steps,
+                        time() - st_time,
+                    )
+                )
+                logging.info(
+                    "{:2d} - {:5d} \t L: {:.3f} A: {:.3f} \t {:.2f}".format(
+                        epoch,
+                        step,
+                        loc_loss / loc_steps,
+                        loc_full_acc / loc_steps,
+                        time() - st_time,
+                    )
+                )
+                logging.info("text span acc: {:.3f}".format(loc_text_span_accuracy / loc_steps))
+                logging.info("text span loss: {:.3f}".format(loc_text_span_loss / loc_steps))
+                # Log training outputs to CSV
+                self.train_outputs_logger.log_dialogue_outputs(
+                    [
+                        epoch,
+                        step,
+                        # loss averaged over number of steps between gradient updates
+                        loc_loss / loc_steps,
+                        loc_full_acc / loc_steps,
+                        loc_text_span_accuracy / loc_steps,
+                        loc_text_span_loss / loc_steps,
+                        time() - st_time,
+                    ]
+                )
+                # Local calculations are reset (depends on frequency of updates)
+                loc_steps = 0
+                loc_loss = 0.0
+                loc_int_acc = 0.0
+                loc_span_acc = 0.0
+                loc_full_acc = 0.0
+                loc_text_span_accuracy = 0.0
+                loc_text_span_loss = 0.0
+
+        if phase == "train":
+            return (ep_loss, ep_full_acc, ep_steps, dataset)
+        else:
+            return (
+                ep_loss / ep_steps,
+                ep_int_acc / ep_steps,
+                ep_span_acc / ep_steps,
+                ep_full_acc / ep_steps,
+                ep_text_span_accuracy / ep_steps,
+                ep_text_span_loss / ep_steps,
             )
-            # Evaluating model
-            model.eval()
-            logging.info("evaluating model")
-            for dtype_spec in json.loads(self.args.dtype_samples):
-                dtype, ratio = dtype_spec
-                self.eval_model_on_dataset(model, dtype, full_tree_voc, tokenizer)
 
-        return (tot_loss / tot_steps, tot_accuracy / tot_steps)
-
-    def validate(self, model, dataset, tokenizer, args):
-        """Validation: same as training loop but without back-propagation"""
+    def train(self, epoch, dataset):
+        """Training loop (one epoch at once)
+        Args:
+            epoch: The current training epoch
+            dataset: Training dataset
+        Returns:
+            Tuple of (Loss, Accuracy, Steps, Train Dataset)
+        """
         # make data sampler
-        train_sampler = SequentialSampler(dataset)
+        train_sampler = RandomSampler(dataset)
         model_collate_fn = functools.partial(
-            caip_collate, tokenizer=tokenizer, tree_to_text=args.tree_to_text
+            caip_collate, tokenizer=self.tokenizer, tree_to_text=self.args.tree_to_text
         )
         train_dataloader = DataLoader(
-            dataset, sampler=train_sampler, batch_size=args.batch_size, collate_fn=model_collate_fn
-        )
-        epoch_iterator = tqdm(train_dataloader, desc="Iteration", disable=True)
-        # training loop
-        tot_steps = 0
-        tot_loss = 0.0
-        tot_int_acc = 0.0
-        tot_span_acc = 0.0
-        tot_accu = 0.0
-        text_span_tot_acc = 0.0
-        text_span_tot_loss = 0.0
-        # disable autograd to reduce memory usage
-        with torch.no_grad():
-            for step, batch in enumerate(epoch_iterator):
-                batch_tensors = [
-                    t.to(model.decoder.lm_head.predictions.decoder.weight.device)
-                    for t in batch[:4]
-                ]
-                x, x_mask, y, y_mask = batch_tensors
-                outputs = model(x, x_mask, y, y_mask, None, True)
-                loss = outputs["loss"]
-                text_span_loss = outputs["text_span_loss"]
-                # compute accuracy and add hard examples
-                lm_acc, sp_acc, text_span_acc, full_acc = compute_accuracy(outputs, y)
-                # book-keeping
-                tot_int_acc += lm_acc.sum().item() / lm_acc.shape[0]
-                tot_span_acc += sp_acc.sum().item() / sp_acc.shape[0]
-                tot_accu += full_acc.sum().item() / full_acc.shape[0]
-                tot_loss += loss.item()
-                tot_steps += 1
-                # text span stats
-                text_span_tot_acc += text_span_acc.sum().item() / text_span_acc.shape[0]
-                text_span_tot_loss += text_span_loss.item()
-        return (
-            tot_loss / tot_steps,
-            tot_int_acc / tot_steps,
-            tot_span_acc / tot_steps,
-            tot_accu / tot_steps,
-            text_span_tot_acc / tot_steps,
-            text_span_tot_loss / tot_steps,
+            dataset,
+            sampler=train_sampler,
+            batch_size=self.args.batch_size,
+            collate_fn=model_collate_fn,
         )
 
-    def eval_model_on_dataset(
-        self, encoder_decoder, dtype, full_tree_voc, tokenizer, split="valid"
-    ):
-        """Evaluate model on a given validation dataset
+        return self.run_epoch("train", epoch, dataset, train_dataloader)
 
+    def validate(self, epoch, dataset, dtype):
+        """Validation loop
         Args:
-            encoder_decoder: model used for validation
-            dtype: data type (name of file to load)
-            full_tree_voc: full tree vocabulary
-            tokenizer: pre-trained tokenizer for input
-
+            epoch: The current training epoch
+            dataset: Validation dataset
+            dtype: Type of data, [templated, templated_filters, annotated]
+        Returns:
+            Tuple(Loss, Accuracy)
         """
-        valid_dataset = CAIPDataset(
-            tokenizer, self.args, prefix=split, dtype=dtype, full_tree_voc=full_tree_voc
+        # make data sampler
+        val_sampler = SequentialSampler(dataset)
+        model_collate_fn = functools.partial(
+            caip_collate, tokenizer=self.tokenizer, tree_to_text=self.args.tree_to_text
         )
-        l, _, _, a, text_span_acc, text_span_loss = self.validate(
-            encoder_decoder, valid_dataset, tokenizer, self.args
+        val_dataloader = DataLoader(
+            dataset,
+            sampler=val_sampler,
+            batch_size=self.args.batch_size,
+            collate_fn=model_collate_fn,
         )
-        print("evaluating on {} valid: \t Loss: {:.4f} \t Accuracy: {:.4f}".format(dtype, l, a))
-        logging.info(
-            "evaluating on {} valid: \t Loss: {:.4f} \t Accuracy: {:.4f}".format(dtype, l, a)
+
+        print(len(val_dataloader))
+
+        loss, _, _, acc, text_span_acc, text_span_loss = self.run_epoch(
+            "val", epoch, dataset, val_dataloader
         )
         logging.info(
             "text span Loss: {:.4f} \t Accuracy: {:.4f}".format(text_span_loss, text_span_acc)
         )
+        self.valid_outputs_logger.log_dialogue_outputs(
+            [epoch, dtype, loss, acc, text_span_acc, text_span_loss, time()]
+        )
+
+        logging.info(
+            "evaluating on {} valid: \t Loss: {:.4f} \t Accuracy: {:.4f} at epoch {}".format(
+                dtype, loss, acc, epoch
+            )
+        )
+        print(
+            "evaluating on {} valid: \t Loss: {:.4f} \t Accuracy: {:.4f} at epoch {}".format(
+                dtype, loss, acc, epoch
+            )
+        )
+        if self.tb:
+            self.tb.add_scalar("val_accuracy_" + str(dtype), acc, global_step=epoch)
+            self.tb.add_scalar("val_loss_" + str(dtype), loss, global_step=epoch)
+
+        return loss, acc
+
+    def save_model(self, epoch, dataset):
+        M = {
+            "state_dict": self.model.state_dict(),
+            "tree_voc": dataset.tree_voc,
+            "tree_idxs": dataset.tree_idxs,
+            "full_tree_voc": self.full_tree_voc,
+            "args": self.args,
+        }
+        path = pjoin(self.args.output_dir, "{}_ep{}.pth".format(self.model_identifier, epoch))
+        print("saving model to PATH::{} at epoch {}".format(path, epoch))
+        torch.save(M, path)
+
+    def show_examples(self, dataset):
+        self.model.eval()
+        with torch.no_grad():
+            for cid in range(self.args.nm_shows):
+                chat = dataset[cid][2][1]
+                btr = beam_search(
+                    chat,
+                    self.model,
+                    self.tokenizer,
+                    self.args.beam_size,
+                    self.args.well_formed_pen,
+                )
+                if (
+                    btr[0][0].get("dialogue_type", "NONE") == "NOOP"
+                    and math.exp(btr[0][1]) < self.args.noop_thres
+                ):
+                    tree = btr[1][0]
+                else:
+                    tree = btr[0][0]
+                print(chat)
+                print(tree)
+                print("*********************************")
+        self.model.train()
 
 
 def generate_model_name(args, optional_identifier=""):
     """Generate a unique string identifier for the current run.
-
     Args:
         args: Parser arguments
         optional_identifier: Optional string appended to end of the model identifier
-
     Returns:
         String
-
     """
     name = ""
     # unix time in seconds, used as a unique identifier
@@ -297,12 +420,11 @@ def generate_model_name(args, optional_identifier=""):
         "batch_size": "batch",
         "decoder_learning_rate": "dec_lr",
         "decoder_warmup_steps": "dec_ws",
-        "dtype_samples": "spl",
+        "dtype_samples": "data",
         "encoder_learning_rate": "enc_lr",
         "encoder_warmup_steps": "enc_ws",
         "model_name": "name",
         "node_label_smoothing": "n_ls",
-        "num_epochs": "ep",
         "num_highway": "hw",
         "param_update_freq": "upd_frq",
         "word_dropout": "word_drp",
@@ -310,16 +432,34 @@ def generate_model_name(args, optional_identifier=""):
         "train_encoder": "tr",
         "fixed_value_weight": "fv",
     }
+    dsets = {"templated": "t", "templated_filters": "tf", "annotated": "a"}
     for k, v in vars(args).items():
         if k in args_keys:
-            name += "{param}={value}|".format(param=args_keys[k], value=v)
+            if k == "dtype_samples":
+                v = "_".join([dsets[k] + str(v) for k, v in args.dtype_samples.items()])
+            name += "{param}{value}-".format(param=args_keys[k], value=v)
     # In case we want additional identification for the model, eg. test run
     name += "{time}|".format(time=time_now)
     name += optional_identifier
     return name
 
 
-def main():
+def build_grammar(args):
+    data = {"train": {}, "valid": {}, "test": {}}
+    dtypes = list(args.dtype_samples.keys())
+    for spl in data:
+        for dt in dtypes:
+            fname = pjoin(args.data_dir, "{}/{}.txt".format(spl, dt))
+            logging.info("loading file {}".format(fname))
+            if isfile(fname):
+                data[spl][fname.split("/")[-1][:-4]] = process_txt_data(filepath=fname)
+    full_tree, tree_i2w = make_full_tree(
+        [(d_list, 1.0) for spl, dtype_dict in data.items() for dtype, d_list in dtype_dict.items()]
+    )
+    json.dump((full_tree, tree_i2w), open(args.tree_voc_file, "w"))
+
+
+if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--data_dir",
@@ -327,6 +467,13 @@ def main():
         type=str,
         help="train/valid/test data",
     )
+    parser.add_argument(
+        "--root_dir",
+        default="",
+        type=str,
+        help="The root folder of the fairo project",
+    )
+    parser.add_argument("--tensorboard_dir", default="")
     parser.add_argument(
         "--output_dir",
         default="droidlet/artifacts/models/nlu/ttad_bert_updated/",
@@ -339,6 +486,12 @@ def main():
         default="droidlet/artifacts/models/nlu/ttad_bert_updated/caip_test_model_tree.json",
         type=str,
         help="Pre-computed grammar and output vocabulary",
+    )
+    parser.add_argument(
+        "--hard_iter",
+        default=400,
+        type=int,
+        help="Number of iterations to add hard examples",
     )
     # model arguments
     parser.add_argument(
@@ -415,7 +568,7 @@ def main():
     )
     parser.add_argument(
         "--dtype_samples",
-        default='[["templated", 0.55], ["templated_filters", 0.05], ["annotated", 0.4]]',
+        default="templated:.55;templated_filters:.05;annotated:.4",
         type=str,
         help="Sampling probabilities for handling different data types",
     )
@@ -430,6 +583,9 @@ def main():
     )
     parser.add_argument(
         "--encoder_dropout", default=0.0, type=float, help="Apply dropout to encoder output"
+    )
+    parser.add_argument(
+        "--show_samples", action="store_true", help="show samples every few iterations"
     )
     parser.add_argument("--tree_to_text", action="store_true", help="Back translation flag")
     parser.add_argument(
@@ -450,13 +606,46 @@ def main():
         type=float,
         help="Attenuation factor for fixed value loss gradient affecting shared layers for tree structure prediction",
     )
+    # debug parameters
+    parser.add_argument(
+        "--log_iter",
+        default=400,
+        type=int,
+        help="The number of iteration for printing training progress and showing examples",
+    )
+    parser.add_argument(
+        "--noop_thres", default=0.95, type=float, help="The threshold of NOOP action"
+    )
+    parser.add_argument(
+        "--beam_size", default=5, type=int, help="Number of branches to keep in beam search"
+    )
+    parser.add_argument(
+        "--well_formed_pen", default=1e2, type=float, help="Penalization for poorly formed trees"
+    )
+    parser.add_argument(
+        "--nm_shows", default=10, type=int, help="Number of branches to keep in beam search"
+    )
     args = parser.parse_args()
+
+    # parse proportion of different types of data samples from input arguments
+    dtype_samples = {}
+    for x in args.dtype_samples.split(";"):
+        y = x.split(":")
+        dtype_samples[y[0]] = float(y[1])
+    args.dtype_samples = dtype_samples
+
     # HACK: allows us to give rephrase proba only instead of full dictionary
     if args.rephrase_proba > 0:
         args.dtype_samples = json.dumps(
             [["templated", 1.0 - args.rephrase_proba], ["rephrases", args.rephrase_proba]]
         )
+
+    # build up directory for saving output
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    # generate a unique identifier for the training model
     model_identifier = generate_model_name(args, args.optional_identifier)
+
     # set up logging
     l_handler = logging.handlers.WatchedFileHandler(
         "{}/{}.log".format(args.output_dir, model_identifier)
@@ -471,68 +660,67 @@ def main():
     logging.info("model identifier: {}".format(model_identifier))
     if isfile(args.tree_voc_file):
         logging.info("====== Loading Grammar ======")
-        with open(args.tree_voc_file) as fd:
-            full_tree, tree_i2w = json.load(fd)
     else:
         logging.info("====== Making Grammar ======")
-        data = {"train": {}, "valid": {}, "test": {}}
-        dtype_samples_unpacked = json.loads(args.dtype_samples)
-        dtypes = [t for t, p in dtype_samples_unpacked]
-        for spl in data:
-            for dt in dtypes:
-                fname = pjoin(args.data_dir, "{}/{}.txt".format(spl, dt))
-                logging.info("loading file {}".format(fname))
-                if isfile(fname):
-                    data[spl][fname.split("/")[-1][:-4]] = process_txt_data(filepath=fname)
-        full_tree, tree_i2w = make_full_tree(
-            [
-                (d_list, 1.0)
-                for spl, dtype_dict in data.items()
-                for dtype, d_list in dtype_dict.items()
-            ]
-        )
-        json.dump((full_tree, tree_i2w), open(args.tree_voc_file, "w"))
-    tokenizer = AutoTokenizer.from_pretrained(args.pretrained_encoder_name)
-    logging.info("====== Loading Dataset ======")
+        build_grammar(args)
+    with open(args.tree_voc_file) as fd:
+        full_tree, tree_i2w = json.load(fd)
+    full_tree_voc = (full_tree, tree_i2w)
+
+    logging.info("====== Setting up NLU Model ======")
+    _, encoder_decoder, tokenizer = build_model(args, tree_i2w)
+
+    logging.info("====== Loading Training Dataset ======")
     train_dataset = CAIPDataset(
         tokenizer,
         args,
         prefix="train",
         sampling=True,
         word_noise=args.word_dropout,
-        full_tree_voc=(full_tree, tree_i2w),
+        full_tree_voc=full_tree_voc,
     )
-    logging.info("====== Setting up Model ======")
 
-    # make model
-    logging.info("making model")
-    enc_model = AutoModel.from_pretrained(args.pretrained_encoder_name)
-    bert_config = BertConfig.from_pretrained(args.decoder_config_name)
+    logging.info("====== Loading Validation Datasets ======")
+    val_datasets = {}
+    for dtype, _ in args.dtype_samples.items():
+        val_dataset = CAIPDataset(
+            tokenizer,
+            args,
+            prefix="valid",
+            dtype=dtype,
+            full_tree_voc=full_tree_voc,
+        )
+        val_datasets[dtype] = val_dataset
 
-    bert_config.is_decoder = True
-    bert_config.add_cross_attention = True
-    if args.tree_to_text:
-        tokenizer.add_tokens(tree_i2w)
-    else:
-        bert_config.vocab_size = len(tree_i2w) + 8
-    logging.info("vocab size {}".format(bert_config.vocab_size))
-    dec_with_loss = DecoderWithLoss(bert_config, args, tokenizer)
-    encoder_decoder = EncoderDecoderWithLoss(enc_model, dec_with_loss, args)
-    # save configs
-    json.dump(
-        (full_tree, tree_i2w), open(pjoin(args.output_dir, model_identifier + "_tree.json"), "w")
-    )
-    pickle.dump(args, open(pjoin(args.output_dir, model_identifier + "_args.pk"), "wb"))
-    # train_model
-    logging.info("====== Training Model ======")
+    print(val_datasets)
+
+    logging.info("====== Initializing NLU Model Trainer ======")
     encoder_decoder = encoder_decoder.cuda()
-    encoder_decoder.train()
-    full_tree_voc = (full_tree, tree_i2w)
-    model_trainer = ModelTrainer(args)
-    loss, accu = model_trainer.train(
-        encoder_decoder, train_dataset, tokenizer, model_identifier, full_tree_voc
+    model_trainer = NLUModelTrainer(
+        args, encoder_decoder, tokenizer, model_identifier, full_tree_voc
     )
 
+    logging.info("====== Starting Training Process ======")
+    train_steps = 0
+    train_loss = 0.0
+    train_acc = 0.0
+    for epoch in range(args.num_epochs):
+        logging.info("Epoch: {}".format(epoch))
+        ep_loss, ep_acc, ep_steps, train_dataset = model_trainer.train(epoch, train_dataset)
 
-if __name__ == "__main__":
-    main()
+        train_steps += ep_steps
+        train_loss += ep_loss
+        train_acc += ep_acc
+
+        # save the model after each epoch
+        model_trainer.save_model(epoch, train_dataset)
+
+        logging.info("evaluating model")
+        for dtype, val_dataset in val_datasets.items():
+            val_loss, val_acc = model_trainer.validate(epoch, val_dataset, dtype)
+
+    print(
+        "Training done! Loss: {:.4f} \t Accuracy: {:.4f}".format(
+            train_loss / train_steps, train_acc / train_steps
+        )
+    )

--- a/droidlet/perception/semantic_parsing/nsp_transformer_model/train_model.py
+++ b/droidlet/perception/semantic_parsing/nsp_transformer_model/train_model.py
@@ -1,4 +1,3 @@
-
 """
 Copyright (c) Facebook, Inc. and its affiliates.
 """


### PR DESCRIPTION
# Description

Refactor the main training script for NLU model. No new functionality was added but tried to improve its readability and maintainability.

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [x] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

- Before, the process of running a single epoch is repeatedly written in the methods of ```train``` and ```val```.
- After, I extracted the similar part out into a method named ```run_epoch```, which will be called by ```train``` and ```val```. Meanwhile, I added more comments for easy understanding.

# Testing

You could run the following command to train an epoch for testing
```
python droidlet/perception/semantic_parsing/nsp_transformer_model/train_model.py --batch_size 32 --data_dir droidlet/artifacts/datasets/annotated_data/ --dtype_samples 'annotated:1.' --tree_voc_file droidlet/artifacts/models/nlu/ttad_bert_updated/caip_test_model_tree.json --output_dir ./test_outputs --num_epochs 1
```

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
