### PR TITLE
Enable clarification from command line

### DIFF
--- a/agents/argument_parser.py
+++ b/agents/argument_parser.py
@@ -113,6 +113,12 @@ class ArgumentParser:
             type=int,
             help='number of ticks after which agent updates map')
         mc_parser.add_argument("--port", type=int, default=25565)
+        mc_parser.add_argument(
+            "--allow_clarification",
+            action="store_true",
+            default=False,
+            help="allow reference object clarification pathway",
+        )
 
     def add_loco_parser(self):
         loco_parser = self.parser.add_argument_group("Locobot Agent Args")

--- a/agents/craftassist/craftassist_agent.py
+++ b/agents/craftassist/craftassist_agent.py
@@ -97,6 +97,7 @@ class CraftAssistAgent(DroidletAgent):
             "fill_idmeta": fill_idmeta,
             "color_bid_map": COLOR_BID_MAP,
         }
+        self.allow_clarification = opts.allow_clarification
         self.backend = opts.backend
         self.mark_airtouching_blocks = opts.mark_airtouching_blocks
         super(CraftAssistAgent, self).__init__(opts)
@@ -262,6 +263,7 @@ class CraftAssistAgent(DroidletAgent):
             "color_bid_map": self.low_level_data["color_bid_map"],
             "get_all_holes_fn": heuristic_perception.get_all_nearby_holes,
             "get_locs_from_entity": get_locs_from_entity,
+            "allow_clarification": self.allow_clarification,
         }
         self.dialogue_manager = DialogueManager(
             memory=self.memory,

--- a/agents/craftassist/tests/fake_agent.py
+++ b/agents/craftassist/tests/fake_agent.py
@@ -174,6 +174,7 @@ class FakeAgent(DroidletAgent):
             "color_bid_map": self.low_level_data["color_bid_map"],
             "get_all_holes_fn": heuristic_perception.get_all_nearby_holes,
             "get_locs_from_entity": get_locs_from_entity,
+            "allow_clarification": False,
         }
         self.dialogue_manager = DialogueManager(
             self.memory,

--- a/droidlet/interpreter/craftassist/mc_interpreter.py
+++ b/droidlet/interpreter/craftassist/mc_interpreter.py
@@ -63,6 +63,7 @@ class MCInterpreter(Interpreter):
         self.get_locs_from_entity = low_level_data["get_locs_from_entity"]
         self.special_shape_functions = low_level_data["special_shape_functions"]
         self.color_bid_map = low_level_data["color_bid_map"]
+        self.allow_clarification = low_level_data["allow_clarification"]
         # These come from agent's perception
         self.get_all_holes_fn = low_level_data["get_all_holes_fn"]
         self.workspace_memory_prio = ["Mob", "BlockObject"]

--- a/droidlet/interpreter/interpret_location.py
+++ b/droidlet/interpreter/interpret_location.py
@@ -31,7 +31,6 @@ class ReferenceLocationInterpreter:
         d: logical form from semantic parser
         """
         loose_speakerlook = False
-        allow_clarification = True
         expected_num = 1
         # FIXME! merge/generalize this, code in spatial_reasoning, and filter_by_sublocation
         if d.get("relative_direction") == "BETWEEN":
@@ -40,19 +39,18 @@ class ReferenceLocationInterpreter:
             ref_obj_1 = d.get("reference_object_1")
             ref_obj_2 = d.get("reference_object_2")
             if ref_obj_1 and ref_obj_2:
+                interpreter.allow_clarificaiton = False
                 mem1 = interpreter.subinterpret["reference_objects"](
                     interpreter,
                     speaker,
                     ref_obj_1,
                     loose_speakerlook=loose_speakerlook,
-                    allow_clarification=False,
                 )[0]
                 mem2 = interpreter.subinterpret["reference_objects"](
                     interpreter,
                     speaker,
                     ref_obj_2,
                     loose_speakerlook=loose_speakerlook,
-                    allow_clarification=False,
                 )[0]
                 if mem1 is None or mem2 is None:
                     raise ErrorWithResponse("I don't know what you're referring to")
@@ -61,7 +59,7 @@ class ReferenceLocationInterpreter:
                 return mems
 
             else:
-                allow_clarification = False
+                interpreter.allow_clarification = False
 
         default_loc = getattr(interpreter, "default_loc", SPEAKERLOOK)
         ref_obj = d.get("reference_object", default_loc["reference_object"])
@@ -70,7 +68,6 @@ class ReferenceLocationInterpreter:
             speaker,
             ref_obj,
             loose_speakerlook=loose_speakerlook,
-            allow_clarification=allow_clarification,
         )
 
         # FIXME use FILTERS here!!

--- a/droidlet/interpreter/interpret_reference_objects.py
+++ b/droidlet/interpreter/interpret_reference_objects.py
@@ -138,7 +138,6 @@ def interpret_reference_object(
     d,
     extra_tags=[],
     loose_speakerlook=False,
-    allow_clarification=True,
     all_proximity=100,
 ) -> List[ReferenceObjectNode]:
     """this tries to find a ref obj memory matching the criteria from the
@@ -151,8 +150,12 @@ def interpret_reference_object(
     d: logical form from semantic parser
 
     extra_tags (list of strings): tags added by parent to narrow the search
-    allow_clarification (bool): should a Clarification object be put on the DialogueStack
     """
+
+    if hasattr(interpreter, "allow_clarification"):
+        allow_clarification = interpreter.allow_clarification
+    else:
+        allow_clarification = False
 
     filters_d = d.get("filters")
     special = d.get("special_reference")

--- a/droidlet/shared_data_structs.py
+++ b/droidlet/shared_data_structs.py
@@ -126,6 +126,7 @@ class MockOpt:
         self.enable_timeline = False
         # flag for whether loading true model
         self.flag_load_nsp_model = False
+        self.allow_clarification = False
 
 
 class PriorityQueue:


### PR DESCRIPTION
# Description

This PR enables to user to enable clarification from the command line using the --allow_clarification flag.  This gets passed to MCInterpreter through interpreter_low_level_data.  The default without the flag is that clarification is disabled.

## Type of change

Please check the options that are relevant.

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [X] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [X] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Previously clarification was enabled by default.  Now the default is that clarification is not allowed, but can be enabled at agent launch by adding the flag.

# Testing

I've tested this by issuing commands with bad normal and location reference objects, with and without the flag.

# Checklist:

- [X] I have performed manual end-to-end testing of the feature in my environment.
- [X] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [X] New and existing unit tests pass locally with my changes.
- [X] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
