### PR TITLE
Mirror State Services

### DIFF
--- a/polymetis/polymetis/include/polymetis/polymetis_server.hpp
+++ b/polymetis/polymetis/include/polymetis/polymetis_server.hpp
@@ -124,11 +124,11 @@ public:
   /**
   TODO
   */
-  Status SetMirrorRobotState(ServerContext *context,
-                             const RobotState *robot_state, Empty *) override;
+  Status SetSimRobotState(ServerContext *context, const RobotState *robot_state,
+                          Empty *) override;
 
-  Status GetMirrorRobotState(ServerContext *context, const Empty *,
-                             RobotState *robot_state) override;
+  Status GetSimRobotState(ServerContext *context, const Empty *,
+                          RobotState *robot_state) override;
 
   /**
   TODO
@@ -180,10 +180,10 @@ private:
   CircularBuffer<RobotState> robot_state_buffer_ =
       CircularBuffer<RobotState>(MAX_CIRCULAR_BUFFER_SIZE);
 
-  RobotState mirror_sim_robot_state_;
-  long int mirror_state_last_update_ = 0;
-  bool is_mirror_state_set_ = false;
-  std::mutex mirror_state_mtx_;
+  RobotState sim_robot_state_;
+  long int sim_state_last_update_ = 0;
+  bool is_sim_state_set_ = false;
+  std::mutex sim_state_mtx_;
 
   CustomControllerContext custom_controller_context_;
   RobotClientContext robot_client_context_;

--- a/polymetis/polymetis/include/polymetis/polymetis_server.hpp
+++ b/polymetis/polymetis/include/polymetis/polymetis_server.hpp
@@ -124,6 +124,15 @@ public:
   /**
   TODO
   */
+  Status SetMirrorRobotState(ServerContext *context,
+                             const RobotState *robot_state, Empty *) override;
+
+  Status GetMirrorRobotState(ServerContext *context, const Empty *,
+                             RobotState *robot_state) override;
+
+  /**
+  TODO
+  */
   Status GetRobotStateStream(ServerContext *context, const Empty *,
                              ServerWriter<RobotState> *writer) override;
 
@@ -170,6 +179,11 @@ private:
 
   CircularBuffer<RobotState> robot_state_buffer_ =
       CircularBuffer<RobotState>(MAX_CIRCULAR_BUFFER_SIZE);
+
+  RobotState mirror_sim_robot_state_;
+  long int mirror_state_last_update_ = 0;
+  bool is_mirror_state_set_ = false;
+  std::mutex mirror_state_mtx_;
 
   CustomControllerContext custom_controller_context_;
   RobotClientContext robot_client_context_;

