### PR TITLE
Make memory map grid infinite

### DIFF
--- a/droidlet/dashboard/web/src/components/Memory2D.js
+++ b/droidlet/dashboard/web/src/components/Memory2D.js
@@ -294,14 +294,20 @@ class Memory2D extends React.Component {
     var padding = 10;
     var gridKey = 12344;
     for (var i = 0; i < width / padding; i++) {
+      // Vertical Lines
+      let startX = drag_coordinates[0] % (padding * stageScale);
+      let plotX =
+        startX +
+        Math.round(i * padding * stageScale - drag_coordinates[0]) +
+        0.5;
       gridLayer.push(
         <Line
           key={gridKey + i}
           points={[
-            Math.round(i * padding) + 0.5,
-            0,
-            Math.round(i * padding) + 0.5,
-            height,
+            plotX / stageScale,
+            (0 - drag_coordinates[1]) / stageScale,
+            plotX / stageScale,
+            (height - drag_coordinates[1]) / stageScale,
           ]}
           stroke="#f5f5f5"
           strokeWidth={1}
@@ -311,10 +317,19 @@ class Memory2D extends React.Component {
 
     gridLayer.push(<Line key={gridKey + i++} points={[0, 0, 10, 10]} />);
     for (j = 0; j < height / padding; j++) {
+      // Horizontal Lines
+      let startY = drag_coordinates[1] % (padding * stageScale);
+      let plotY =
+        startY + Math.round(j * padding * stageScale - drag_coordinates[1]);
       gridLayer.push(
         <Line
           key={gridKey + i + j}
-          points={[0, Math.round(j * padding), width, Math.round(j * padding)]}
+          points={[
+            (0 - drag_coordinates[0]) / stageScale,
+            plotY / stageScale,
+            (width - drag_coordinates[0]) / stageScale,
+            plotY / stageScale,
+          ]}
           stroke="#ddd"
           strokeWidth={0.5}
         />


### PR DESCRIPTION
# Description

As title suggests, this PR makes the memory map grid infinite. The grid behaves as expected upon drag and zooming in.

Fixes # (issue)

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [x] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Before:
![Screen Shot 2022-06-17 at 4 08 28 PM](https://user-images.githubusercontent.com/54821527/174411446-60b9d9d2-e29a-4190-8283-68aa5ac4c680.png)

After:
![Screen Shot 2022-06-17 at 4 08 58 PM](https://user-images.githubusercontent.com/54821527/174411457-3c767944-96f6-4e93-8f75-03d59013aec3.png)


# Testing
General traversing of the grid.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
