### PR TITLE
Hitl dashbaord model viz improve

### DIFF
--- a/droidlet/tools/hitl/dashboard_app/README.MD
+++ b/droidlet/tools/hitl/dashboard_app/README.MD
@@ -1,9 +1,17 @@
 # Dashboard App for HITL
-Updated July 22 by Chuxi.
+Updated Aug 4 by Chuxi.
 
 This is a Dashboard app prototype for the HITL system.
 
 ## Update Note
+- Aug 4:
+    - Update support for visualizing the model:
+        - Changed from showing loss and accuracy of validation and text_span to showing loss and accuracy seperately, and show training loss/accuracy & validation loss/accuracy in the same graph. 
+        - Demo:
+            - Best models loss & accuracy for NLU pipeline:
+                - 
+            - Best model in a run:
+                - 
 - July 22:
     - Updated frontend component to show the model line graph of loss and accuracy vs epoch.
     - Demo:
@@ -128,15 +136,21 @@ APIs are based on socket event, the following APIs are supported currently:
         - the key for the model, could be any key from the model, or "COMPLETE", indicating getting the complete model dict
     - output: the key and the value specific to the key for the model if the model exists and key is valid, otherwise error code
 - get_best_model_loss_acc_by_id
-    - get loss and accuracy from a model log for a specific run's best model, 
-    the loss and accuracy infomation is reterived by crawling the best model's log file
+    - get loss and accuracy from a model log for a specific run's best model, the loss and accuracy infomation is reterived by crawling the best model's log file
     - input:
         - batch id of a specific run
     - output:
-        - a dictionary containing:
-            - epoch loss and accuracy
-            - text_span loss and accuracy
+        - a list contains the following when a best model log file can be found:
+            - a dictionary containing:
+                - key: loss, value: loss list for training and validation dataset
+                - key: acc, value: accuracy list for training and validation dataset
+            - batch id 
         - or an error code indicating the best model log cannot be find
