### PR TITLE
Update Polymetis to use the latest habitat-sim built from source

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,8 @@ commands:
       - run:
           name: Build habitat
           command: |
+            pwd
+            ls
             cd ./third_party/habitat-sim
             pip install -r requirements.txt
             export PYTHONPATH=${pwd}/src_python

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,8 +77,8 @@ commands:
       - run:
           name: Build habitat
           command: |
-            sudo apt update
-            sudo apt install -y git python3 python3-pip apt-transport-https ca-certificates curl gnupg-agent software-properties-common
+            . /opt/conda/etc/profile.d/conda.sh
+            conda activate polymetis-local
             cd polymetis/third_party/habitat-sim
             pip install -r requirements.txt
             export PYTHONPATH=${pwd}/src_python

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ commands:
             cd ./third_party/habitat-sim
             pip install -r requirements.txt
             export PYTHONPATH=${pwd}/src_python
-            ./build.sh
+            ./build.sh --bullet
       - polymetis_tests
       - run:
           name: Generate documentation

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,13 @@ commands:
 
             export BUILD_DOCS="ON"
             ./install.sh
+      - run:
+          name: Build habitat
+          command: |
+            cd ./third_party/habitat-sim
+            pip install -r requirements.txt
+            export PYTHONPATH=${pwd}/src_python
+            ./build.sh
       - polymetis_tests
       - run:
           name: Generate documentation

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,46 +80,48 @@ commands:
             . /opt/conda/etc/profile.d/conda.sh
             conda activate polymetis-local
             # Following installs taken from habitat-sim CI
+            # sudo apt-get install -yq \
+            #       gconf-service \
+            #       libasound2 \
+            #       libatk1.0-0 \
+            #       libatk-bridge2.0-0 \
+            #       libc6 \
+            #       libcairo2 \
+            #       libcups2 \
+            #       libdbus-1-3  \
+            #       libexpat1 \
+            #       libfontconfig1 \
+            #       libgcc1 \
+            #       libgconf-2-4 \
+            #       libgdk-pixbuf2.0-0 \
+            #       libglib2.0-0 \
+            #       libgtk-3-0 \
+            #       libnspr4 \
+            #       libpango-1.0-0 \
+            #       libpangocairo-1.0-0 \
+            #       libstdc++6 \
+            #       libx11-6 \
+            #       libx11-xcb1 \
+            #       libxcb1 \
+            #       libxcomposite1 \
+            #       libxcursor1 \
+            #       libxdamage1 \
+            #       libxext6 \
+            #       libxfixes3 \
+            #       libxi6 \
+            #       libxrandr2 \
+            #       libxrender1 \
+            #       libxss1 \
+            #       libxtst6 \
+            #       ca-certificates \
+            #       fonts-liberation \
+            #       libappindicator1 \
+            #       libnss3 \
+            #       lsb-release \
+            #       xdg-utils \
+            #       wget 
             sudo apt-get install -yq \
-                  gconf-service \
-                  libasound2 \
-                  libatk1.0-0 \
-                  libatk-bridge2.0-0 \
-                  libc6 \
-                  libcairo2 \
-                  libcups2 \
-                  libdbus-1-3  \
-                  libexpat1 \
-                  libfontconfig1 \
-                  libgcc1 \
-                  libgconf-2-4 \
-                  libgdk-pixbuf2.0-0 \
-                  libglib2.0-0 \
-                  libgtk-3-0 \
-                  libnspr4 \
-                  libpango-1.0-0 \
-                  libpangocairo-1.0-0 \
-                  libstdc++6 \
-                  libx11-6 \
-                  libx11-xcb1 \
-                  libxcb1 \
-                  libxcomposite1 \
-                  libxcursor1 \
-                  libxdamage1 \
-                  libxext6 \
-                  libxfixes3 \
-                  libxi6 \
-                  libxrandr2 \
-                  libxrender1 \
-                  libxss1 \
-                  libxtst6 \
-                  ca-certificates \
-                  fonts-liberation \
-                  libappindicator1 \
-                  libnss3 \
-                  lsb-release \
-                  xdg-utils \
-                  wget            
+              libxrandr2     
             cd polymetis/third_party/habitat-sim
             pip install -r requirements.txt
             export PYTHONPATH=${pwd}/src_python

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,47 @@ commands:
           command: |
             . /opt/conda/etc/profile.d/conda.sh
             conda activate polymetis-local
