### PR TITLE
mrp optional process list in import

### DIFF
--- a/mrp/setup.py
+++ b/mrp/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="mrp",
-    version="1.0.2",
+    version="1.0.4",
     author="Leonid Shamis",
     package_dir={"": "src"},
     packages=find_packages(

--- a/mrp/src/mrp/__init__.py
+++ b/mrp/src/mrp/__init__.py
@@ -1,10 +1,12 @@
-from mrp.process_def import process
+import mrp
+from mrp.process_def import defined_processes, process
 from mrp.runtime.conda import Conda
 from mrp.runtime.docker import Docker
 from mrp.runtime.host import Host
 from mrp.util import NoEscape
 from importlib.machinery import SourceFileLoader
 import click
+import contextlib
 import inspect
 import os
 import sys
@@ -24,16 +26,35 @@ def main(*args):
     sys.exit(0)
 
 
-def import_msetup(path):
-    # TODO(lshamis): Maybe add args to filter imported processes.
+def import_msetup(path, processes=None):
+    # Get path relative to caller.
     caller_path = inspect.stack()[1].filename
     caller_dir = os.path.dirname(caller_path)
     target_path = os.path.join(caller_dir, path)
 
+    # Add default filename if provided path is a directory.
     if os.path.isdir(target_path):
         target_path = os.path.join(target_path, "msetup.py")
 
+    # We hook mrp.process to filter processes within the import.
+
+    # Save the real function for use within the hook
+    # and to restore post-import.
+    process_impl = mrp.process
+
+    # Replacement implementation.
+    def hook(name, *args, **kwargs):
+        if processes is None or name in processes:
+            return process_impl(name, *args, **kwargs)
+
+    # Attach the hook.
+    mrp.process = hook
+
+    # Import.
     SourceFileLoader("msetup", target_path).load_module()
+
+    # Undo the hook.
+    mrp.process = process_impl
 
 
 class cmd:
@@ -62,4 +83,17 @@ for cmd_file in os.listdir(cmds_path):
         setattr(cmd, cmd_name, module.cli.callback)
         cli.add_command(module.cli, cmd_name)
 
-__all__ = ["main", "process", "NoEscape", "Docker", "Conda", "Host", "cmd"]
+__all__ = [
+    # CLI entrypoint.
+    "main",
+    # Process definition.
+    "process",
+    "defined_processes",
+    "NoEscape",
+    # Runtimes.
+    "Docker",
+    "Conda",
+    "Host",
+    # Command interface.
+    "cmd",
+]

--- a/mrp/src/mrp/__init__.py
+++ b/mrp/src/mrp/__init__.py
@@ -6,7 +6,6 @@ from mrp.runtime.host import Host
 from mrp.util import NoEscape
 from importlib.machinery import SourceFileLoader
 import click
-import contextlib
 import inspect
 import os
 import sys

--- a/mrp/tests/conftest.py
+++ b/mrp/tests/conftest.py
@@ -1,0 +1,5 @@
+import mrp
+
+
+def pytest_runtest_setup(item):
+    mrp.defined_processes.clear()

--- a/mrp/tests/test_data/msetup.py
+++ b/mrp/tests/test_data/msetup.py
@@ -1,0 +1,18 @@
+import mrp
+
+mrp.process(
+    name="proc1",
+    runtime=mrp.Host(
+        run_command=["echo", "data", ">", "./file1.txt"],
+    ),
+)
+
+mrp.process(
+    name="proc2",
+    runtime=mrp.Host(
+        run_command=["echo", "data", ">", "./file2.txt"],
+    ),
+)
+
+if __name__ == "__main__":
+    mrp.main()

--- a/mrp/tests/test_data/msetup.py
+++ b/mrp/tests/test_data/msetup.py
@@ -3,14 +3,14 @@ import mrp
 mrp.process(
     name="proc1",
     runtime=mrp.Host(
-        run_command=["echo", "data", ">", "./file1.txt"],
+        run_command=[],
     ),
 )
 
 mrp.process(
     name="proc2",
     runtime=mrp.Host(
-        run_command=["echo", "data", ">", "./file2.txt"],
+        run_command=[],
     ),
 )
 

--- a/mrp/tests/test_import.py
+++ b/mrp/tests/test_import.py
@@ -1,5 +1,6 @@
 import mrp
 
+
 def test_import():
     assert mrp.defined_processes == {}
 

--- a/mrp/tests/test_import.py
+++ b/mrp/tests/test_import.py
@@ -1,0 +1,23 @@
+import mrp
+
+def test_import():
+    assert mrp.defined_processes == {}
+
+    mrp.import_msetup("./test_data/")
+    assert list(mrp.defined_processes.keys()) == ["proc1", "proc2"]
+
+    mrp.defined_processes.clear()
+    mrp.import_msetup("./test_data/msetup.py")
+    assert list(mrp.defined_processes.keys()) == ["proc1", "proc2"]
+
+    mrp.defined_processes.clear()
+    mrp.import_msetup("./test_data/", processes=["proc1"])
+    assert list(mrp.defined_processes.keys()) == ["proc1"]
+
+    mrp.defined_processes.clear()
+    mrp.import_msetup("./test_data/", processes=["proc2"])
+    assert list(mrp.defined_processes.keys()) == ["proc2"]
+
+    mrp.defined_processes.clear()
+    mrp.import_msetup("./test_data/", processes=["proc1", "proc2"])
+    assert list(mrp.defined_processes.keys()) == ["proc1", "proc2"]


### PR DESCRIPTION
# Description

Adds an optional parameter to `import_msetup`, allowing users to enumerate a subset of the processes.
```
mrp.import_msetup(path, processes=["proc1", "proc2"])
```

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

If this PR introduces a change or fixes a bug, please add before and after screenshots (if this is causes a UX change) or before and after examples(this could be plain text, videos etc ) to demonstrate the change.

If this PR introduces a new feature, please also add examples or screenshots demonstrating the feature.

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
