### PR TITLE
fixed recorder - check if in dict before calling

### DIFF
--- a/droidlet/tools/hitl/nsp_retrain_infra.py
+++ b/droidlet/tools/hitl/nsp_retrain_infra.py
@@ -248,7 +248,7 @@ class NSPRetrainingJob(DataGenerator):
         self._job_mng_util.set_job_stat(
             Job.RETRAIN, JobStat.ORI_DATA_SZ, total_rows - new_data_rows
         )
-        self._job_mng_util.set_job_stat(Job.register, JobStat.NEW_DATA_SZ, total_rows)
+        self._job_mng_util.set_job_stat(Job.RETRAIN, JobStat.NEW_DATA_SZ, total_rows)
 
         # Save locally and upload to S3
         mask_filepath = os.path.join(batch_config_dir, "split_masks.pth")
@@ -282,7 +282,7 @@ class NSPRetrainingJob(DataGenerator):
         return True
 
     def run(self):
-        self._job_mng_util.set_job_start(Job.INTERACTION)
+        self._job_mng_util.set_job_start(Job.RETRAIN)
         logging.info(f"NSP Retraining Job initialized, downloading new data")
         opts = self.opts
 
@@ -460,9 +460,9 @@ class NSPRetrainingJob(DataGenerator):
             f_log.write("hash_dataset " + checksum_d + "\n")
 
             # update corresponding job status
-            self._job_mng_util.set_job_stat(Job.INTERACTION, JobStat.MODEL_ACCURACY, acc)
-            self._job_mng_util.set_job_stat(Job.INTERACTION, JobStat.MODEL_EPOCH, epoch)
-            self._job_mng_util.set_job_stat(Job.INTERACTION, JobStat.MODEL_LOSS, loss)
+            self._job_mng_util.set_job_stat(Job.RETRAIN, JobStat.MODEL_ACCURACY, acc)
+            self._job_mng_util.set_job_stat(Job.RETRAIN, JobStat.MODEL_EPOCH, epoch)
+            self._job_mng_util.set_job_stat(Job.RETRAIN, JobStat.MODEL_LOSS, loss)
 
         # Tar model and upload them to AWS
         tar_and_upload(checksum_m, artifact_path_name, artifact_name)

--- a/droidlet/tools/hitl/utils/hitl_recorder.py
+++ b/droidlet/tools/hitl/utils/hitl_recorder.py
@@ -9,10 +9,7 @@ This util class is extendable, if you want to add a new statistics for recording
 please do the following:
     - To add a new meta data - please add a new entry in the MetaData enum.
     - To add a new job type - please add a new entry in the Job enum.