+            # Following installs taken from habitat-sim CI
+            sudo apt-get install -yq \
+                  gconf-service \
+                  libasound2 \
+                  libatk1.0-0 \
+                  libatk-bridge2.0-0 \
+                  libc6 \
+                  libcairo2 \
+                  libcups2 \
+                  libdbus-1-3  \
+                  libexpat1 \
+                  libfontconfig1 \
+                  libgcc1 \
+                  libgconf-2-4 \
+                  libgdk-pixbuf2.0-0 \
+                  libglib2.0-0 \
+                  libgtk-3-0 \
+                  libnspr4 \
+                  libpango-1.0-0 \
+                  libpangocairo-1.0-0 \
+                  libstdc++6 \
+                  libx11-6 \
+                  libx11-xcb1 \
+                  libxcb1 \
+                  libxcomposite1 \
+                  libxcursor1 \
+                  libxdamage1 \
+                  libxext6 \
+                  libxfixes3 \
+                  libxi6 \
+                  libxrandr2 \
+                  libxrender1 \
+                  libxss1 \
+                  libxtst6 \
+                  ca-certificates \
+                  fonts-liberation \
+                  libappindicator1 \
+                  libnss3 \
+                  lsb-release \
+                  xdg-utils \
+                  wget            
             cd polymetis/third_party/habitat-sim
             pip install -r requirements.txt
             export PYTHONPATH=${pwd}/src_python

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ commands:
             cd polymetis/third_party/habitat-sim
             pip install -r requirements.txt
             export PYTHONPATH=${pwd}/src_python
-            ./build.sh --bullet
+            ./build.sh --bullet --headless
       - polymetis_tests
       - run:
           name: Generate documentation

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,9 +77,7 @@ commands:
       - run:
           name: Build habitat
           command: |
-            pwd
-            ls
-            cd ./third_party/habitat-sim
+            cd polymetis/polymetis/third_party/habitat-sim
             pip install -r requirements.txt
             export PYTHONPATH=${pwd}/src_python
             ./build.sh --bullet

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ commands:
       - run:
           name: Build habitat
           command: |
-            cd polymetis/polymetis/third_party/habitat-sim
+            cd polymetis/third_party/habitat-sim
             pip install -r requirements.txt
             export PYTHONPATH=${pwd}/src_python
             ./build.sh --bullet

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,8 @@ commands:
       - run:
           name: Build habitat
           command: |
+            sudo apt update
+            sudo apt install -y git python3 python3-pip apt-transport-https ca-certificates curl gnupg-agent software-properties-common
             cd polymetis/third_party/habitat-sim
             pip install -r requirements.txt
             export PYTHONPATH=${pwd}/src_python

--- a/.gitmodules
+++ b/.gitmodules
@@ -26,6 +26,6 @@
 [submodule "perception/sandbox/polygrasp/third_party/graspnet-baseline"]
 	path = perception/sandbox/polygrasp/third_party/graspnet-baseline
 	url = git@github.com:1heart/graspnet-baseline.git
-[submodule "habitat-sim"]
-	path = habitat-sim
-	url = git@github.com:facebookresearch/habitat-sim
+[submodule "polymetis/third_party/habitat-sim"]
+	path = polymetis/third_party/habitat-sim
+	url = git@github.com:facebookresearch/habitat-sim.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -26,3 +26,6 @@
 [submodule "perception/sandbox/polygrasp/third_party/graspnet-baseline"]
 	path = perception/sandbox/polygrasp/third_party/graspnet-baseline
 	url = git@github.com:1heart/graspnet-baseline.git
+[submodule "habitat-sim"]
+	path = habitat-sim
+	url = git@github.com:facebookresearch/habitat-sim

--- a/polymetis/polymetis/conf/robot_client/habitat_sim.yaml
+++ b/polymetis/polymetis/conf/robot_client/habitat_sim.yaml
@@ -3,7 +3,6 @@ hz: 240
 gui: true
 use_grav_comp: true
 use_real_time: true
-habitat_dir: "../../../../third_party/habitat-sim/"
 habitat_scene_path: "data/test_assets/scenes/simple_room.glb"
 
 robot_client:
@@ -13,7 +12,6 @@ robot_client:
     robot_model_cfg: ${robot_model}
     hz: ${hz}
     gui: ${gui}
