### PR TITLE
Mirror sim user flow

### DIFF
--- a/polymetis/polymetis/python/polymetis/robot_interface.py
+++ b/polymetis/polymetis/python/polymetis/robot_interface.py
@@ -744,3 +744,9 @@ class RobotInterface(BaseRobotInterface):
             "The method 'move_ee_xyz' is deprecated, use 'move_to_ee_pose' with 'delta=True' instead."
         )
         return self.move_to_ee_pose(position=displacement, delta=True, **kwargs)
+
+    def set_sim_state(self, robot_state: RobotState):
+        self.grpc_connection.SetSimRobotState(robot_state)
+
+    def sync(self, tgt_robot, timestep):
+        pass

--- a/polymetis/polymetis/python/polymetis/robot_interface.py
+++ b/polymetis/polymetis/python/polymetis/robot_interface.py
@@ -744,9 +744,3 @@ class RobotInterface(BaseRobotInterface):
             "The method 'move_ee_xyz' is deprecated, use 'move_to_ee_pose' with 'delta=True' instead."
         )
         return self.move_to_ee_pose(position=displacement, delta=True, **kwargs)
-
-    def set_sim_state(self, robot_state: RobotState):
-        self.grpc_connection.SetSimRobotState(robot_state)
-
-    def sync(self, tgt_robot, timestep):
-        pass

