### PR TITLE
HiTL Dashboard - Turk List for viewing & managing blocking turks

### DIFF
--- a/droidlet/tools/hitl/dashboard_app/README.MD
+++ b/droidlet/tools/hitl/dashboard_app/README.MD
@@ -8,7 +8,7 @@ This is a Dashboard app prototype for the HITL system.
     - Add frontend for viewing & editing turk list
     - The turk list supports sort, and search by turk id; when editing the list, user need to unlock first
     - Demo:
-        - 
+        - ![demo_turk_list_manage](https://user-images.githubusercontent.com/51009396/179618044-f253777b-1486-410a-ba04-29d187c62f1a.gif)
 - July 14:
     - Added model visualization component, user can see text info about a model:
     - Demo:

--- a/droidlet/tools/hitl/dashboard_app/README.MD
+++ b/droidlet/tools/hitl/dashboard_app/README.MD
@@ -1,9 +1,14 @@
 # Dashboard App for HITL
-Updated July 13 by Chuxi.
+Updated July 18 by Chuxi.
 
 This is a Dashboard app prototype for the HITL system.
 
 ## Update Note
+- July 18:
+    - Add frontend for viewing & editing turk list
+    - The turk list supports sort, and search by turk id; when editing the list, user need to unlock first
+    - Demo:
+        - 
 - July 14:
     - Added model visualization component, user can see text info about a model:
     - Demo:
@@ -11,7 +16,6 @@ This is a Dashboard app prototype for the HITL system.
             - ![demo_view_model_with_retrain](https://user-images.githubusercontent.com/51009396/179124247-e1521123-aeaa-4ea9-a47a-d05323a37d3a.gif)
         - Model showing NA for a run without retrain jobs:
             - ![demo_view_model_no_retrain](https://user-images.githubusercontent.com/51009396/179124182-9840f1ff-ccbe-4709-9452-025fb5be5c8a.gif) 
-
 - July 13:
     - Added dataset visualization component including:
         - View newly added data points indices on the run detail page

--- a/droidlet/tools/hitl/dashboard_app/dashboard_frontend/src/component/pipeline/metaInfo/turkList.js
+++ b/droidlet/tools/hitl/dashboard_app/dashboard_frontend/src/component/pipeline/metaInfo/turkList.js
@@ -1,56 +1,80 @@
-import { Button, Checkbox, Table } from "antd";
+import { Button, Checkbox, Input, Table, Typography } from "antd";
 import React, { useEffect, useState } from "react";
 import { LockOutlined, UnlockOutlined } from '@ant-design/icons';
 
+const { Search } = Input;
 
 const fakeTurkList = [
-    {   
+    {
         'id': 1213023,
         'blocked': true
-    }, 
-    {   
+    },
+    {
         'id': 32349712,
         'blocked': false
-    }, {   
+    }, {
         'id': 143412,
         'blocked': false
-    }, {   
+    }, {
         'id': 435304,
         'blocked': false
-    }, {   
+    }, {
         'id': 2234948,
         'blocked': true
-    }, {   
+    }, {
         'id': 9453311,
         'blocked': false
-    }, {   
+    }, {
         'id': 134524441,
         'blocked': false
-    }, 
+    },
 ]
 
 const TurkList = (props) => {
     const [listData, setListData] = useState(fakeTurkList); // TODO: use turk list from backend
-    const [editable, setEditable] = useState(false); 
+    const [searchKey, setSearchKey] = useState(null);
+    const [displayData, setDisplayData] = useState(fakeTurkList);
+    const [editable, setEditable] = useState(false);
 
     const handleOnClickCheckbox = (checked, id) => {
         // TODO: end request to backend, update only when backend returns success
-        const newDataList = listData.map((o) => (o.id === id ? {'id': o.id, 'blocked': checked}: {'id': o.id, 'blocked': o.blocked}));
+        const newDataList = listData.map((o) => (o.id === id ? { 'id': o.id, 'blocked': checked } : { 'id': o.id, 'blocked': o.blocked }));
         setListData(newDataList);
+        setDisplayData(searchKey ? newDataList.filter((o) => (String(o.id).includes(searchKey))): newDataList);
     }
 
-    useEffect(() => {}, [listData, editable]);
+    const onSearch = (searchBoxValue) => {
+        if (searchBoxValue) {
+            setDisplayData(listData.filter((o) => (String(o.id).includes(searchBoxValue))));
+            setSearchKey(searchBoxValue);
+        } else {
+            setDisplayData(listData);
+            setSearchKey(null);
+        }
+    }
 
-    return <div>
-        <div style={{textAlign: 'left', paddingBottom: '12px'}}>
-            <Button 
-                type="primary" 
-                icon={editable ? <UnlockOutlined />: <LockOutlined />} 
-                onClick={() => setEditable(!editable)}>
-                    {editable ? "Lock": "Unlock"} Editing
-            </Button>
-        </div> 
+    useEffect(() => {}, [displayData]);
+
+    return <div style={{ textAlign: 'left' }}>
+        <Typography.Title level={5}>Manage Turk List</Typography.Title>
+        <div style={{ paddingBottom: '12px'}}>
+            <Search
+                placeholder="Search by Id"
+                style={{ width: '30%' }}
+                allowClear
+                onSearch={onSearch}
+                enterButton />
+            <div style={{ float: 'right', paddingRight: '18px', display: 'inline-block' }}>
+                <Button
+                    type="primary"
+                    icon={editable ? <UnlockOutlined /> : <LockOutlined />}
+                    onClick={() => setEditable(!editable)}>
+                    {editable ? "Lock" : "Unlock"} Editing
+                </Button>
+            </div>
+        </div>
         <Table
+            style={{paddingRight: '24px'}}
             columns={[{
                 title: 'Id',
                 dataIndex: 'id',
@@ -64,7 +88,7 @@ const TurkList = (props) => {
                         disabled={!editable}
                         checked={blocked} />
             }]}
-            dataSource={listData}
+            dataSource={displayData}
         />
     </div>;
 };

--- a/droidlet/tools/hitl/dashboard_app/dashboard_frontend/src/component/pipeline/metaInfo/turkList.js
+++ b/droidlet/tools/hitl/dashboard_app/dashboard_frontend/src/component/pipeline/metaInfo/turkList.js
@@ -1,0 +1,72 @@
+import { Button, Checkbox, Table } from "antd";
+import React, { useEffect, useState } from "react";
+import { LockOutlined, UnlockOutlined } from '@ant-design/icons';
+
+
+const fakeTurkList = [
+    {   
+        'id': 1213023,
+        'blocked': true
+    }, 
+    {   
+        'id': 32349712,
+        'blocked': false
+    }, {   
+        'id': 143412,
+        'blocked': false
+    }, {   
+        'id': 435304,
+        'blocked': false
+    }, {   
+        'id': 2234948,
+        'blocked': true
+    }, {   
+        'id': 9453311,
+        'blocked': false
+    }, {   
+        'id': 134524441,
+        'blocked': false
+    }, 
+]
+
+const TurkList = (props) => {
+    const [listData, setListData] = useState(fakeTurkList); // TODO: use turk list from backend
+    const [editable, setEditable] = useState(false); 
+
+    const handleOnClickCheckbox = (checked, id) => {
+        // TODO: end request to backend, update only when backend returns success
+        const newDataList = listData.map((o) => (o.id === id ? {'id': o.id, 'blocked': checked}: {'id': o.id, 'blocked': o.blocked}));
+        setListData(newDataList);
+    }
+
+    useEffect(() => {}, [listData, editable]);
+
+    return <div>
+        <div style={{textAlign: 'left', paddingBottom: '12px'}}>
+            <Button 
+                type="primary" 
+                icon={editable ? <UnlockOutlined />: <LockOutlined />} 
+                onClick={() => setEditable(!editable)}>
+                    {editable ? "Lock": "Unlock"} Editing
+            </Button>
+        </div> 
+        <Table
+            columns={[{
+                title: 'Id',
+                dataIndex: 'id',
+                sorter: (one, other) => (one === other ? 0 : (one < other ? -1 : 1)),
+            }, {
+                title: 'Blocked',
+                dataIndex: 'blocked',
+                sorter: (one, other) => (one === other ? 0 : (one < other ? -1 : 1)),
+                render: (blocked, row) =>
+                    <Checkbox onChange={(e) => handleOnClickCheckbox(e.target.checked, row.id)}
+                        disabled={!editable}
+                        checked={blocked} />
+            }]}
+            dataSource={listData}
+        />
+    </div>;
+};
+
+export default TurkList;

--- a/droidlet/tools/hitl/dashboard_app/dashboard_frontend/src/component/pipeline/metaInfo/turkList.js
+++ b/droidlet/tools/hitl/dashboard_app/dashboard_frontend/src/component/pipeline/metaInfo/turkList.js
@@ -1,3 +1,11 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Turk list used for viewing & setting turks to block or not blocked.
+
+Usage:
+<TurkList pipelineType={pipelineType} />
+*/
 import { Button, Checkbox, Input, Table, Typography } from "antd";
 import React, { useEffect, useState } from "react";
 import { LockOutlined, UnlockOutlined } from '@ant-design/icons';
@@ -31,6 +39,7 @@ const fakeTurkList = [
 ]
 
 const TurkList = (props) => {
+    const pipelineType = props.pipelineType;
     const [listData, setListData] = useState(fakeTurkList); // TODO: use turk list from backend
     const [searchKey, setSearchKey] = useState(null);
     const [displayData, setDisplayData] = useState(fakeTurkList);

--- a/droidlet/tools/hitl/dashboard_app/dashboard_frontend/src/component/pipeline/metaInfo/turkList.js
+++ b/droidlet/tools/hitl/dashboard_app/dashboard_frontend/src/component/pipeline/metaInfo/turkList.js
@@ -78,11 +78,11 @@ const TurkList = (props) => {
             columns={[{
                 title: 'Id',
                 dataIndex: 'id',
-                sorter: (one, other) => (one === other ? 0 : (one < other ? -1 : 1)),
+                sorter: (one, other) => (one.id === other.id ? 0 : (one.id < other.id ? -1 : 1)),
             }, {
                 title: 'Blocked',
                 dataIndex: 'blocked',
-                sorter: (one, other) => (one === other ? 0 : (one < other ? -1 : 1)),
+                sorter: (one, other) => (one.blocked === other.blocked ? 0 : (one.blocked < other.blocked ? -1 : 1)),
                 render: (blocked, row) =>
                     <Checkbox onChange={(e) => handleOnClickCheckbox(e.target.checked, row.id)}
                         disabled={!editable}

--- a/droidlet/tools/hitl/dashboard_app/dashboard_frontend/src/component/pipeline/panel.js
+++ b/droidlet/tools/hitl/dashboard_app/dashboard_frontend/src/component/pipeline/panel.js
@@ -14,6 +14,7 @@ import { Link, Outlet, useLocation, useParams } from 'react-router-dom';
 import { TAB_ITEMS } from '../../constants/pipelineConstants';
 import InfoBlock from './metaInfo/infoBlock';
 import RunList from './metaInfo/runList';
+import TurkList from './metaInfo/turkList';
 
 const menuItems = Object.values(TAB_ITEMS);
 const { TabPane } = Tabs;
@@ -107,6 +108,8 @@ const PipelinePanel = (props) => {
                                                 // render job list if key is jobs, otherwise render info block
                                                 item.key === TAB_ITEMS.RUNS.key ?
                                                     <RunList pipelineType={pipelineType} /> :
+                                                item.key === TAB_ITEMS.TURK.key ? 
+                                                    <TurkList pipelineType={pipelineType} /> :
                                                     <InfoBlock infoType={item.key} pipelineType={pipelineType} />
                                             }
                                         </TabPane>

--- a/droidlet/tools/hitl/dashboard_app/dashboard_frontend/src/constants/pipelineConstants.js
+++ b/droidlet/tools/hitl/dashboard_app/dashboard_frontend/src/constants/pipelineConstants.js
@@ -23,5 +23,10 @@ export const TAB_ITEMS = {
     {
         label: 'View Runs',
         key: 'runs'
+    },
+    TURK: 
+    {
+        label: 'Manage Turks',
+        key: 'turk'
     }
 }


### PR DESCRIPTION
# Description

  - Add frontend for viewing & editing turk list (toggle a turk to be blocked or unblocked)
  - The turk list supports sort, and search by turk id; when editing the list, user need to unlock first
  - Note this frontend change only shows fake data right now

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

- Demo:
  - ![demo_turk_list_manage](https://user-images.githubusercontent.com/51009396/179618044-f253777b-1486-410a-ba04-29d187c62f1a.gif)

# Testing

Manually tested

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [x] I have added Docstrings and comments to the code.
- [x] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