+- get best models' batch ids for a specific pipeline
+    - input:
+        - pipeline name (can be nlu, tao or vision)
+    - output:
+        - a list of the batch ids of the best models
  
 ## Demo
 ![backend_api_demo](https://user-images.githubusercontent.com/51009396/175696481-532cec55-5b2e-4bae-bceb-9e7d3f2aa7b7.gif)

--- a/droidlet/tools/hitl/dashboard_app/README.MD
+++ b/droidlet/tools/hitl/dashboard_app/README.MD
@@ -7,10 +7,11 @@ This is a Dashboard app prototype for the HITL system.
 - Aug 4:
     - Update support for visualizing the model:
         - Changed from showing loss and accuracy of validation and text_span to showing loss and accuracy seperately, and show training loss/accuracy & validation loss/accuracy in the same graph. 
+        - Updated the graph visualization container to be responsive to browser window changes. 
         - Demo:
             - Best models loss & accuracy for NLU pipeline:
                 - 
-            - Best model in a run:
+            - Best model in a run (showing loss and accuracy seperately, graph responsive to browser window changes):
                 - 
 - July 22:
     - Updated frontend component to show the model line graph of loss and accuracy vs epoch.

--- a/droidlet/tools/hitl/dashboard_app/README.MD
+++ b/droidlet/tools/hitl/dashboard_app/README.MD
@@ -147,7 +147,8 @@ APIs are based on socket event, the following APIs are supported currently:
                 - key: acc, value: accuracy list for training and validation dataset
             - batch id 
         - or an error code indicating the best model log cannot be find
-- get best models' batch ids for a specific pipeline
+- get_best_model_bids_by_pipeline
+    - get best models' batch ids for a specific pipeline
     - input:
         - pipeline name (can be nlu, tao or vision)
     - output:

--- a/droidlet/tools/hitl/dashboard_app/README.MD
+++ b/droidlet/tools/hitl/dashboard_app/README.MD
@@ -9,10 +9,10 @@ This is a Dashboard app prototype for the HITL system.
         - Changed from showing loss and accuracy of validation and text_span to showing loss and accuracy seperately, and show training loss/accuracy & validation loss/accuracy in the same graph. 
         - Updated the graph visualization container to be responsive to browser window changes. 
         - Demo:
-            - Best models loss & accuracy for NLU pipeline:
-                - 
+            - Best models loss & accuracy for a pipeline:
+                - ![demo_best_models_for_pipeline](https://user-images.githubusercontent.com/51009396/182976894-a1eb380b-06fd-491b-8e4f-29abd7c2024d.gif)
             - Best model in a run (showing loss and accuracy seperately, graph responsive to browser window changes):
-                - 
+                - ![demo_best_model_for_a_run](https://user-images.githubusercontent.com/51009396/182976905-60713821-31d8-4187-889a-11b3b1d1ce82.gif)
 - July 22:
     - Updated frontend component to show the model line graph of loss and accuracy vs epoch.
     - Demo:

--- a/droidlet/tools/hitl/dashboard_app/README.MD
+++ b/droidlet/tools/hitl/dashboard_app/README.MD
@@ -6,7 +6,7 @@ This is a Dashboard app prototype for the HITL system.
 ## Update Note
 - Aug 4:
     - Update support for visualizing the model:
-        - Changed from showing loss and accuracy of validation and text_span to showing loss and accuracy seperately, and show training loss/accuracy & validation loss/accuracy in the same graph. 
+        - Changed from showing loss and accuracy of validation and text_span to showing loss and accuracy separately, and show training loss/accuracy & validation loss/accuracy in the same graph. 
         - Updated the graph visualization container to be responsive to browser window changes. 
         - Demo:
             - Best models loss & accuracy for a pipeline:

--- a/droidlet/tools/hitl/dashboard_app/backend/dashboard_aws_helper.py
+++ b/droidlet/tools/hitl/dashboard_app/backend/dashboard_aws_helper.py
@@ -230,3 +230,18 @@ def get_best_model_loss_acc_by_id(batch_id: int):
     # read best model log file
     epoch_ls, text_span_ls = read_model_log_to_list(best_model_log_fname)
     return {"epoch": epoch_ls, "text_span": text_span_ls}, None
+
+
+def get_best_models_by_pipeline(pipeline: str):
+    """
+    Get best models batch_id list for a pipeline.
+    The pipeline can be nlu, tao or vision
+    """
+    local_fname = _download_file(f"{pipeline}_model_viz_batch_list.txt")
+    if local_fname is None:
+        return f"Cannot find best model list for {pipeline}", 404
+    
+    model_batch_id_list = _read_file(local_fname).split("\n")
+    
+    return model_batch_id_list, None
+

--- a/droidlet/tools/hitl/dashboard_app/backend/dashboard_aws_helper.py
+++ b/droidlet/tools/hitl/dashboard_app/backend/dashboard_aws_helper.py
@@ -202,7 +202,6 @@ def get_best_model_loss_acc_by_id(batch_id: int):
         - a dict including epoch & text span loss and accuracy, and no error code if can find the best model log
         - an error message with error code 404 if cannot find the best model log
     """
-
     def get_best_model_name(batch_id: int):
         # download and read best_model.txt file
         best_model_fname = ""

--- a/droidlet/tools/hitl/dashboard_app/backend/dashboard_aws_helper.py
+++ b/droidlet/tools/hitl/dashboard_app/backend/dashboard_aws_helper.py
@@ -229,6 +229,7 @@ def get_best_model_loss_acc_by_id(batch_id: int):
 
     # read best model log file
     epoch_ls, text_span_ls = read_model_log_to_list(best_model_log_fname)
+    print(f"epoch length: {len(epoch_ls)}, text_span length: {len(text_span_ls)}")
     return {"epoch": epoch_ls, "text_span": text_span_ls}, None
 
 

--- a/droidlet/tools/hitl/dashboard_app/backend/dashboard_aws_helper.py
+++ b/droidlet/tools/hitl/dashboard_app/backend/dashboard_aws_helper.py
@@ -199,7 +199,7 @@ def get_best_model_loss_acc_by_id(batch_id: int):
     """
     Get best model loss and accuracy from model log file,
     return:
-        - a dict including epoch & text span loss and accuracy, and no error code if can find the best model log
+        - a dict including loss and accuracy for training and valiation, and no error code if can find the best model log
         - an error message with error code 404 if cannot find the best model log
     """
     def get_best_model_name(batch_id: int):
@@ -227,9 +227,9 @@ def get_best_model_loss_acc_by_id(batch_id: int):
         return f"Cannot find best model log file with batch_id = {batch_id}", 404
 
     # read best model log file
-    epoch_ls, text_span_ls = read_model_log_to_list(best_model_log_fname)
-    print(f"epoch length: {len(epoch_ls)}, text_span length: {len(text_span_ls)}")
-    return {"epoch": epoch_ls, "text_span": text_span_ls}, None
+    loss_ls, acc_ls = read_model_log_to_list(best_model_log_fname)
+    print(f"loss length: {len(loss_ls)}, accuracy length: {len(acc_ls)}")
+    return {"loss": loss_ls, "acc": acc_ls}, None
 
 
 def get_best_models_by_pipeline(pipeline: str):

--- a/droidlet/tools/hitl/dashboard_app/backend/dashboard_server.py
+++ b/droidlet/tools/hitl/dashboard_app/backend/dashboard_server.py
@@ -237,9 +237,11 @@ def get_best_model_loss_acc(batch_id: int):
     - input:
         - batch id of a specific run
     - output:
-        - a dictionary containing:
-            - epoch loss and accuracy
-            - text_span loss and accuracy
+        - a list contains the following when a best model log file can be found:
+            - a dictionary containing:
+                - epoch loss and accuracy
+                - text_span loss and accuracy
+            - batch id 
         - or an error code indicating the best model log cannot be find
     """
     print(
@@ -254,6 +256,13 @@ def get_best_model_loss_acc(batch_id: int):
 
 @socketio.on(DASHBOARD_EVENT.GET_BEST_MODELS.value)
 def get_best_model_batches(pipeline: str):
+    """
+    get best models' batch ids for a specific pipeline
+    - input:
+        - pipeline name (can be nlu, tao or vision)
+    - output:
+        - a list of the batch ids of the best models
+    """
     print(f"Request received: {DASHBOARD_EVENT.GET_BEST_MODELS.value}, pipeline = {pipeline}")
     model_dict, error_code = get_best_models_by_pipeline(pipeline)
     if error_code:

--- a/droidlet/tools/hitl/dashboard_app/backend/dashboard_server.py
+++ b/droidlet/tools/hitl/dashboard_app/backend/dashboard_server.py
@@ -251,6 +251,7 @@ def get_best_model_loss_acc(batch_id: int):
     else:
         emit(DASHBOARD_EVENT.GET_BEST_MODEL_LOSS_ACC.value, [loss_acc_dict, int(batch_id)])
 
+
 @socketio.on(DASHBOARD_EVENT.GET_BEST_MODELS.value)
 def get_best_model_batches(pipeline: str):
     print(f"Request received: {DASHBOARD_EVENT.GET_BEST_MODELS.value}, pipeline = {pipeline}")

--- a/droidlet/tools/hitl/dashboard_app/backend/dashboard_server.py
+++ b/droidlet/tools/hitl/dashboard_app/backend/dashboard_server.py
@@ -10,6 +10,7 @@ from enum import Enum
 import json
 from droidlet.tools.hitl.dashboard_app.backend.dashboard_aws_helper import (
     get_best_model_loss_acc_by_id,
+    get_best_models_by_pipeline,
     get_dataset_by_name,
     get_dataset_indices_by_id,
     get_dataset_version_list_by_pipeline,
@@ -50,6 +51,7 @@ class DASHBOARD_EVENT(Enum):
     GET_MODEL_KEYS = "get_model_keys_by_id"
     GET_MODEL_VALUE = "get_model_value_by_id_n_key"
     GET_BEST_MODEL_LOSS_ACC = "get_best_model_loss_acc_by_id"
+    GET_BEST_MODELS = "get_best_model_bids_by_pipeline"
 
 
 # constants for model related apis
@@ -247,7 +249,18 @@ def get_best_model_loss_acc(batch_id: int):
     if error_code:
         emit(DASHBOARD_EVENT.GET_BEST_MODEL_LOSS_ACC.value, error_code)
     else:
-        emit(DASHBOARD_EVENT.GET_BEST_MODEL_LOSS_ACC.value, loss_acc_dict)
+        emit(DASHBOARD_EVENT.GET_BEST_MODEL_LOSS_ACC.value, json.dumps([loss_acc_dict, int(batch_id)]))
+
+@socketio.on(DASHBOARD_EVENT.GET_BEST_MODELS.value)
+def get_best_model_batches(pipeline: str):
+    print(
+        f"Request received: {DASHBOARD_EVENT.GET_BEST_MODELS.value}, pipeline = {pipeline}"
+    )
+    model_dict, error_code = get_best_models_by_pipeline(pipeline)
+    if error_code:
+        emit(DASHBOARD_EVENT.GET_BEST_MODELS.value, error_code)
+    else:
+        emit(DASHBOARD_EVENT.GET_BEST_MODELS.value, model_dict)
 
 
 if __name__ == "__main__":

--- a/droidlet/tools/hitl/dashboard_app/backend/dashboard_server.py
+++ b/droidlet/tools/hitl/dashboard_app/backend/dashboard_server.py
@@ -249,7 +249,7 @@ def get_best_model_loss_acc(batch_id: int):
     if error_code:
         emit(DASHBOARD_EVENT.GET_BEST_MODEL_LOSS_ACC.value, error_code)
     else:
-        emit(DASHBOARD_EVENT.GET_BEST_MODEL_LOSS_ACC.value, json.dumps([loss_acc_dict, int(batch_id)]))
+        emit(DASHBOARD_EVENT.GET_BEST_MODEL_LOSS_ACC.value, [loss_acc_dict, int(batch_id)])
 
 @socketio.on(DASHBOARD_EVENT.GET_BEST_MODELS.value)
 def get_best_model_batches(pipeline: str):

--- a/droidlet/tools/hitl/dashboard_app/backend/dashboard_server.py
+++ b/droidlet/tools/hitl/dashboard_app/backend/dashboard_server.py
@@ -239,8 +239,8 @@ def get_best_model_loss_acc(batch_id: int):
     - output:
         - a list contains the following when a best model log file can be found:
             - a dictionary containing:
-                - epoch loss and accuracy
-                - text_span loss and accuracy
+                - key: loss, value: loss list for training and validation dataset
+                - key: acc, value: accuracy list for training and validation dataset
             - batch id 
         - or an error code indicating the best model log cannot be find
     """

--- a/droidlet/tools/hitl/dashboard_app/dashboard_frontend/src/component/pipeline/detail/asset/modelCard.js
+++ b/droidlet/tools/hitl/dashboard_app/dashboard_frontend/src/component/pipeline/detail/asset/modelCard.js
@@ -15,12 +15,14 @@ import { LineChart, Line, XAxis, YAxis, CartesianGrid, Legend, Tooltip as ChartT
 const { Meta } = Card;
 
 export const ModelLossAccGraph = (props) => {
+    const width = props.width;
+    const height = props.height;
     const data = props.data.map((o, idx) => ({ Loss: o.loss, Accuracy: o.acc, Epoch: idx }));
 
     return <div style={{ width: "100%", height: "100%" }}>
         <LineChart
-            width={750}
-            height={400}
+            width={width}
+            height={height}
             data={data}
             margin={{
                 top: 5,
@@ -41,6 +43,8 @@ export const ModelLossAccGraph = (props) => {
 }
 
 export const ViewLossAccCard = (props) => {
+    const width = props.width ? props.width : 750;
+    const height = props.height ? props.height : 400;
     const lossAccData = props.data;
 
     const LOSS_ACC_TYPES = [{ "label": "Epoch", "value": "epoch" }, { "label": "Text Span", "value": "text_span" }]
@@ -52,13 +56,12 @@ export const ViewLossAccCard = (props) => {
         activeTabKey={activeTabKey}
         onTabChange={(key) => setActiveTabKey(key)}
     >
-        <ModelLossAccGraph data={lossAccData[activeTabKey]} />
+        <ModelLossAccGraph data={lossAccData[activeTabKey]} height = {height} width = {width} />
     </Card>
 }
 
 const ModelCard = (props) => {
     const batchId = props.batchId;
-    const pipelineType = props.pipelineType;
     const [modelArgs, setModelArgs] = useState(null);
     const [modelKeys, setModelKeys] = useState(null);
     const [loadingArgs, setLoadingArgs] = useState(true);

--- a/droidlet/tools/hitl/dashboard_app/dashboard_frontend/src/component/pipeline/detail/asset/modelCard.js
+++ b/droidlet/tools/hitl/dashboard_app/dashboard_frontend/src/component/pipeline/detail/asset/modelCard.js
@@ -13,9 +13,8 @@ import ModelAtrributeModal from "./modelAttributeDetailModal";
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Legend, Tooltip as ChartTooltip } from 'recharts';
 
 const { Meta } = Card;
-const LOSS_ACC_TYPES = [{ "label": "Epoch", "value": "epoch" }, { "label": "Text Span", "value": "text_span" }]
 
-const ModelLossAccGraph = (props) => {
+export const ModelLossAccGraph = (props) => {
     const data = props.data.map((o, idx) => ({ Loss: o.loss, Accuracy: o.acc, Epoch: idx }));
 
     return <div style={{ width: "100%", height: "100%" }}>
@@ -41,8 +40,11 @@ const ModelLossAccGraph = (props) => {
     </div>
 }
 
-const ViewLossAccCard = (props) => {
+export const ViewLossAccCard = (props) => {
     const lossAccData = props.data;
+
+    const LOSS_ACC_TYPES = [{ "label": "Epoch", "value": "epoch" }, { "label": "Text Span", "value": "text_span" }]
+
     const [activeTabKey, setActiveTabKey] = useState(LOSS_ACC_TYPES[0]["value"]);
 
     return <Card
@@ -86,7 +88,7 @@ const ModelCard = (props) => {
     const handleReceivedLossAcc = useCallback((data) => {
         setLoadingLossAcc(false);
         if (data !== 404) {
-            setLossAccData(data);
+            setLossAccData(data[0]);
         }
     });
 
@@ -128,10 +130,6 @@ const ModelCard = (props) => {
     const handleOnClickViewModelAttibute = (modelKey) => {
         setCurrentModelKey(modelKey);
         setAttrModalOpen(true);
-    }
-
-    const handleViewModelLossAndAcc = (lossAccType) => {
-        alert(lossAccData[lossAccType].map((o) => (`loss: ${o.loss},  acc: ${o.acc}`)));
     }
 
     return (

--- a/droidlet/tools/hitl/dashboard_app/dashboard_frontend/src/component/pipeline/metaInfo/modelViz.js
+++ b/droidlet/tools/hitl/dashboard_app/dashboard_frontend/src/component/pipeline/metaInfo/modelViz.js
@@ -10,7 +10,7 @@ Usage:
 */
 
 import { SyncOutlined } from "@ant-design/icons";
-import { Progress, Typography } from "antd";
+import { Progress, Tag, Typography } from "antd";
 import React, { useContext, useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
 import { SocketContext } from "../../../context/socket";
@@ -72,11 +72,21 @@ const PipelineModelVizContent = (props) => {
 
     return <div>
         <Typography.Title level={4}>{"View Model Accuracy & Loss"}</Typography.Title>
+        {
+            modelBids && modelBids !== 404 
+            && 
+            <div
+                style={{padding: "0 0 12px 0"}}
+            >
+                Showing {modelBids.map((bid) => <Tag>{bid}</Tag>)} 
+            </div>
+        }
         <div style={{ padding: "0 24px 0 24px" }}>
             {
                 // show progress bar after getting model batch ids
                 modelBids && modelBids !== 404 && (Object.keys(modelDict).length) !== modelBids.length &&
-                <div> <span><SyncOutlined spin /> Loading Model Data... </span>
+                <div> 
+                    <span><SyncOutlined spin /> Loading Model Data... </span>
                     <Progress percent={Math.trunc((Object.keys(modelDict).length) / modelBids.length * 100)} />
                 </div>
             }

--- a/droidlet/tools/hitl/dashboard_app/dashboard_frontend/src/component/pipeline/metaInfo/modelViz.js
+++ b/droidlet/tools/hitl/dashboard_app/dashboard_frontend/src/component/pipeline/metaInfo/modelViz.js
@@ -1,0 +1,44 @@
+import React, { useContext, useEffect, useState } from "react";
+import { useLocation } from "react-router-dom";
+import { SocketContext } from "../../../context/socket";
+
+const PipelineModelVizContent = (props) => {
+    const location = useLocation();
+    const socket = useContext(SocketContext);
+    const [modelBids, setModelBids] = useState(null);
+    const [currentIdx, setCurrentIdx] = useState(0);
+    const [modelDict, setModelDict] = useState({});
+    
+    const handleReceivedModelBids = (data) => {
+        console.log(data)
+        setModelBids(data.map((bid) => parseInt(bid)));
+    }
+
+    const handleReceivedModelLossAcc = (data) => {
+        console.log(data);
+        if (modelBids && modelBids !== 404 && currentIdx >= 0 && currentIdx + 1 < modelBids.length) {
+            setCurrentIdx(currentIdx + 1);
+        }
+    }
+
+    useEffect(() => {
+        socket.on("get_best_model_bids_by_pipeline", (data) => handleReceivedModelBids(data));
+        socket.on("get_best_model_loss_acc_by_id", (data) => handleReceivedModelLossAcc(data));
+    }, [socket, handleReceivedModelBids, handleReceivedModelLossAcc]);
+
+    useEffect(() => {
+        socket.emit("get_best_model_bids_by_pipeline", location.pathname.substring(1));
+    }, []);
+
+    useEffect(() => {
+        if (modelBids && modelBids !== 404 && currentIdx >= 0) {
+            socket.emit("get_best_model_loss_acc_by_id", modelBids[currentIdx]);
+        }
+    }, [modelBids, currentIdx]);
+
+    return <div>
+        Model
+    </div>
+}
+
+export default PipelineModelVizContent;

--- a/droidlet/tools/hitl/dashboard_app/dashboard_frontend/src/component/pipeline/metaInfo/modelViz.js
+++ b/droidlet/tools/hitl/dashboard_app/dashboard_frontend/src/component/pipeline/metaInfo/modelViz.js
@@ -8,6 +8,7 @@ const PipelineModelVizContent = (props) => {
     const [modelBids, setModelBids] = useState(null);
     const [currentIdx, setCurrentIdx] = useState(0);
     const [modelDict, setModelDict] = useState({});
+    const [loadingPrecent, setPercent] = useState(0);
     
     const handleReceivedModelBids = (data) => {
         console.log(data)
@@ -15,10 +16,20 @@ const PipelineModelVizContent = (props) => {
     }
 
     const handleReceivedModelLossAcc = (data) => {
+        // data = JSON.parse(data);
         console.log(data);
-        if (modelBids && modelBids !== 404 && currentIdx >= 0 && currentIdx + 1 < modelBids.length) {
-            setCurrentIdx(currentIdx + 1);
+
+        if (data !== 404) {
+            modelDict[data[1]] = data[0];
+            console.log(modelDict)
+            setPercent(Object.keys(modelDict).length);
+            console.log(Object.keys(modelDict).length);
+
+            if (modelBids && modelBids !== 404 && currentIdx >= 0 && currentIdx + 1 < modelBids.length) {
+                setCurrentIdx(currentIdx + 1);
+            }
         }
+        
     }
 
     useEffect(() => {
@@ -38,6 +49,7 @@ const PipelineModelVizContent = (props) => {
 
     return <div>
         Model
+        {loadingPrecent}
     </div>
 }
 

--- a/droidlet/tools/hitl/dashboard_app/dashboard_frontend/src/component/pipeline/metaInfo/modelViz.js
+++ b/droidlet/tools/hitl/dashboard_app/dashboard_frontend/src/component/pipeline/metaInfo/modelViz.js
@@ -1,6 +1,9 @@
+import { SyncOutlined } from "@ant-design/icons";
+import { Progress, Typography } from "antd";
 import React, { useContext, useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
 import { SocketContext } from "../../../context/socket";
+import { ViewLossAccCard } from "../detail/asset/modelCard";
 
 const PipelineModelVizContent = (props) => {
     const location = useLocation();
@@ -8,28 +11,37 @@ const PipelineModelVizContent = (props) => {
     const [modelBids, setModelBids] = useState(null);
     const [currentIdx, setCurrentIdx] = useState(0);
     const [modelDict, setModelDict] = useState({});
-    const [loadingPrecent, setPercent] = useState(0);
-    
+    const [modelCombined, setModelCombined] = useState(null);
+
     const handleReceivedModelBids = (data) => {
-        console.log(data)
         setModelBids(data.map((bid) => parseInt(bid)));
     }
 
     const handleReceivedModelLossAcc = (data) => {
-        // data = JSON.parse(data);
-        console.log(data);
-
         if (data !== 404) {
             modelDict[data[1]] = data[0];
-            console.log(modelDict)
-            setPercent(Object.keys(modelDict).length);
-            console.log(Object.keys(modelDict).length);
 
-            if (modelBids && modelBids !== 404 && currentIdx >= 0 && currentIdx + 1 < modelBids.length) {
-                setCurrentIdx(currentIdx + 1);
+            if (modelBids && modelBids !== 404 && Object.keys(modelDict).length < modelBids.length) {
+                setCurrentIdx(Object.keys(modelDict).length);
+            } else if (modelBids && modelBids !== 404 && Object.keys(modelDict).length === modelBids.length) {
+                // finished loading, combine based on bid sequence
+                const modelArr = modelBids.map((bid) => (modelDict[bid]));
+                let comb = {}
+
+                for (let i = 0; i < modelArr.length; i++) {
+                    const o = modelArr[i];
+                    for (let j = 0; j < Object.keys(o).length; j++) {
+                        const key = Object.keys(o)[j];
+                        if (!(key in comb)) {
+                            comb[key] = o[key];
+                        } else {
+                            comb[key] = [...comb[key], ...o[key]]
+                        }
+                    }
+                }
+                setModelCombined(comb);
             }
         }
-        
     }
 
     useEffect(() => {
@@ -48,8 +60,22 @@ const PipelineModelVizContent = (props) => {
     }, [modelBids, currentIdx]);
 
     return <div>
-        Model
-        {loadingPrecent}
+        <Typography.Title level={4}>{"View Model Accuracy & Loss"}</Typography.Title>
+        {
+            // show loading model progress
+            modelBids && modelBids !== 404 && (currentIdx + 1) !== modelBids.length &&
+            <div style={{ padding: "0 24px 0 24px" }}>
+                <span><SyncOutlined spin /> Loading Model Data... </span>
+                <Progress percent={Math.trunc((currentIdx + 1) / modelBids.length * 100)} />
+            </div>
+        }
+        {
+            // show graph when loading is done
+            modelBids && modelBids !== 404 && (currentIdx + 1) === modelBids.length && modelCombined &&
+            <div style={{ width: '1200px', height: '500px' }}>
+                <ViewLossAccCard data={modelCombined} />
+            </div>
+        }
     </div>
 }
 

--- a/droidlet/tools/hitl/dashboard_app/dashboard_frontend/src/component/pipeline/metaInfo/modelViz.js
+++ b/droidlet/tools/hitl/dashboard_app/dashboard_frontend/src/component/pipeline/metaInfo/modelViz.js
@@ -1,3 +1,14 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+The content for model visualization for a pipeline.
+
+The **pipeline** can be nlu/tao or vision; the pipeline information was reterived from path parameter so no props are required.
+
+Usage:
+<PipelineModelVizContent />
+*/
+
 import { SyncOutlined } from "@ant-design/icons";
 import { Progress, Typography } from "antd";
 import React, { useContext, useEffect, useState } from "react";
@@ -10,7 +21,7 @@ const PipelineModelVizContent = (props) => {
     const socket = useContext(SocketContext);
     const [modelBids, setModelBids] = useState(null);
     const [currentIdx, setCurrentIdx] = useState(0);
-    const [modelDict, setModelDict] = useState({});
+    const [modelDict, ] = useState({});
     const [modelCombined, setModelCombined] = useState(null);
 
     const handleReceivedModelBids = (data) => {
@@ -61,21 +72,31 @@ const PipelineModelVizContent = (props) => {
 
     return <div>
         <Typography.Title level={4}>{"View Model Accuracy & Loss"}</Typography.Title>
-        {
-            // show loading model progress
-            modelBids && modelBids !== 404 && (currentIdx + 1) !== modelBids.length &&
-            <div style={{ padding: "0 24px 0 24px" }}>
-                <span><SyncOutlined spin /> Loading Model Data... </span>
-                <Progress percent={Math.trunc((currentIdx + 1) / modelBids.length * 100)} />
-            </div>
-        }
-        {
-            // show graph when loading is done
-            modelBids && modelBids !== 404 && (currentIdx + 1) === modelBids.length && modelCombined &&
-            <div style={{ width: '1200px', height: '500px' }}>
-                <ViewLossAccCard data={modelCombined} />
-            </div>
-        }
+        <div style={{ padding: "0 24px 0 24px" }}>
+            {
+                // show progress bar after getting model batch ids
+                modelBids && modelBids !== 404 && (Object.keys(modelDict).length) !== modelBids.length &&
+                <div> <span><SyncOutlined spin /> Loading Model Data... </span>
+                    <Progress percent={Math.trunc((Object.keys(modelDict).length) / modelBids.length * 100)} />
+                </div>
+            }
+
+            {
+                // show graph when loading is done
+                modelBids && modelBids !== 404 && (Object.keys(modelDict).length) === modelBids.length && modelCombined &&
+                <div>
+                    <ViewLossAccCard data={modelCombined} width={1500}/>
+                </div>
+            } 
+            {
+                // show no data when not having any batch ids
+                modelBids && modelBids === 404 && 
+                <div>
+                    Sorry, no model data is avaible yet. 
+                </div>
+            }
+        </div>
+
     </div>
 }
 

--- a/droidlet/tools/hitl/dashboard_app/dashboard_frontend/src/component/pipeline/panel.js
+++ b/droidlet/tools/hitl/dashboard_app/dashboard_frontend/src/component/pipeline/panel.js
@@ -13,6 +13,7 @@ import React, { useEffect, useState } from 'react';
 import { Link, Outlet, useLocation, useParams } from 'react-router-dom';
 import { TAB_ITEMS } from '../../constants/pipelineConstants';
 import InfoBlock from './metaInfo/infoBlock';
+import PipelineModelVizContent from './metaInfo/modelViz';
 import RunList from './metaInfo/runList';
 
 const menuItems = Object.values(TAB_ITEMS);
@@ -107,6 +108,9 @@ const PipelinePanel = (props) => {
                                                 // render job list if key is jobs, otherwise render info block
                                                 item.key === TAB_ITEMS.RUNS.key ?
                                                     <RunList pipelineType={pipelineType} /> :
+                                                    item.key === TAB_ITEMS.MODEL.key ? 
+                                                    <PipelineModelVizContent />
+                                                    : 
                                                     <InfoBlock infoType={item.key} pipelineType={pipelineType} />
                                             }
                                         </TabPane>

--- a/droidlet/tools/hitl/dashboard_app/dashboard_frontend/src/constants/pipelineConstants.js
+++ b/droidlet/tools/hitl/dashboard_app/dashboard_frontend/src/constants/pipelineConstants.js
@@ -23,5 +23,10 @@ export const TAB_ITEMS = {
     {
         label: 'View Runs',
         key: 'runs'
+    },
+    MODEL: 
+    {
+        label: 'View Model',
+        key: 'model'
     }
 }

--- a/droidlet/tools/hitl/utils/read_model_log.py
+++ b/droidlet/tools/hitl/utils/read_model_log.py
@@ -9,35 +9,39 @@ import math
 def read_model_log_to_list(fname: str):
     """
     Read model log and export to a dictionary including:
-        - Epoch loss and accuracy
-        - Text span loss and accuracy
+        - Loss changes over epoch increases of training / validation
+        - Accuracy changes over epoch increases of training / validation
     """
-    f = open(fname)
-    content = f.read()
-    f.close()
-
-    lines = content.split("\n")
-
     def get_loss_acc(line: str):
         words = line.split(" ")
         loss, acc = None, None
         for i in range(0, len(words)):
-            if i > 0 and words[i - 1] == "Loss:":
+            if i > 0 and (words[i - 1] == "Loss:" or words[i - 1] == "L:"):
                 loss = float(words[i])
                 loss = None if math.isnan(loss) else loss
-            elif i > 0 and words[i - 1] == "Accuracy:":
+            elif i > 0 and (words[i - 1] == "Accuracy:" or words[i - 1] == "A:"):
                 acc = float(words[i])
                 acc = None if acc is math.isnan(acc) else acc
         return loss, acc
 
-    epoch_loss_acc_list = []
-    text_span_loss_acc_list = []
-    for line in lines:
-        if "epoch" in line:
-            loss, acc = get_loss_acc(line)
-            epoch_loss_acc_list.append({"loss": loss, "acc": acc})
-        elif " text span Loss: " in line:
-            loss, acc = get_loss_acc(line)
-            text_span_loss_acc_list.append({"loss": loss, "acc": acc})
+    loss_list = []  
+    acc_list = []
+    t_key, v_key = "training", "validation"
 
-    return epoch_loss_acc_list, text_span_loss_acc_list
+    f = open(fname)
+    for line in f:
+        if "Epoch: " in line:
+            loss_list.append({})
+            acc_list.append({})
+        elif "L: " in line:
+            # training
+            loss, acc = get_loss_acc(line)
+            loss_list[-1][t_key] = loss
+            acc_list[-1][t_key] = acc
+        elif "valid: " in line:
+            # validation
+            loss, acc = get_loss_acc(line)
+            loss_list[-1][v_key] = loss
+            acc_list[-1][v_key] = acc
+    f.close()
+    return loss_list, acc_list

--- a/droidlet/tools/hitl/utils/read_model_log.py
+++ b/droidlet/tools/hitl/utils/read_model_log.py
@@ -5,6 +5,7 @@ Utils for processing model log.
 """
 import math
 
+
 def read_model_log_to_list(fname: str):
     """
     Read model log and export to a dictionary including:
@@ -25,7 +26,7 @@ def read_model_log_to_list(fname: str):
                 loss = float(words[i])
                 loss = None if math.isnan(loss) else loss
             elif i > 0 and words[i - 1] == "Accuracy:":
-                acc = float(words[i]) 
+                acc = float(words[i])
                 acc = None if acc is math.isnan(acc) else acc
         return loss, acc
 

--- a/droidlet/tools/hitl/utils/read_model_log.py
+++ b/droidlet/tools/hitl/utils/read_model_log.py
@@ -3,7 +3,7 @@ Copyright (c) Facebook, Inc. and its affiliates.
 
 Utils for processing model log.
 """
-
+import math
 
 def read_model_log_to_list(fname: str):
     """
@@ -23,8 +23,10 @@ def read_model_log_to_list(fname: str):
         for i in range(0, len(words)):
             if i > 0 and words[i - 1] == "Loss:":
                 loss = float(words[i])
+                loss = None if math.isnan(loss) else loss
             elif i > 0 and words[i - 1] == "Accuracy:":
-                acc = float(words[i])
+                acc = float(words[i]) 
+                acc = None if acc is math.isnan(acc) else acc
         return loss, acc
 
     epoch_loss_acc_list = []


### PR DESCRIPTION
# Description
- Update frontend/backend support for visualizing the model:
        - Based on @ethan-carlson 's suggestion, changed from showing loss and accuracy of validation and text_span to showing loss and accuracy separately; and show training loss/accuracy & validation loss/accuracy in the same graph. 
        - Updated the graph visualization container to be responsive to browser window changes. 
- Added new API to get batch ids for runs that has the models need to be visualized in a pipeline. 

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

### API changes:
- get_best_model_loss_acc_by_id 
  - Before: this API returns model loss and accuracy for validation and the text_span. 
  - After: returns loss and accuracy for validation and training.
### Added new API:
- get_best_model_bids_by_pipeline
    - get best models' batch ids for a specific pipeline
    - input:
        - pipeline name (can be nlu, tao or vision)
    - output:
        - a list of the batch ids of the best models
### Demo:
- Demo:
            - Best models loss & accuracy for a pipeline:
                - ![demo_best_models_for_pipeline](https://user-images.githubusercontent.com/51009396/182976894-a1eb380b-06fd-491b-8e4f-29abd7c2024d.gif)
            - Best model in a run (showing loss and accuracy seperately, graph responsive to browser window changes):
                - ![demo_best_model_for_a_run](https://user-images.githubusercontent.com/51009396/182976905-60713821-31d8-4187-889a-11b3b1d1ce82.gif)

# Testing

Manually tested.

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [x] I have added Docstrings and comments to the code.
- [x] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
