### PR TITLE
Added cuda enable flag to nlu training pipeline

### DIFF
--- a/droidlet/perception/semantic_parsing/nsp_transformer_model/train_model.py
+++ b/droidlet/perception/semantic_parsing/nsp_transformer_model/train_model.py
@@ -137,7 +137,6 @@ class NLUModelTrainer:
                 t.to(model.decoder.lm_head.predictions.decoder.weight.device) for t in batch[:4]
             ]
             x, x_mask, y, y_mask = batch_tensors
-
             # pass batch data through model
             if self.args.tree_to_text:
                 outputs = model(y, y_mask, x, x_mask)
@@ -623,6 +622,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--nm_shows", default=10, type=int, help="Number of branches to keep in beam search"
     )
+    parser.add_argument("--cuda", action="store_true", help="use cuda")
     args = parser.parse_args()
 
     # parse proportion of different types of data samples from input arguments
@@ -693,7 +693,8 @@ if __name__ == "__main__":
     print(val_datasets)
 
     logging.info("====== Initializing NLU Model Trainer ======")
-    encoder_decoder = encoder_decoder.cuda()
+    if args.cuda:
+        encoder_decoder = encoder_decoder.cuda()
     model_trainer = NLUModelTrainer(
         args, encoder_decoder, tokenizer, model_identifier, full_tree_voc
     )


### PR DESCRIPTION
# Description

Currently NLU training pipeline assumes cuda is supported. It will throw error if running in a cpu-only machine. So added an `cuda` option here to let user choose device.


## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

If this PR introduces a change or fixes a bug, please add before and after screenshots (if this is causes a UX change) or before and after examples(this could be plain text, videos etc ) to demonstrate the change.

If this PR introduces a new feature, please also add examples or screenshots demonstrating the feature.

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