-    habitat_dir: ${habitat_dir}
     habitat_scene_path: ${habitat_scene_path}
   metadata_cfg:
     _target_: polymetis.robot_client.metadata.RobotClientMetadata

--- a/polymetis/polymetis/conf/robot_client/habitat_sim.yaml
+++ b/polymetis/polymetis/conf/robot_client/habitat_sim.yaml
@@ -3,7 +3,7 @@ hz: 240
 gui: true
 use_grav_comp: true
 use_real_time: true
-habitat_dir: "../../../../habitat-sim/"
+habitat_dir: "../../../../third_party/habitat-sim/"
 habitat_scene_path: "data/test_assets/scenes/simple_room.glb"
 
 robot_client:

--- a/polymetis/polymetis/conf/robot_client/habitat_sim.yaml
+++ b/polymetis/polymetis/conf/robot_client/habitat_sim.yaml
@@ -3,8 +3,8 @@ hz: 240
 gui: true
 use_grav_comp: true
 use_real_time: true
-habitat_dir: ???
-habitat_scene_path: "data/scene_datasets/habitat-test-scenes/apartment_1.glb"
+habitat_dir: "../../../../habitat-sim/"
+habitat_scene_path: "data/test_assets/scenes/simple_room.glb"
 
 robot_client:
   _target_: polysim.grpc_sim_client.GrpcSimulationClient

--- a/polymetis/polymetis/environment.yml
+++ b/polymetis/polymetis/environment.yml
@@ -38,7 +38,7 @@ dependencies:
     - hydra-core ==1.0.6
     - importlib-resources ==5.7.1
     - myst-parser
-    - numpy
+    - numpy<=1.22
     - pandas
     - plotly
     - pip

--- a/polymetis/polymetis/environment.yml
+++ b/polymetis/polymetis/environment.yml
@@ -34,7 +34,7 @@ dependencies:
     - breathe
     - dash
     - grpcio ==1.46.0
-    - habitat-sim=0.2.1=py3.8_bullet_linux_fc7fb11ccec407753a73ab810d1dbb5f57d0f9b9
+    # - habitat-sim=0.2.1=py3.8_bullet_linux_fc7fb11ccec407753a73ab810d1dbb5f57d0f9b9
     - hydra-core ==1.0.6
     - importlib-resources ==5.7.1
     - myst-parser

--- a/polymetis/polymetis/python/polysim/envs/habitat_manipulator.py
+++ b/polymetis/polymetis/python/polysim/envs/habitat_manipulator.py
@@ -22,29 +22,16 @@ import torchcontrol as toco
 """
 Habitat simulation setup helper functions. Based on the URDF prototype branch:
 https://github.com/facebookresearch/habitat-sim/blob/f6267cbfe0ad6c8f86d79edc917a49fb26ddbb73/examples/tutorials/URDF_robotics_tutorial.py
-"""
-def get_habitat_dir():
-    """
-
-    """
-    # Parsing assumes the following paths to this file and to the habitat-sim directory respectively:
-    # polymetis > polymetis > python > polysim > env > habitat_manipulator.py
-    # polymetis > third_party > habitat-sim
-    
+""" 
 
 
 def make_configuration(
-    habitat_dir: str,
     glb_path: str,
 ) -> habitat_sim.SimulatorConfiguration:
     """Create a habitat_sim.SimulatorConfiguration object, and populate it
     with the scene from the glb_path.
 
     Args:
