### PR TITLE
Fix craftassist nsp bugs

### DIFF
--- a/droidlet/documents/json_schema/filters.schema.json
+++ b/droidlet/documents/json_schema/filters.schema.json
@@ -20,30 +20,7 @@
         "attribute": {
             "oneOf": [
                 {
-                    "enum": [
-                        "HEIGHT",
-                        "WIDTH",
-                        "X",
-                        "Y",
-                        "Z",
-                        "REF_TYPE",
-                        "HEAD_PITCH",
-                        "HEAD_YAW",
-                        "NAME",
-                        "BORN_TIME",
-                        "MODIFY_TIME",
-                        "SPEAKER",
-                        "VISIT_TIME",
-                        "FINISHED_TIME",
-                        "CHAT",
-                        "LOGICAL_FORM",
-                        "SIZE",
-                        "COLOUR",
-                        "LOCATION",
-                        "TAG",
-                        "BLOCK_TYPE",
-                        "CURRENT_TIME"
-                    ]
+                    "type": "string"	
                 },
                 {
                     "type": "object",

--- a/droidlet/perception/semantic_parsing/nsp_querier.py
+++ b/droidlet/perception/semantic_parsing/nsp_querier.py
@@ -15,6 +15,89 @@ from .utils.nsp_logger import NSPLogger
 from .utils.validate_json import JSONValidator
 from droidlet.base_util import hash_user
 
+# FIXME: move all this to json validator and model data
+cats = [
+    "HUMAN_GIVE_COMMAND",
+    "GET_MEMORY",
+    "SAY",
+    "BUILD",
+    "DESTROY",
+    "MOVE",
+    "UNDO",
+    "STOP",
+    "DIG",
+    "DANCE",
+    "GET",
+    "SPAWN",
+    "RESUME",
+    "FILL",
+    "SCOUT",
+    "AGENT",
+    "AGENT_POS",
+    "SPEAKER_POS",
+    "SPEAKER_LOOK",
+    "SPEAKER",
+    "LEFT",
+    "RIGHT",
+    "UP",
+    "DOWN",
+    "FRONT",
+    "BACK",
+    "AWAY",
+    "INSIDE",
+    "NEAR",
+    "OUTSIDE",
+    "AROUND",
+    "BETWEEN",
+    "ANTICLOCKWISE",
+    "CLOCKWISE",
+    "FIRST",
+    "RANDOM",
+    "ALL",
+    "THIS",
+    "ALLOWED",
+    "DISALLOWED",
+    "REQUIRED",
+    "MAX",
+    "MIN",
+    "GREATER_THAN",
+    "LESS_THAN",
+    "GREATER_THAN_EQUAL",
+    "LESS_THAN_EQUAL",
+    "NOT_EQUAL",
+    "EQUAL",
+    "ANY",
+    "SELF",
+    "CURRENTLY_RUNNING",
+    "FINISHED",
+    "AND",
+    "OR",
+    "NOT",
+]
+
+CATS_LOWER = [l.lower() for l in cats]
+
+
+def capitalize_categoricals(d):
+    """ 
+    if semantic parser outputs lowercase categoricals, fix here....
+    """
+    if type(d) is not dict:
+        return
+    keys_to_fix = []
+    for k, v in d.items():
+        if type(k) is str and k in ["and", "or", "not"]:
+            keys_to_fix.append(k)
+        if type(v) is str and v in CATS_LOWER:
+            d[k] = v.upper()
+        elif type(v) is dict:
+            capitalize_categoricals(v)
+        elif type(v) is list:
+            for l in v:
+                capitalize_categoricals(l)
+    for k in keys_to_fix:
+        d[k.upper()] = d.pop(k)
+
 
 class MockNSPQuerier(object):
     def __init__(self, opts):
@@ -176,6 +259,8 @@ class NSPQuerier(object):
             pkg_resources.resource_filename("droidlet.documents", "json_schema")
         )
         json_validator = JSONValidator(schema_dir, span_type="all")
+        # FIXME: model should get these...
+        capitalize_categoricals(parse_tree)
         is_valid_json = json_validator.validate_instance(parse_tree, debug)
         return is_valid_json
 
@@ -226,6 +311,7 @@ class NSPQuerier(object):
             [chat, logical_form, logical_form_source, "craftassist", time_now]
         )
         # check if logical_form conforms to the grammar
+
         is_valid_json = self.validate_parse_tree(logical_form)
         if not is_valid_json:
             # Send a NOOP

--- a/droidlet/perception/semantic_parsing/nsp_querier.py
+++ b/droidlet/perception/semantic_parsing/nsp_querier.py
@@ -79,7 +79,7 @@ CATS_LOWER = [l.lower() for l in cats]
 
 
 def capitalize_categoricals(d):
-    """ 
+    """
     if semantic parser outputs lowercase categoricals, fix here....
     """
     if type(d) is not dict:


### PR DESCRIPTION
# Description

adds a short term fix for new nsp model lowercasing some keys and values in parse; and eliminates the requirement that attributes are uppercased (or in a special allowset) in json formatter

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.