### PR TITLE
mrp better support for import msetup

### DIFF
--- a/mrp/examples/01_basic/msetup.py
+++ b/mrp/examples/01_basic/msetup.py
@@ -8,4 +8,5 @@ mrp.process(
     ),
 )
 
-mrp.main()
+if __name__ == "__main__":
+    mrp.main()

--- a/mrp/examples/03_api/msetup.py
+++ b/mrp/examples/03_api/msetup.py
@@ -21,4 +21,5 @@ mrp.process(
     runtime=mrp.Docker(image="ghcr.io/alephzero/api:latest"),
 )
 
-mrp.main()
+if __name__ == "__main__":
+    mrp.main()

--- a/mrp/examples/04_cfg/msetup.py
+++ b/mrp/examples/04_cfg/msetup.py
@@ -16,4 +16,5 @@ mrp.process(
     runtime=mrp.Docker(image="ghcr.io/alephzero/api:latest"),
 )
 
-mrp.main()
+if __name__ == "__main__":
+    mrp.main()

--- a/mrp/examples/05_logs/msetup.py
+++ b/mrp/examples/05_logs/msetup.py
@@ -34,4 +34,5 @@ mrp.process(
     },
 )
 
-mrp.main()
+if __name__ == "__main__":
+    mrp.main()

--- a/mrp/examples/06_remote/msetup.py
+++ b/mrp/examples/06_remote/msetup.py
@@ -21,4 +21,5 @@ mrp.process(
     runtime=mrp.Docker(image="ghcr.io/alephzero/api:latest"),
 )
 
-mrp.main()
+if __name__ == "__main__":
+    mrp.main()

--- a/mrp/examples/07_rosmsg/mrun.py
+++ b/mrp/examples/07_rosmsg/mrun.py
@@ -15,4 +15,5 @@ mrp.process(
     ),
 )
 
-mrp.main()
+if __name__ == "__main__":
+    mrp.main()

--- a/mrp/examples/07_rosmsg/msetup.py
+++ b/mrp/examples/07_rosmsg/msetup.py
@@ -27,4 +27,5 @@ mrp.process(
     ),
 )
 
-mrp.main()
+if __name__ == "__main__":
+    mrp.main()

--- a/mrp/examples/08_gui/msetup.py
+++ b/mrp/examples/08_gui/msetup.py
@@ -40,4 +40,5 @@ mrp.process(
     ),
 )
 
-mrp.main()
+if __name__ == "__main__":
+    mrp.main()

--- a/mrp/examples/09_cpp_ompl/msetup.py
+++ b/mrp/examples/09_cpp_ompl/msetup.py
@@ -28,4 +28,5 @@ mrp.process(
     ),
 )
 
-mrp.main()
+if __name__ == "__main__":
+    mrp.main()

--- a/mrp/examples/10_ifttt/msetup.py
+++ b/mrp/examples/10_ifttt/msetup.py
@@ -27,4 +27,5 @@ mrp.process(
     },
 )
 
-mrp.main()
+if __name__ == "__main__":
+    mrp.main()

--- a/mrp/examples/11_elasticsearch/msetup.py
+++ b/mrp/examples/11_elasticsearch/msetup.py
@@ -72,4 +72,5 @@ mrp.process(
     ),
 )
 
-mrp.main()
+if __name__ == "__main__":
+    mrp.main()

--- a/mrp/examples/12_import/README.md
+++ b/mrp/examples/12_import/README.md
@@ -1,0 +1,16 @@
+# Example 08: Importing other msetup
+
+In this example, we show two ways of importing process definitions from other `msetup.py`.
+
+The first, is to directly import the module.
+
+The top level `msetup.py` is able to import bob's processes with
+```py
+import bob.msetup
+```
+
+The second method, where refering to modules directly might be painful, we can use the helper method
+```py
+mrp.import_msetup("../alice")
+```
+as is done in bob's `msetup.py`

--- a/mrp/examples/12_import/alice/alice.py
+++ b/mrp/examples/12_import/alice/alice.py
@@ -1,0 +1,7 @@
+import time
+
+i = 0
+while True:
+    print(f"alice {i}")
+    i += 1
+    time.sleep(1)

--- a/mrp/examples/12_import/alice/msetup.py
+++ b/mrp/examples/12_import/alice/msetup.py
@@ -3,16 +3,8 @@ import mrp
 mrp.process(
     name="alice",
     runtime=mrp.Conda(
-        yaml="env.yml",
+        dependencies=["python>=3.7"],
         run_command=["python3", "alice.py"],
-    ),
-)
-
-mrp.process(
-    name="bob",
-    runtime=mrp.Conda(
-        yaml="env.yml",
-        run_command=["python3", "bob.py"],
     ),
 )
 