--- a/polymetis/polymetis/src/polymetis_server.cpp
+++ b/polymetis/polymetis/src/polymetis_server.cpp
@@ -14,6 +14,12 @@ PolymetisControllerServerImpl::PolymetisControllerServerImpl() {
 Status PolymetisControllerServerImpl::GetRobotState(ServerContext *context,
                                                     const Empty *,
                                                     RobotState *robot_state) {
+  std::cout << "Get called, buffer size " << robot_state_buffer_.size()
+            << std::endl;
+  if (robot_state_buffer_.size() == 0) {
+    return Status(StatusCode::FAILED_PRECONDITION,
+                  "Cannot retrieve robot state from empty buffer!");
+  }
   *robot_state = *robot_state_buffer_.get(robot_state_buffer_.size() - 1);
   return Status::OK;
 }

--- a/polymetis/scripts/mirror_sim.py
+++ b/polymetis/scripts/mirror_sim.py
@@ -6,29 +6,113 @@ from polymetis import RobotInterface
 import numpy as np
 import hydra
 from polymetis.utils.data_dir import PKG_ROOT_DIR, which
+from polymetis.utils.grpc_utils import check_server_exists
+
+hw_ip = "localhost"
+hw_port = 50052
+sim_ip = "localhost"
+sim_port = 50051
+
+
+class MyPolicy(toco.PolicyModule):
+    """
+    Custom policy that executes a sine trajectory on joint 6
+    (magnitude = 0.5 radian, frequency = 1 second)
+    """
+
+    def __init__(self, time_horizon, hz, magnitude, period, kq, kqd, coef, **kwargs):
+        """
+        Args:
+            time_horizon (int):         Number of steps policy should execute
+            hz (double):                Frequency of controller
+            kq, kqd (torch.Tensor):     PD gains (1d array)
+        """
+        super().__init__(**kwargs)
+
+        self.hz = hz
+        self.time_horizon = time_horizon
+        self.m = magnitude
+        self.T = period
+
+        # Initialize modules
+        self.feedback = toco.modules.JointSpacePD(kq, kqd)
+
+        # Initialize variables
+        self.steps = 0
+        self.q_initial = torch.zeros_like(kq)
+        self.coef = coef
+
+    def forward(self, state_dict: Dict[str, torch.Tensor]):
+        # Parse states
+        q_current = state_dict["joint_positions"]
+        qd_current = state_dict["joint_velocities"]
+
+        # Initialize
+        if self.steps == 0:
+            self.q_initial = q_current.clone()
+
+        # Compute reference position and velocity
+        q_desired = self.q_initial.clone()
+        q_desired += np.ones_like(q_desired) * self.coef
+        qd_desired = torch.zeros_like(qd_current)
+
+        # Execute PD control
+        output = self.feedback(
+            q_current, qd_current, q_desired, torch.zeros_like(qd_current)
+        )
+
+        # Check termination
+        if self.steps > self.time_horizon:
+            self.set_terminated()
+        self.steps += 1
+
+        return {"joint_torques": output}
 
 
 @hydra.main(config_name="launch_robot")
 def main(cfg):
-    # Initialize robot interface
-    robot = RobotInterface(
-        ip_address="localhost",
-    )
+    # launch remote CM server + robot client
+    # launch local CM server
+    assert check_server_exists(
+        ip=hw_ip, port=hw_port
+    ), f"HW CM server must be started at {hw_ip}:{hw_port}"
+    assert check_server_exists(
+        ip="localhost", port=50051
+    ), f"Sim CM server must be started at {sim_ip}:{sim_port}"
+
+    # launch sim client, TODO: move mirror sim into robot interface
     mirror_sim_client = hydra.utils.instantiate(cfg.robot_client)
+    mirror_sim_client.init_connection()
 
-    # Reset
-    robot.go_home()
+    # create hw and sim robots
+    sim_robot = RobotInterface(ip=sim_ip, port=sim_port)
+    hw_robot = RobotInterface(ip=hw_ip, port=sim_port)
 
-    # set state
-    print("Running state setter...")
-    curr_state = robot.get_robot_state()
-    coef = 0.001
-    for _ in range(500):
-        curr_state.joint_positions[:] += coef * np.ones_like(curr_state.joint_positions)
-        # robot.set_state(curr_state)
-        mirror_sim_client.set_robot_state(curr_state)
+    # Create policy instance
+    hz = hw_robot.metadata.hz
+    default_kq = torch.Tensor(hw_robot.metadata.default_Kq)
+    default_kqd = torch.Tensor(hw_robot.metadata.default_Kqd)
+    policy = MyPolicy(
+        time_horizon=5 * hz,
+        hz=hz,
+        magnitude=0.5,
+        period=2.0,
+        kq=default_kq,
+        kqd=default_kqd,
+        coef=0.001,
+    )
+
+    # Reset and test in sim
+    sim_robot.go_home()
+    sim_robot.send_torch_policy(policy)
+
+    # Mirror
+    hw_robot.go_home()
+    mirror_sim_client.sync(hw_robot)  # must be non-blocking
+    hw_robot.send_torch_policy(policy)
+    mirror_sim_client.unsync()
 
 
-# this should be preceded by a call to launch_robot.py robot_client=*_sim on the same machine
+# this should be preceded by a call to launch_robot.py robot_client=None on the same machine
 if __name__ == "__main__":
     main()

--- a/polymetis/scripts/mirror_sim.py
+++ b/polymetis/scripts/mirror_sim.py
@@ -2,7 +2,10 @@
 
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+from typing import Dict
 from polymetis import RobotInterface
+import torchcontrol as toco
+import torch
 import numpy as np
 import hydra
 from polymetis.utils.data_dir import PKG_ROOT_DIR, which
@@ -14,61 +17,6 @@ sim_ip = "localhost"
 sim_port = 50051
 
 
-class MyPolicy(toco.PolicyModule):
-    """
-    Custom policy that executes a sine trajectory on joint 6
-    (magnitude = 0.5 radian, frequency = 1 second)
-    """
-
-    def __init__(self, time_horizon, hz, magnitude, period, kq, kqd, coef, **kwargs):
-        """
-        Args:
-            time_horizon (int):         Number of steps policy should execute
-            hz (double):                Frequency of controller
-            kq, kqd (torch.Tensor):     PD gains (1d array)
-        """
-        super().__init__(**kwargs)
-
-        self.hz = hz
-        self.time_horizon = time_horizon
-        self.m = magnitude
-        self.T = period
-
-        # Initialize modules
-        self.feedback = toco.modules.JointSpacePD(kq, kqd)
-
-        # Initialize variables
-        self.steps = 0
-        self.q_initial = torch.zeros_like(kq)
-        self.coef = coef
-
-    def forward(self, state_dict: Dict[str, torch.Tensor]):
-        # Parse states
-        q_current = state_dict["joint_positions"]
-        qd_current = state_dict["joint_velocities"]
-
-        # Initialize
-        if self.steps == 0:
-            self.q_initial = q_current.clone()
-
-        # Compute reference position and velocity
-        q_desired = self.q_initial.clone()
-        q_desired += np.ones_like(q_desired) * self.coef
-        qd_desired = torch.zeros_like(qd_current)
-
-        # Execute PD control
-        output = self.feedback(
-            q_current, qd_current, q_desired, torch.zeros_like(qd_current)
-        )
-
-        # Check termination
-        if self.steps > self.time_horizon:
-            self.set_terminated()
-        self.steps += 1
-
-        return {"joint_torques": output}
-
-
 @hydra.main(config_name="launch_robot")
 def main(cfg):
     # launch remote CM server + robot client
@@ -77,39 +25,54 @@ def main(cfg):
         ip=hw_ip, port=hw_port
     ), f"HW CM server must be started at {hw_ip}:{hw_port}"
     assert check_server_exists(
-        ip="localhost", port=50051
+        ip=sim_ip, port=sim_port
     ), f"Sim CM server must be started at {sim_ip}:{sim_port}"