-
-        habitat_dir: the directory containing habitat-sim. Mainly used as root
-            of glb_path (if it's not an absolute path) and the physics config
-            file (typically `data/default.physics_config.json`).
 
         glb_path: path to the .glb file. If a relative path, assumed to be
             relative to `habitat_dir`.
@@ -146,7 +133,6 @@ class HabitatManipulatorEnv(AbstractControlledEnv):
     def __init__(
         self,
         robot_model_cfg: DictConfig,
-        habitat_dir: str,
         hz: int = 240,
         joint_damping: float = 0.1,
         grav_comp: bool = True,
@@ -197,7 +183,7 @@ class HabitatManipulatorEnv(AbstractControlledEnv):
         )
 
         # Start Habitat simulator
-        self.habitat_cfg = make_configuration(habitat_dir, glb_path=habitat_scene_path)
+        self.habitat_cfg = make_configuration(glb_path=habitat_scene_path)
         self.sim = habitat_sim.Simulator(self.habitat_cfg)
         place_agent(self.sim, agent_pos=agent_pos, agent_orient=agent_orient)
 

--- a/polymetis/polymetis/python/polysim/envs/habitat_manipulator.py
+++ b/polymetis/polymetis/python/polysim/envs/habitat_manipulator.py
@@ -22,7 +22,7 @@ import torchcontrol as toco
 """
 Habitat simulation setup helper functions. Based on the URDF prototype branch:
 https://github.com/facebookresearch/habitat-sim/blob/f6267cbfe0ad6c8f86d79edc917a49fb26ddbb73/examples/tutorials/URDF_robotics_tutorial.py
-""" 
+"""
 
 
 def make_configuration(
@@ -48,7 +48,7 @@ def make_configuration(
     for _ in range(5):
         habitat_dir = os.path.dirname(habitat_dir)
     habitat_dir = os.path.join(habitat_dir, "third_party/habitat-sim")
-    
+
     if not os.path.isabs(glb_path):
         glb_path = os.path.join(habitat_dir, glb_path)
 

--- a/polymetis/polymetis/python/polysim/envs/habitat_manipulator.py
+++ b/polymetis/polymetis/python/polysim/envs/habitat_manipulator.py
@@ -23,6 +23,14 @@ import torchcontrol as toco
 Habitat simulation setup helper functions. Based on the URDF prototype branch:
 https://github.com/facebookresearch/habitat-sim/blob/f6267cbfe0ad6c8f86d79edc917a49fb26ddbb73/examples/tutorials/URDF_robotics_tutorial.py
 """
+def get_habitat_dir():
+    """
+
+    """
+    # Parsing assumes the following paths to this file and to the habitat-sim directory respectively:
+    # polymetis > polymetis > python > polysim > env > habitat_manipulator.py
+    # polymetis > third_party > habitat-sim
+    
 
 
 def make_configuration(
@@ -45,6 +53,15 @@ def make_configuration(
         habitat_sim.SimulatorConfiguration object with reasonable values and
             loaded with glb scene.
     """
+    # Assumes habitat dir is located at:
+    #   polymetis > third_party > habitat-sim
+    # Assumes current file at:
+    #   polymetis > polymetis > python > polysim > env > habitat_manipulator.py
+    habitat_dir = os.path.abspath(__file__)
+    for _ in range(5):
+        habitat_dir = os.path.dirname(habitat_dir)
+    habitat_dir = os.path.join(habitat_dir, "third_party/habitat-sim")
+    
     if not os.path.isabs(glb_path):
         glb_path = os.path.join(habitat_dir, glb_path)
 

--- a/polymetis/polymetis/python/polysim/envs/habitat_manipulator.py
+++ b/polymetis/polymetis/python/polysim/envs/habitat_manipulator.py
@@ -152,8 +152,6 @@ class HabitatManipulatorEnv(AbstractControlledEnv):
             robot_model_cfg: a typical configuration for a robot model (e.g. see
                 `franka_panda.yaml`).
 
-            habitat_dir: directory containing habitat-sim.
-
             hz: the rate at which to update the simulation.
 
             joint_damping: velocity gains damping joint movement towards 0 velocity.

--- a/polymetis/polymetis/tests/python/polysim/test_env.py
+++ b/polymetis/polymetis/tests/python/polysim/test_env.py
@@ -194,9 +194,6 @@ kuka_gripper_sdf = OmegaConf.create(
             HabitatManipulatorEnv,
             {
                 "robot_model_cfg": franka_panda,
-                "habitat_dir": os.path.join(
-                    os.path.dirname(__file__), "../../data/habitat-sim"
-                ),
             },
         ),
     ],


### PR DESCRIPTION
# Description

The habitat-sim repository is added as a submodule to the fairo repo allowing polymetis to run with the most current build of habitat-sim. The habitat-sim client configuration file was updated to reference the local copy of habitat-sim.

Fixes # (issue)

[T122948452](https://www.internalfb.com/intern/tasks/?t=122948452)

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

https://user-images.githubusercontent.com/12128112/176018178-ae140302-a038-477f-9a10-276485d4d3c9.mov
Franka robot running in example scene sourced from habitat

# Testing

1. Run ```launch_robot.py robot_client=habitat_sim use_real_time=false gui=true```
2. Run an example polymetis controller (I used ```examples/3_custom_controller.py```)
3. See result in video above
4. I needed to update ffmpeg (and potentially needed to install opencv)