--- a/mrp/examples/12_import/bob/bob.py
+++ b/mrp/examples/12_import/bob/bob.py
@@ -1,0 +1,7 @@
+import time
+
+i = 0
+while True:
+    print(f"bob {i}")
+    i += 1
+    time.sleep(1)

--- a/mrp/examples/12_import/bob/msetup.py
+++ b/mrp/examples/12_import/bob/msetup.py
@@ -1,17 +1,11 @@
 import mrp
 
-mrp.process(
-    name="alice",
-    runtime=mrp.Conda(
-        yaml="env.yml",
-        run_command=["python3", "alice.py"],
-    ),
-)
+mrp.import_msetup("../alice")
 
 mrp.process(
     name="bob",
     runtime=mrp.Conda(
-        yaml="env.yml",
+        dependencies=["python>=3.7"],
         run_command=["python3", "bob.py"],
     ),
 )

--- a/mrp/examples/12_import/msetup.py
+++ b/mrp/examples/12_import/msetup.py
@@ -1,6 +1,6 @@
 import mrp
 
-import bob.msetup
+import bob.msetup  # noqa: F401
 
 # Importing bob chains an import of alice.
 

--- a/mrp/examples/12_import/msetup.py
+++ b/mrp/examples/12_import/msetup.py
@@ -1,0 +1,8 @@
+import mrp
+
+import bob.msetup
+
+# Importing bob chains an import of alice.
+
+if __name__ == "__main__":
+    mrp.main()

--- a/mrp/examples/13_rostf/msetup.py
+++ b/mrp/examples/13_rostf/msetup.py
@@ -14,4 +14,5 @@ mrp.process(
     ),
 )
 
-mrp.main()
+if __name__ == "__main__":
+    mrp.main()

--- a/mrp/examples/14_habitat/msetup.py
+++ b/mrp/examples/14_habitat/msetup.py
@@ -25,4 +25,5 @@ mrp.process(
     ),
 )
 
-mrp.main()
+if __name__ == "__main__":
+    mrp.main()

--- a/mrp/src/mrp/__init__.py
+++ b/mrp/src/mrp/__init__.py
@@ -5,6 +5,7 @@ from mrp.runtime.host import Host
 from mrp.util import NoEscape
 from importlib.machinery import SourceFileLoader
 import click
+import inspect
 import os
 import sys
 
@@ -21,6 +22,17 @@ def main(*args):
         click.echo(ex, err=True)
         sys.exit(1)
     sys.exit(0)
+
+
+def import_msetup(path):
+    # TODO(lshamis): Maybe add args to filter imported processes.
+    if not path.endswith("msetup.py"):
+        path = os.path.join(path, "msetup.py")
+
+    caller_path = inspect.stack()[1].filename
+    caller_dir = os.path.dirname(caller_path)
+    target_path = os.path.join(caller_dir, path)
+    SourceFileLoader("msetup", target_path).load_module()
 
 
 class cmd:

--- a/mrp/src/mrp/__init__.py
+++ b/mrp/src/mrp/__init__.py
@@ -26,12 +26,13 @@ def main(*args):
 
 def import_msetup(path):
     # TODO(lshamis): Maybe add args to filter imported processes.
-    if not path.endswith("msetup.py"):
-        path = os.path.join(path, "msetup.py")
-
     caller_path = inspect.stack()[1].filename
     caller_dir = os.path.dirname(caller_path)
     target_path = os.path.join(caller_dir, path)
+
+    if os.path.isdir(target_path):
+        target_path = os.path.join(target_path, "msetup.py")
+
     SourceFileLoader("msetup", target_path).load_module()
 
 

--- a/mrp/src/mrp/tool/__init__.py
+++ b/mrp/src/mrp/tool/__init__.py
@@ -19,7 +19,7 @@ def main():
 
     # Run the entrypoint file.
     sys.path.append(os.path.dirname(msetup_path))
-    SourceFileLoader("msetup", msetup_path).load_module()
+    SourceFileLoader("__main__", msetup_path).load_module()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

Adds an example of importing process definitions from other `msetup.py`.

To aid in relative imports (and other not easy to import cases), we add a `mrp.import_msetup` helper function.

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

If this PR introduces a change or fixes a bug, please add before and after screenshots (if this is causes a UX change) or before and after examples(this could be plain text, videos etc ) to demonstrate the change.

If this PR introduces a new feature, please also add examples or screenshots demonstrating the feature.

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