-
     # launch sim client, TODO: move mirror sim into robot interface
     mirror_sim_client = hydra.utils.instantiate(cfg.robot_client)
-    mirror_sim_client.init_connection()
+    mirror_sim_client.init_robot_client()
 
     # create hw and sim robots
-    sim_robot = RobotInterface(ip=sim_ip, port=sim_port)
-    hw_robot = RobotInterface(ip=hw_ip, port=sim_port)
+    sim_robot = RobotInterface(ip_address=sim_ip, port=sim_port)
+    hw_robot = RobotInterface(ip_address=hw_ip, port=hw_port)
 
     # Create policy instance
     hz = hw_robot.metadata.hz
-    default_kq = torch.Tensor(hw_robot.metadata.default_Kq)
-    default_kqd = torch.Tensor(hw_robot.metadata.default_Kqd)
-    policy = MyPolicy(
-        time_horizon=5 * hz,
+    Kq_default = torch.Tensor(hw_robot.metadata.default_Kq)
+    Kqd_default = torch.Tensor(hw_robot.metadata.default_Kqd)
+    Kx_default = torch.Tensor(hw_robot.metadata.default_Kx)
+    Kxd_default = torch.Tensor(hw_robot.metadata.default_Kxd)
+
+    print("Planning...")
+    waypoints = toco.planning.generate_joint_space_min_jerk(
+        start=hw_robot.get_joint_positions(),
+        goal=hw_robot.get_joint_positions() + 0.01,
+        time_to_go=1,
         hz=hz,
-        magnitude=0.5,
-        period=2.0,
-        kq=default_kq,
-        kqd=default_kqd,
-        coef=0.001,
+    )
+    print("Creating policy...")
+    policy = toco.policies.JointTrajectoryExecutor(
+        joint_pos_trajectory=[waypoint["position"] for waypoint in waypoints],
+        joint_vel_trajectory=[waypoint["velocity"] for waypoint in waypoints],
+        Kq=Kq_default,
+        Kqd=Kqd_default,
+        Kx=Kx_default,
+        Kxd=Kxd_default,
+        robot_model=hw_robot.robot_model,
+        ignore_gravity=hw_robot.use_grav_comp,
     )
 
-    # Reset and test in sim
-    sim_robot.go_home()
-    sim_robot.send_torch_policy(policy)
+    # Reset and test in sim, TODO: not easily doable until the mirror sim is moved into RoboInterface
+    # sim_robot.go_home()
+    # sim_robot.send_torch_policy(policy)
 
     # Mirror
+    print("Homing robot...")
     hw_robot.go_home()
+    print("Syncing...")
     mirror_sim_client.sync(hw_robot)  # must be non-blocking
+    print("Sending policy...")
     hw_robot.send_torch_policy(policy)
+    print("Unsyncing...")
     mirror_sim_client.unsync()
 
 

--- a/polymetis/scripts/mirror_sim.py
+++ b/polymetis/scripts/mirror_sim.py
@@ -45,8 +45,8 @@ def main(cfg):
     print("Planning...")
     waypoints = toco.planning.generate_joint_space_min_jerk(
         start=hw_robot.get_joint_positions(),
-        goal=hw_robot.get_joint_positions() + 0.01,
-        time_to_go=1,
+        goal=hw_robot.get_joint_positions() + 0.3,
+        time_to_go=5,
         hz=hz,
     )
     print("Creating policy...")


### PR DESCRIPTION
# Description

The user interface for mirroring the state of a hardware robot in a local simulation is created.
<img width="1098" alt="Screen Shot 2022-08-22 at 11 10 10 AM" src="https://user-images.githubusercontent.com/12128112/185955562-88e3c600-017a-49fb-8568-f37efcda1c9b.png">

Fixes # (issue)

[T122948322](https://www.internalfb.com/intern/tasks/?t=122948322)

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

If this PR introduces a change or fixes a bug, please add before and after screenshots (if this is causes a UX change) or before and after examples(this could be plain text, videos etc ) to demonstrate the change.

If this PR introduces a new feature, please also add examples or screenshots demonstrating the feature.

# Testing

1. Launch a "HW" robot server: `DISPLAY=:100 launch_robot.py robot_client=franka_mujoco_sim port=50052`
2. Launch an empty local server: `DISPLAY=:100 launch_robot.py robot_client=none`
3. Launch the mirroring script: `DISPLAY=:100 scripts/mirror_sim.py robot_client=franka_sim`

Ideally, this should be tested with an actual hardware robot, or at the very least two sim visualizations to ensure the HW states match the sim states (currently only the beginning and end states are verified)

https://user-images.githubusercontent.com/12128112/185957140-98cc883d-9e78-4160-abdb-a6c5bd10ee8b.mov


# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
