### PR TITLE
mrp down default all

### DIFF
--- a/mrp/setup.py
+++ b/mrp/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="mrp",
-    version="1.0.0",
+    version="1.0.2",
     author="Leonid Shamis",
     package_dir={"": "src"},
     packages=find_packages(

--- a/mrp/src/mrp/cmd/down.py
+++ b/mrp/src/mrp/cmd/down.py
@@ -26,7 +26,7 @@ def cli(*cmd_procs, procs=None, local=False, wait=True):
     defined_procs = set(process_def.defined_processes.keys())
 
     if local:  # Down local msetup.py
-        assert not procs, "Specifying processes is not supported with the flag '--local'."
+        assert not procs, "Cannot use '--local' flag and also specify processes."
         down_procs = running_procs & defined_procs
 
     elif procs:  # Specified process set.

--- a/mrp/src/mrp/cmd/down.py
+++ b/mrp/src/mrp/cmd/down.py
@@ -6,32 +6,40 @@ import click
 
 
 @click.command()
-@click.option("--all", is_flag=True)
+@click.option("--local", is_flag=True)
 @click.option("--wait/--nowait", is_flag=True)
-@click.argument("procs", nargs=-1, shell_complete=_autocomplete.defined_processes)
-def cli(*cmd_procs, procs=None, all=False, wait=True):
+@click.argument("procs", nargs=-1, shell_complete=_autocomplete.running_processes)
+def cli(*cmd_procs, procs=None, local=False, wait=True):
     procs = procs or []
+    procs += cmd_procs
 
-    # Get all MRP procs running in the system
-    running_procs = life_cycle.system_state().procs.keys()
-    down_procs = set(running_procs)
+    specified_procs = set(procs)
 
-    if all:  # system-wide down
-        assert not procs, "Specifying processes is not supported with the flag '--all'."
-        assert not cmd_procs, "Specifying processes is not supported when all=True."
+    # Get all MRP procs running in the system.
+    running_procs = set(
+        name
+        for name, info in life_cycle.system_state().procs.items()
+        if info.state != life_cycle.State.STOPPED
+    )
 
-    else:  #  local down (only processes defined within the current msetup.py)
-        defined_procs = process_def.defined_processes.keys()
-        down_procs = down_procs & set(defined_procs)
+    # Get MRP procs defined in the local msetup.py
+    defined_procs = set(process_def.defined_processes.keys())
 
-        # Support procs as *args when using cmd syntax.
-        procs += cmd_procs
-        if procs:
-            down_procs = down_procs & set(procs)
+    if local:  # Down local msetup.py
+        assert not procs, "Specifying processes is not supported with the flag '--local'."
+        down_procs = running_procs & defined_procs
 
+    elif procs:  # Specified process set.
+        down_procs = running_procs & specified_procs
+
+    else:  # System-wide down.
+        down_procs = running_procs
+
+    # Ask all the procs to go down.
     for proc in down_procs:
         click.echo(f"stopping {proc}...")
         life_cycle.set_ask(proc, life_cycle.Ask.DOWN)
 
+    # Wait for them to finished shutting down.
     if wait and down_procs:
         mrp.cmd.wait(*down_procs)

--- a/mrp/tests/cmd/test_down.py
+++ b/mrp/tests/cmd/test_down.py
@@ -47,12 +47,12 @@ def test_down(reset, hanging_proc):
 
 def test_down_all(reset, hanging_proc, hanging_proc_external):
     # proc should be told to go down, but not proc_ext
-    mrp.cmd.down()
+    mrp.cmd.down(local=True)
     assert mrp.life_cycle.system_state().procs["proc"].ask == Ask.DOWN
     assert mrp.life_cycle.system_state().procs["proc_ext"].ask == Ask.UP
 
     # proc should be told to go down
-    mrp.cmd.down(all=True)
+    mrp.cmd.down()
     assert mrp.life_cycle.system_state().procs["proc_ext"].ask == Ask.DOWN
 
 


### PR DESCRIPTION
# Description
Change default behavior for `mrp down` from local processes to all processes.
This change `all` flag to `local` flag.

Also, change auto-complete from defined processes to running processes.

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

If this PR introduces a change or fixes a bug, please add before and after screenshots (if this is causes a UX change) or before and after examples(this could be plain text, videos etc ) to demonstrate the change.

If this PR introduces a new feature, please also add examples or screenshots demonstrating the feature.

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
