### PR TITLE
HiTL Dashboard - Best Model Loss & Accuracy Visualization Backend

### DIFF
--- a/droidlet/tools/hitl/dashboard_app/README.MD
+++ b/droidlet/tools/hitl/dashboard_app/README.MD
@@ -7,7 +7,7 @@ This is a Dashboard app prototype for the HITL system.
 - July 21:
     - Updated backend api for reteriving loss and accuracy for a model.
     - Demo:
-        - 
+        - ![demo_model_loss_acc_backend](https://user-images.githubusercontent.com/51009396/180333355-1927feec-8f01-4985-bc51-f3f08eb4c5b8.gif)
 - July 14:
     - Added model visualization component, user can see text info about a model:
     - Demo:

--- a/droidlet/tools/hitl/dashboard_app/README.MD
+++ b/droidlet/tools/hitl/dashboard_app/README.MD
@@ -1,9 +1,13 @@
 # Dashboard App for HITL
-Updated July 13 by Chuxi.
+Updated July 21 by Chuxi.
 
 This is a Dashboard app prototype for the HITL system.
 
 ## Update Note
+- July 21:
+    - Updated backend api for reteriving loss and accuracy for a model.
+    - Demo:
+        - 
 - July 14:
     - Added model visualization component, user can see text info about a model:
     - Demo:
@@ -119,6 +123,16 @@ APIs are based on socket event, the following APIs are supported currently:
         - the batch id of the run.
         - the key for the model, could be any key from the model, or "COMPLETE", indicating getting the complete model dict
     - output: the key and the value specific to the key for the model if the model exists and key is valid, otherwise error code
-    
+- get_best_model_loss_acc_by_id
+    - get loss and accuracy from a model log for a specific run's best model, 
+    the loss and accuracy infomation is reterived by crawling the best model's log file
+    - input:
+        - batch id of a specific run
+    - output:
+        - a dictionary containing:
+            - epoch loss and accuracy
+            - text_span loss and accuracy
+        - or an error code indicating the best model log cannot be find
+ 
 ## Demo
 ![backend_api_demo](https://user-images.githubusercontent.com/51009396/175696481-532cec55-5b2e-4bae-bceb-9e7d3f2aa7b7.gif)

--- a/droidlet/tools/hitl/dashboard_app/backend/dashboard_aws_helper.py
+++ b/droidlet/tools/hitl/dashboard_app/backend/dashboard_aws_helper.py
@@ -14,6 +14,7 @@ import os
 import re
 
 from droidlet.tools.hitl.dashboard_app.backend.dashboard_model_utils import load_model
+from droidlet.tools.hitl.utils.read_model_log import read_model_log_to_list
 
 
 PIPELINE_DATASET_MAPPING = {
@@ -41,6 +42,9 @@ def _download_file(fname: str):
     """
     download file from s3 if it does not exists in local tmp storage
     """
+    # sanity check
+    if fname is None:
+        return None
     # check if exists on local tmp directory
     local_file_name = os.path.join(HITL_TMP_DIR, fname)
 
@@ -189,3 +193,38 @@ def get_model_by_id(batch_id: int):
         return f"cannot find best_model file related to {batch_id}", 404
     else:
         return load_model(local_fname), None
+
+def get_best_model_loss_acc_by_id(batch_id: int):
+    """
+    Get best model loss and accuracy from model log file,
+    return:
+        - a dict including epoch & text span loss and accuracy, and no error code if can find the best model log
+        - an error message with error code 404 if cannot find the best model log
+    """
+    def get_best_model_name(batch_id: int):
+        # download and read best_model.txt file
+        best_model_fname = ""
+        bm_info_prefix = "best_model_info"
+        pattern = f"{batch_id}.*model_out\/{bm_info_prefix}\.txt"
+        for obj in s3.Bucket(S3_BUCKET_NAME).objects.all():
+            if re.match(pattern, obj.key):
+                best_model_fname = _download_file(obj.key)
+                f = open(best_model_fname)
+                best_model_name = f.readline()
+                f.close()
+
+                best_model_name = obj.key[ : (obj.key.rindex("/") + 1)] + best_model_name.split("|")[0] + "|.log"
+                return best_model_name
+        return None # cannot find
+
+    best_model_log_fname = get_best_model_name(batch_id) 
+    best_model_log_fname = _download_file(best_model_log_fname)
+
+    if best_model_log_fname is None:
+        return f"Cannot find best model log file with batch_id = {batch_id}", 404
+    
+    # read best model log file
+    epoch_ls, text_span_ls = read_model_log_to_list(best_model_log_fname)
+    return {"epoch": epoch_ls, "text_span": text_span_ls}, None
+
+

--- a/droidlet/tools/hitl/dashboard_app/backend/dashboard_aws_helper.py
+++ b/droidlet/tools/hitl/dashboard_app/backend/dashboard_aws_helper.py
@@ -194,6 +194,7 @@ def get_model_by_id(batch_id: int):
     else:
         return load_model(local_fname), None
 
+
 def get_best_model_loss_acc_by_id(batch_id: int):
     """
     Get best model loss and accuracy from model log file,
@@ -201,6 +202,7 @@ def get_best_model_loss_acc_by_id(batch_id: int):
         - a dict including epoch & text span loss and accuracy, and no error code if can find the best model log
         - an error message with error code 404 if cannot find the best model log
     """
+
     def get_best_model_name(batch_id: int):
         # download and read best_model.txt file
         best_model_fname = ""
@@ -213,18 +215,18 @@ def get_best_model_loss_acc_by_id(batch_id: int):
                 best_model_name = f.readline()
                 f.close()
 
-                best_model_name = obj.key[ : (obj.key.rindex("/") + 1)] + best_model_name.split("|")[0] + "|.log"
+                best_model_name = (
+                    obj.key[: (obj.key.rindex("/") + 1)] + best_model_name.split("|")[0] + "|.log"
+                )
                 return best_model_name
-        return None # cannot find
+        return None  # cannot find
 
-    best_model_log_fname = get_best_model_name(batch_id) 
+    best_model_log_fname = get_best_model_name(batch_id)
     best_model_log_fname = _download_file(best_model_log_fname)
 
     if best_model_log_fname is None:
         return f"Cannot find best model log file with batch_id = {batch_id}", 404
-    
+
     # read best model log file
     epoch_ls, text_span_ls = read_model_log_to_list(best_model_log_fname)
     return {"epoch": epoch_ls, "text_span": text_span_ls}, None
-
-

--- a/droidlet/tools/hitl/dashboard_app/backend/dashboard_server.py
+++ b/droidlet/tools/hitl/dashboard_app/backend/dashboard_server.py
@@ -226,6 +226,7 @@ def get_model_value(batch_id, key):
         # get a specific value
         emit(DASHBOARD_EVENT.GET_MODEL_VALUE.value, [key, get_value_by_key(model, key)])
 
+
 @socketio.on(DASHBOARD_EVENT.GET_BEST_MODEL_LOSS_ACC.value)
 def get_best_model_loss_acc(batch_id: int):
     """
@@ -235,7 +236,7 @@ def get_best_model_loss_acc(batch_id: int):
         - batch id of a specific run
     - output:
         - a dictionary containing:
-            - epoch loss and accuracy 
+            - epoch loss and accuracy
             - text_span loss and accuracy
         - or an error code indicating the best model log cannot be find
     """
@@ -247,6 +248,7 @@ def get_best_model_loss_acc(batch_id: int):
         emit(DASHBOARD_EVENT.GET_BEST_MODEL_LOSS_ACC.value, error_code)
     else:
         emit(DASHBOARD_EVENT.GET_BEST_MODEL_LOSS_ACC.value, loss_acc_dict)
+
 
 if __name__ == "__main__":
     socketio.run(app)

--- a/droidlet/tools/hitl/dashboard_app/dashboard_frontend/src/component/pipeline/detail/asset/modelCard.js
+++ b/droidlet/tools/hitl/dashboard_app/dashboard_frontend/src/component/pipeline/detail/asset/modelCard.js
@@ -12,6 +12,7 @@ import { SocketContext } from "../../../../context/socket";
 import ModelAtrributeModal from "./modelAttributeDetailModal";
 
 const { Meta } = Card;
+const LOSS_ACC_TYPES = [{ "label": "Epoch", "value": "epoch" }, { "label": "Text Span", "value": "text_span" }]
 
 const ModelCard = (props) => {
     const batchId = props.batchId;
@@ -21,7 +22,9 @@ const ModelCard = (props) => {
     const [loadingArgs, setLoadingArgs] = useState(true);
     const [loadingKeys, setLoadingKeys] = useState(true);
     const [currentModelKey, setCurrentModelKey] = useState(null);
-    const [modalOpen, setModalOpen] = useState(false);
+    const [attrModalOpen, setAttrModalOpen] = useState(false);
+    const [lossAccData, setLossAccData] = useState(null);
+    const [loadingLossAcc, setLoadingLossAcc] = useState(true);
 
     const socket = useContext(SocketContext);
 
@@ -40,6 +43,14 @@ const ModelCard = (props) => {
         }
     });
 
+    const handleReceivedLossAcc = useCallback((data) => {
+        setLoadingLossAcc(false);
+        console.log(data);
+        if (data !== 404) {
+            setLossAccData(data);
+        }
+    });
+
     const getModelArgs = () => {
         // get args for the model
         socket.emit("get_model_value_by_id_n_key", batchId, "args");
@@ -49,14 +60,20 @@ const ModelCard = (props) => {
         socket.emit("get_model_keys_by_id", batchId);
     }
 
+    const getLossAcc = () => {
+        socket.emit("get_best_model_loss_acc_by_id", batchId);
+    }
+
     useEffect(() => {
         socket.on("get_model_value_by_id_n_key", (data) => handleReceivedModelArgs(data));
         socket.on("get_model_keys_by_id", (data) => handleRecievedModelKeys(data));
+        socket.on("get_best_model_loss_acc_by_id", (data) => handleReceivedLossAcc(data));
     }, [socket, handleReceivedModelArgs]);
 
     useEffect(() => {
         loadingArgs && getModelArgs();
         loadingKeys && getModelKeys();
+        loadingLossAcc && getLossAcc();
     }, []); // component did mount
 
     const processModelArg = (arg) => {
@@ -71,12 +88,16 @@ const ModelCard = (props) => {
 
     const handleOnClickViewModelAttibute = (modelKey) => {
         setCurrentModelKey(modelKey);
-        setModalOpen(true);
+        setAttrModalOpen(true);
+    }
+
+    const handleViewModelLossAndAcc = (lossAccType) => {
+        alert(lossAccData[lossAccType].map((o) => (`loss: ${o.loss},  acc: ${o.acc}`)));
     }
 
     return (
         <div style={{ width: '70%' }}>
-            <Card title="Model" loading={loadingKeys || loadingArgs}>
+            <Card title="Model" loading={loadingKeys || loadingArgs || loadingLossAcc}>
                 <Meta />
                 {
                     !loadingKeys && !loadingArgs && (
@@ -101,6 +122,23 @@ const ModelCard = (props) => {
                                         </Descriptions.Item>
                                     )}
                                 </Descriptions>
+                                {
+                                    lossAccData &&
+                                    <>
+                                        <Divider />
+                                        <Descriptions title="Model Loss and Accuracy" bordered column={2}>
+                                            {LOSS_ACC_TYPES.map((o) => (
+                                                <Descriptions.Item>
+                                                    <Tooltip title={`View ${o.label}`}>
+                                                        <Button type="link" onClick={() => handleViewModelLossAndAcc(o.value)}>
+                                                            {o.label}
+                                                        </Button>
+                                                    </Tooltip>
+                                                </Descriptions.Item>
+                                            ))}
+                                        </Descriptions>
+                                    </>
+                                }
                             </div>
                             :
                             <div>NA</div>
@@ -112,9 +150,9 @@ const ModelCard = (props) => {
                     <ModelAtrributeModal
                         modelKey={currentModelKey}
                         setModelKey={setCurrentModelKey}
-                        modalOpen={modalOpen}
-                        setModalOpen={setModalOpen}
-                        batchId={batchId} 
+                        modalOpen={attrModalOpen}
+                        setModalOpen={setAttrModalOpen}
+                        batchId={batchId}
                     />
                 }
             </Card>

--- a/droidlet/tools/hitl/utils/read_model_log.py
+++ b/droidlet/tools/hitl/utils/read_model_log.py
@@ -3,6 +3,8 @@ Copyright (c) Facebook, Inc. and its affiliates.
 
 Utils for processing model log.
 """
+
+
 def read_model_log_to_list(fname: str):
     """
     Read model log and export to a dictionary including:
@@ -14,7 +16,7 @@ def read_model_log_to_list(fname: str):
     f.close()
 
     lines = content.split("\n")
-    
+
     def get_loss_acc(line: str):
         words = line.split(" ")
         loss, acc = None, None
@@ -25,7 +27,6 @@ def read_model_log_to_list(fname: str):
                 acc = float(words[i])
         return loss, acc
 
-    
     epoch_loss_acc_list = []
     text_span_loss_acc_list = []
     for line in lines:
@@ -37,4 +38,3 @@ def read_model_log_to_list(fname: str):
             text_span_loss_acc_list.append({"loss": loss, "acc": acc})
 
     return epoch_loss_acc_list, text_span_loss_acc_list
-    

--- a/droidlet/tools/hitl/utils/read_model_log.py
+++ b/droidlet/tools/hitl/utils/read_model_log.py
@@ -1,0 +1,32 @@
+import pandas as pd
+
+def log_to_df(fname: str):
+    f = open(fname)
+    content = f.read()
+    f.close()
+
+    lines = content.split("\n")
+    
+    def get_loss_acc(line: str):
+        words = line.split(" ")
+        loss, acc = None, None
+        for i in range(0, len(words)):
+            if i > 0 and words[i - 1] == "Loss:":
+                loss = float(words[i])
+            elif i > 0 and words[i - 1] == "Accuracy:":
+                acc = float(words[i])
+        return loss, acc
+
+    
+    epoch_loss_acc_list = []
+    text_span_loss_acc_list = []
+    for line in lines:
+        if "epoch" in line:
+            loss, acc = get_loss_acc(line)
+            epoch_loss_acc_list.append({"loss": loss, "acc": acc})
+        elif " text span Loss: " in line:
+            loss, acc = get_loss_acc(line)
+            text_span_loss_acc_list.append({"loss": loss, "acc": acc})
+
+    return pd.DataFrame(epoch_loss_acc_list), pd.DataFrame(text_span_loss_acc_list)
+    

--- a/droidlet/tools/hitl/utils/read_model_log.py
+++ b/droidlet/tools/hitl/utils/read_model_log.py
@@ -1,6 +1,14 @@
-import pandas as pd
+"""
+Copyright (c) Facebook, Inc. and its affiliates.
 
-def log_to_df(fname: str):
+Utils for processing model log.
+"""
+def read_model_log_to_list(fname: str):
+    """
+    Read model log and export to a dictionary including:
+        - Epoch loss and accuracy
+        - Text span loss and accuracy
+    """
     f = open(fname)
     content = f.read()
     f.close()
@@ -28,5 +36,5 @@ def log_to_df(fname: str):
             loss, acc = get_loss_acc(line)
             text_span_loss_acc_list.append({"loss": loss, "acc": acc})
 
-    return pd.DataFrame(epoch_loss_acc_list), pd.DataFrame(text_span_loss_acc_list)
+    return epoch_loss_acc_list, text_span_loss_acc_list
     


### PR DESCRIPTION
# Description

- Added backend implementation to send best model's loss and accuracy via socket 
  - `get_best_model_loss_acc_by_id`
    - get loss and accuracy from a model log for a specific run's best model, the loss and accuracy infomation is reterived by crawling the best model's log file
    - input:
        - batch id of a specific run
    - output:
        - a dictionary containing:
            - epoch loss and accuracy
            - text_span loss and accuracy
        - or an error code indicating the best model log cannot be find
- Added utils for reading model log to extract loss and accuracy data
- Added a frontend block for viewing loss and accuracy (right now only showing data in the alert, will create a new PR for visualizing the accuracy and loss in a graph) 

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After
- Demo:
  - ![demo_model_loss_acc_backend](https://user-images.githubusercontent.com/51009396/180333355-1927feec-8f01-4985-bc51-f3f08eb4c5b8.gif)

# Testing

Manually tested

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [x] I have added Docstrings and comments to the code.
- [x] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