-    - To add a new job statistic:
-        1. add a new entry in the JobStat enum.
-        2a. if this job statistic is shared by all jobs, add it to the STAT_FOR_ALL set.
-        2b. if this job belongs to a specific job, add it to the STAT_JOB_PAIR dict (key - corresonding job, val - a job statistics set).
+    - To add a new job statistic - please add a new entry in the JobStat enum.
 """
 import logging
 import boto3
@@ -77,39 +74,6 @@ class JobStat(Enum):
     MODEL_ACCURACY = "model_accuracy"
     MODEL_EPOCH = "model_epoch"
     MODEL_LOSS = "model_loss"
-
-
-# statastics that all jobs have
-STAT_FOR_ALL = set(
-    [
-        JobStat.ENABLED,
-        JobStat.NUM_REQUESTED,
-        JobStat.NUM_COMPLETED,
-        JobStat.START_TIME,
-        JobStat.END_TIME,
-    ]
-)
-
-# statatics that are unique for a job (not in the STAT_FOR_ALL set)
-STAT_JOB_PAIR = {
-    Job.INTERACTION: set(
-        [
-            JobStat.NUM_SESSION_LOG,
-            JobStat.NUM_COMMAND,
-            JobStat.NUM_ERR_COMMAND,
-            JobStat.DASHBOARD_VER,
-        ]
-    ),
-    Job.RETRAIN: set(
-        [
-            JobStat.ORI_DATA_SZ,
-            JobStat.NEW_DATA_SZ,
-            JobStat.MODEL_ACCURACY,
-            JobStat.MODEL_EPOCH,
-            JobStat.MODEL_LOSS,
-        ]
-    ),
-}
 
 # update job stat interval in seconds
 DEFAULT_STAT_UPDATE_INTERVAL = 60
@@ -236,16 +200,16 @@ class Recorder:
         """
         save local job management record to remote s3 bucket
         """
-        batch_id = self._record_dict[MetaData.BATCH_ID._name_]
+        batch_id = self._record_dict[MetaData.BATCH_ID._name_] if MetaData.BATCH_ID._name_ in self._record_dict else None
         # check batch_id for saving to s3
         if batch_id is None:
             logging.error(
-                "[Job Management Util] Must have an associated batch to be able to save to s3"
+                f"[Job Management Util] Must have an associated batch to be able to save to s3, please check local path for temporary file job stats record file - {self._local_path}"
             )
-            raise RuntimeError("No associated batch_id set")
         # save to s3
-        remote_file_path = f"{JOB_MNG_PATH_PREFIX}/{batch_id}.json"
-        try:
-            resp = s3.meta.client.upload_file(self._local_path, S3_BUCKET_NAME, remote_file_path)
-        except botocore.exceptions.ClientError as e:
-            logging.info(f"[Job Management Util] Not able to save file {self._local_path} to s3.")
+        else:
+            remote_file_path = f"{JOB_MNG_PATH_PREFIX}/{batch_id}.json"
+            try:
+                resp = s3.meta.client.upload_file(self._local_path, S3_BUCKET_NAME, remote_file_path)
+            except botocore.exceptions.ClientError as e:
+                logging.error(f"[Job Management Util] Not able to save file {self._local_path} to s3.")

--- a/droidlet/tools/hitl/utils/hitl_recorder.py
+++ b/droidlet/tools/hitl/utils/hitl_recorder.py
@@ -148,12 +148,13 @@ class Recorder:
         tname = time_type._name_
 
         if job_type is not None:
+            self._check_n_init_job(job_type)
             # set job start / end
             jname = job_type._name_
-            if rec_dict[jname][tname] is None:
+            if tname not in rec_dict[jname]:
                 rec_dict[jname][tname] = []
             rec_dict[jname][tname].append(time_now)
-        elif rec_dict[tname]:
+        elif tname in rec_dict and rec_dict[tname]:
             # set meta data start / end, can only be set once
             logging.error(
                 f"[Job Management Util] Cannot set meta data start/end time twice, ignoring setting {tname}."
@@ -206,7 +207,7 @@ class Recorder:
         since_last_update = since_last_update.total_seconds()
 
         if (
-            self._record_dict[jname][sname] is None
+            sname not in self._record_dict[jname]
             or since_last_update > self._stat_update_interval
             or force_update
         ):

--- a/droidlet/tools/hitl/utils/hitl_recorder.py
+++ b/droidlet/tools/hitl/utils/hitl_recorder.py
@@ -75,6 +75,7 @@ class JobStat(Enum):
     MODEL_EPOCH = "model_epoch"
     MODEL_LOSS = "model_loss"
 
+
 # update job stat interval in seconds
 DEFAULT_STAT_UPDATE_INTERVAL = 60
 
@@ -200,7 +201,11 @@ class Recorder:
         """
         save local job management record to remote s3 bucket
         """
-        batch_id = self._record_dict[MetaData.BATCH_ID._name_] if MetaData.BATCH_ID._name_ in self._record_dict else None
+        batch_id = (
+            self._record_dict[MetaData.BATCH_ID._name_]
+            if MetaData.BATCH_ID._name_ in self._record_dict
+            else None
+        )
         # check batch_id for saving to s3
         if batch_id is None:
             logging.error(
@@ -210,6 +215,10 @@ class Recorder:
         else:
             remote_file_path = f"{JOB_MNG_PATH_PREFIX}/{batch_id}.json"
             try:
-                resp = s3.meta.client.upload_file(self._local_path, S3_BUCKET_NAME, remote_file_path)
+                resp = s3.meta.client.upload_file(
+                    self._local_path, S3_BUCKET_NAME, remote_file_path
+                )
             except botocore.exceptions.ClientError as e:
-                logging.error(f"[Job Management Util] Not able to save file {self._local_path} to s3.")
+                logging.error(
+                    f"[Job Management Util] Not able to save file {self._local_path} to s3."
+                )


### PR DESCRIPTION
# Description

Fixes #1325 #1327
The issue was caused by retrieving dict value before assign, fixed by checking if the key is in dict instead of checking if the value is null.

## Type of change


- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Before: see issue #1325 , #1327 
After: can record without KeyError/Attribute error now. 
<img width="1123" alt="Screen Shot 2022-08-03 at 2 49 46 PM" src="https://user-images.githubusercontent.com/51009396/182718781-4e01d1d3-e4e4-444f-b1c7-46aa2c32fb4b.png">

Also changed behavior when not having the batch_id:
Before: if the current run does not have batch_id, program will exit with errors
After: if the current run does not have batch_id, program will log error, and log the local job_stats file path; but the program will continue and exit normally. 
<img width="1241" alt="Screen Shot 2022-08-03 at 5 03 14 PM" src="https://user-images.githubusercontent.com/51009396/182735340-9004fdb9-b0bf-4289-a93e-cf6f5787202e.png">


# Testing

Tested by running `simple_hitl_example.py` and `annotation_jobs.py`.

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
