### PR TITLE
Hitl dashboard Dataset Page -  pretty print json

### DIFF
--- a/droidlet/tools/hitl/dashboard_app/README.MD
+++ b/droidlet/tools/hitl/dashboard_app/README.MD
@@ -6,7 +6,7 @@ This is a Dashboard app prototype for the HITL system.
 ## Update Note
 - Aug 1:
     - Updated database display to be able to show pretty print json when user clicks on the json string:
-        - 
+        - ![demo_pretty_json](https://user-images.githubusercontent.com/51009396/182296422-8fd45bc1-36a8-434c-b344-4e2a1d6e63f5.gif)
 - July 13:
     - Added dataset visualization component including:
         - View newly added data points indices on the run detail page

--- a/droidlet/tools/hitl/dashboard_app/README.MD
+++ b/droidlet/tools/hitl/dashboard_app/README.MD
@@ -1,9 +1,12 @@
 # Dashboard App for HITL
-Updated July 13 by Chuxi.
+Updated Aug 1 by Chuxi.
 
 This is a Dashboard app prototype for the HITL system.
 
 ## Update Note
+- Aug 1:
+    - Updated database display to be able to show pretty print json when user clicks on the json string:
+        - 
 - July 13:
     - Added dataset visualization component including:
         - View newly added data points indices on the run detail page

--- a/droidlet/tools/hitl/dashboard_app/dashboard_frontend/src/component/dataset/datasetDetailPage.js
+++ b/droidlet/tools/hitl/dashboard_app/dashboard_frontend/src/component/dataset/datasetDetailPage.js
@@ -15,7 +15,9 @@ import { SocketContext } from "../../context/socket";
 
 const { Option } = Select;
 
-const DatasetJSONCmp = (props) => {
+const PrettyJSONText = (props) => {
+    // shows a pretty print json when onclick
+    // on click again will collapse to one line
     const obj = props.obj;
     const [jsonStr, setJsonStr] = useState(props.jsonStr);
     const [tabSep, setTabSep] = useState(false);
@@ -148,7 +150,7 @@ const DatasetDetailPage = (props) => {
                                             <Typography.Text style={{ paddingLeft: "6px" }}>{line[1]}</Typography.Text>
                                         </div>}
                                         description={
-                                            <DatasetJSONCmp obj={line[2].obj} jsonStr={line[2].jsonStr} />
+                                            <PrettyJSONText obj={line[2].obj} jsonStr={line[2].jsonStr} />
                                         }
                                     />
                                 </List.Item>)


### PR DESCRIPTION
# Description

Based on discussion with @aszlam , added a frontend component in the HiTL dashboard to show pretty json when onClick of a json text block, onClick again will trigger collapsing back to one line. 

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Demo:
![demo_pretty_json](https://user-images.githubusercontent.com/51009396/182296422-8fd45bc1-36a8-434c-b344-4e2a1d6e63f5.gif)

# Testing

Manually tested.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [x] I have added Docstrings and comments to the code.
- [x] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