--- a/polymetis/polymetis/protos/polymetis.proto
+++ b/polymetis/polymetis/protos/polymetis.proto
@@ -27,11 +27,12 @@ service PolymetisControllerServer {
   // start & end of controller execution
   rpc TerminateController(Empty) returns(LogInterval) {}
 
-  // Set the mirror robot state (only for simulator clients)
-  rpc SetMirrorRobotState(RobotState) returns(Empty) {}
+  // Set the robot state in simulator clients
+  rpc SetSimRobotState(RobotState) returns(Empty) {}
 
-  // Get the mirror robot state (only for simulator clients)
-  rpc GetMirrorRobotState(Empty) returns(RobotState) {}
+  // Get the mirror robot state in simulator clients
+  // Blocks until a sim state has been set
+  rpc GetSimRobotState(Empty) returns(RobotState) {}
 
   // Get the current robot state
   rpc GetRobotState(Empty) returns(RobotState) {}

--- a/polymetis/polymetis/protos/polymetis.proto
+++ b/polymetis/polymetis/protos/polymetis.proto
@@ -27,6 +27,12 @@ service PolymetisControllerServer {
   // start & end of controller execution
   rpc TerminateController(Empty) returns(LogInterval) {}
 
+  // Set the mirror robot state (only for simulator clients)
+  rpc SetMirrorRobotState(RobotState) returns(Empty) {}
+
+  // Get the mirror robot state (only for simulator clients)
+  rpc GetMirrorRobotState(Empty) returns(RobotState) {}
+
   // Get the current robot state
   rpc GetRobotState(Empty) returns(RobotState) {}
 
@@ -111,6 +117,7 @@ message RobotClientMetadata {
   string polymetis_version = 10;
   repeated float default_Kx = 11;
   repeated float default_Kxd = 12;
+  optional bool is_sim = 13;
 }
 
 message RobotState {

--- a/polymetis/polymetis/protos/polymetis.proto
+++ b/polymetis/polymetis/protos/polymetis.proto
@@ -31,7 +31,6 @@ service PolymetisControllerServer {
   rpc SetSimRobotState(RobotState) returns(Empty) {}
 
   // Get the mirror robot state in simulator clients
-  // Blocks until a sim state has been set
   rpc GetSimRobotState(Empty) returns(RobotState) {}
 
   // Get the current robot state

--- a/polymetis/polymetis/src/polymetis_server.cpp
+++ b/polymetis/polymetis/src/polymetis_server.cpp
@@ -88,18 +88,12 @@ Status PolymetisControllerServerImpl::GetSimRobotState(
     return Status(StatusCode::FAILED_PRECONDITION,
                   "GetSimRobotState may only be used with a simulator client!");
   }
-  while (true) {
-    if (context->IsCancelled()) {
-      return Status::CANCELLED;
-    }
-    if (is_sim_state_set_) {
-      break;
-    }
-    usleep(SPIN_INTERVAL_USEC);
+  if (!is_sim_state_set_) {
+    return Status(StatusCode::FAILED_PRECONDITION,
+                  "Simulator robot state has not been set!");
   }
   std::lock_guard<std::mutex> guard(sim_state_mtx_);
   robot_state->CopyFrom(sim_robot_state_);
-  is_sim_state_set_ = false;
   return Status::OK;
 }
 

--- a/polymetis/polymetis/tests/cpp/test_server.cpp
+++ b/polymetis/polymetis/tests/cpp/test_server.cpp
@@ -196,7 +196,7 @@ TEST_F(ServiceTest, TestInvalidRequests) {
                   .ok());
 }
 
-TEST_F(ServiceTest, TestMirrorRobotState) {
+TEST_F(ServiceTest, TestSimRobotState) {
   RobotClientMetadata sim_metadata_;
   sim_metadata_.CopyFrom(metadata_);
   sim_metadata_.set_is_sim(true);
@@ -206,45 +206,27 @@ TEST_F(ServiceTest, TestMirrorRobotState) {
 
   // write and read
   ASSERT_TRUE(stub_.get()
-                  ->SetMirrorRobotState(new grpc::ClientContext,
-                                        dummy_robot_state_, new Empty)
+                  ->SetSimRobotState(new grpc::ClientContext,
+                                     dummy_robot_state_, new Empty)
                   .ok());
   ASSERT_TRUE(stub_.get()
-                  ->GetMirrorRobotState(new grpc::ClientContext, empty_,
-                                        &acquired_robot_state)
+                  ->GetSimRobotState(new grpc::ClientContext, empty_,
+                                     &acquired_robot_state)
                   .ok());
   EXPECT_EQ(acquired_robot_state.timestamp().nanos(),
             dummy_robot_state_.timestamp().nanos());
 
-  // try to overwrite with stale data
-  RobotState fresh_robot_state;
-  setTimestampToNow(fresh_robot_state.mutable_timestamp());
-  ASSERT_TRUE(stub_.get()
-                  ->SetMirrorRobotState(new grpc::ClientContext,
-                                        fresh_robot_state, new Empty)
-                  .ok());
-  ASSERT_TRUE(stub_.get()
-                  ->SetMirrorRobotState(new grpc::ClientContext,
-                                        dummy_robot_state_, new Empty)
-                  .ok());
-  ASSERT_TRUE(stub_.get()
-                  ->GetMirrorRobotState(new grpc::ClientContext, empty_,
-                                        &acquired_robot_state)
-                  .ok());
-  EXPECT_EQ(acquired_robot_state.timestamp().nanos(),
-            fresh_robot_state.timestamp().nanos());
-
   // read before write
   std::thread reader([&]() {
     ASSERT_TRUE(stub_.get()
-                    ->GetMirrorRobotState(new grpc::ClientContext, empty_,
-                                          &acquired_robot_state)
+                    ->GetSimRobotState(new grpc::ClientContext, empty_,
+                                       &acquired_robot_state)
                     .ok());
   });
   std::this_thread::sleep_for(std::chrono::milliseconds(200));
   ASSERT_TRUE(stub_.get()
-                  ->SetMirrorRobotState(new grpc::ClientContext,
-                                        dummy_robot_state_, new Empty)
+                  ->SetSimRobotState(new grpc::ClientContext,
+                                     dummy_robot_state_, new Empty)
                   .ok());
   reader.join();
   EXPECT_EQ(acquired_robot_state.timestamp().nanos(),
@@ -253,12 +235,12 @@ TEST_F(ServiceTest, TestMirrorRobotState) {
   // read, write for hw fails
   stub_.get()->InitRobotClient(new grpc::ClientContext, metadata_, new Empty);
   ASSERT_FALSE(stub_.get()
-                   ->SetMirrorRobotState(new grpc::ClientContext,
-                                         dummy_robot_state_, new Empty)
+                   ->SetSimRobotState(new grpc::ClientContext,
+                                      dummy_robot_state_, new Empty)
                    .ok());
   ASSERT_FALSE(stub_.get()
-                   ->GetMirrorRobotState(new grpc::ClientContext, empty_,
-                                         &acquired_robot_state)
+                   ->GetSimRobotState(new grpc::ClientContext, empty_,
+                                      &acquired_robot_state)
                    .ok());
 }
 


### PR DESCRIPTION
# Description

Created get/set mirror robot state services. The user client will source robot states from the HW CM and forward them to the local CM using the mirror state setter. The local mirror simulator will pull the mirror states and then update the simulation environment appropriately. While indirect, creating a CM intermediary will facilitate forward simulation (https://www.internalfb.com/tasks/?t=123146501)

Fixes # (issue)

https://www.internalfb.com/tasks/?t=122948322

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

If this PR introduces a change or fixes a bug, please add before and after screenshots (if this is causes a UX change) or before and after examples(this could be plain text, videos etc ) to demonstrate the change.

If this PR introduces a new feature, please also add examples or screenshots demonstrating the feature.

# Testing

TestMirrorRobotState was added to the test_server.cpp file. The cpp tests can be run (after building) with `python ./polymetis/polymetis/tests/cpp/test_server.py`

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
