### PR TITLE
fix trying to iterate over NoneType

### DIFF
--- a/droidlet/lowlevel/minecraft/pyworld/world.py
+++ b/droidlet/lowlevel/minecraft/pyworld/world.py
@@ -59,7 +59,7 @@ class World:
         for m in spec["mobs"]:
             m.add_to_world(self)
         self.items = {}
-        for i in spec.get("items"):
+        for i in spec.get("items", []):
             i.add_to_world(self)
         self.players = {}
         # TODO make this more robust


### PR DESCRIPTION
# Description

Sometimes there are no items in the world spec. Unless that itself is a bug, this fixes the bug of trying to iterate over items of type None.

Fixes # (issue)

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

before: `spec.get("items")`
after: `spec.get("items", [])`

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
