### PR TITLE
Revert "make the ROS odometry (yaw) consistent with non-ROS"

### DIFF
--- a/droidlet/lowlevel/hello_robot/remote/stretch_ros_move_api.py
+++ b/droidlet/lowlevel/hello_robot/remote/stretch_ros_move_api.py
@@ -77,8 +77,7 @@ class MoveNode(hm.HelloNode):
                 ]
             )
             euler = euler_from_quaternion(quat)
-            yaw = euler[2] + math.pi
-            return (pose.pose.pose.position.x, pose.pose.pose.position.y, yaw)
+            return (pose.pose.pose.position.x, pose.pose.pose.position.y, euler[2])
         else:
             return (0.0, 0.0, 0.0)
 
@@ -100,8 +99,7 @@ class MoveNode(hm.HelloNode):
             ]
         )
         euler = euler_from_quaternion(quat)
-        yaw = euler[2] + math.pi
-        return (pose.pose.position.x, pose.pose.position.y, yaw)
+        return (pose.pose.position.x, pose.pose.position.y, euler[2])
 
     def get_joint_state(self, name=None):
         with self._lock:


### PR DESCRIPTION
This reverts commit 962db8497cbfc9e686e0691d34d6e767458c1ab9.

This commit was buggy in deep ways