### PR TITLE
[Polymetis] Fix modbus exception handling

### DIFF
--- a/polymetis/polymetis/environment.yml
+++ b/polymetis/polymetis/environment.yml
@@ -45,7 +45,7 @@ dependencies:
     - pip
     - protobuf
     - pybullet ==3.17
-    - pymodbus
+    - pymodbus ==2.5.3
     - pyserial
     - pytest
     - pytest-benchmark

--- a/polymetis/polymetis/protos/polymetis.proto
+++ b/polymetis/polymetis/protos/polymetis.proto
@@ -85,6 +85,7 @@ message GripperState {
     float width = 2;
     bool is_grasped = 3;
     bool is_moving = 4;
+    int32 error_code = 5;
 }
 
 message LogInterval {

--- a/polymetis/polymetis/python/polymetis/robot_client/robotiq_gripper/robotiq_gripper_client.py
+++ b/polymetis/polymetis/python/polymetis/robot_client/robotiq_gripper/robotiq_gripper_client.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 import time
+import logging
 from concurrent import futures
 
 import grpc
@@ -16,6 +17,8 @@ from polymetis.utils import Spinner
 from .third_party.robotiq_2finger_grippers.robotiq_2f_gripper import (
     Robotiq2FingerGripper,
 )
+
+log = logging.getLogger(__name__)
 
 
 class RobotiqGripperClient:
@@ -71,6 +74,9 @@ class RobotiqGripperClient:
         if not self.gripper.getStatus():
             # NOTE: getStatus returns False and does not update state if modbus read fails
             state.error_code = 1
+            log.warning(
+                "Failed to read gripper state. Returning last observed state instead."
+            )
 
         state.timestamp.GetCurrentTime()
         state.width = self.gripper.get_pos()

--- a/polymetis/polymetis/python/polymetis/robot_client/robotiq_gripper/robotiq_gripper_client.py
+++ b/polymetis/polymetis/python/polymetis/robot_client/robotiq_gripper/robotiq_gripper_client.py
@@ -66,9 +66,12 @@ class RobotiqGripperClient:
         self.connection.InitRobotClient(metadata)
 
     def get_gripper_state(self):
-        self.gripper.getStatus()
-
         state = polymetis_pb2.GripperState()
+
+        if not self.gripper.getStatus():
+            # NOTE: getStatus returns False and does not update state if modbus read fails
+            state.error_code = 1
+
         state.timestamp.GetCurrentTime()
         state.width = self.gripper.get_pos()
         state.is_grasped = self.gripper.object_detected()

--- a/polymetis/polymetis/python/polymetis/robot_client/robotiq_gripper/third_party/robotiq_2finger_grippers/robotiq_modbus_rtu/comModbusRtu.py
+++ b/polymetis/polymetis/python/polymetis/robot_client/robotiq_gripper/third_party/robotiq_2finger_grippers/robotiq_modbus_rtu/comModbusRtu.py
@@ -50,6 +50,7 @@ The module depends on pymodbus (http://code.google.com/p/pymodbus/) for the Modb
 """
 
 from pymodbus.client.sync import ModbusSerialClient
+from pymodbus.exceptions import ModbusIOException
 from math import ceil
 
 
@@ -112,6 +113,9 @@ class communication:
         # When reading failes, response is of type None
         if response is None:
             #   print("Failed to receive status")
+            return None
+        # Newer versions of pymodbus returns a ModbusIOException instead
+        elif type(response) is ModbusIOException:
             return None
 
         # Instantiate output as an empty list


### PR DESCRIPTION
# Description

Fixes #1383

### Changes
- Change error handling to account for different return types during read fail in newer pymodbus versions
- Add error code field in gripper state msg to indicate a read fail
- Pin pymodbus version

### Todos
- [ ] Test on hardware (Concern: how to repro read fail?)

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.


# Testing

Tested on hardware, reproducing read fail by unplugging the USB connection to the Robotiq gripper.

### Before
Server side:
```
Traceback (most recent call last):
  File "/home/wangaustin/dev/fairo/polymetis/polymetis/python/scripts/launch_gripper.py", line 46, in main
    gripper_client.run()
  File "/home/wangaustin/dev/fairo/polymetis/polymetis/python/polymetis/robot_client/robotiq_gripper/robotiq_gripper_client.py", line 94, in run
    state = self.get_gripper_state()
  File "/home/wangaustin/dev/fairo/polymetis/polymetis/python/polymetis/robot_client/robotiq_gripper/robotiq_gripper_client.py", line 69, in get_gripper_state
    self.gripper.getStatus()
  File "/home/wangaustin/dev/fairo/polymetis/polymetis/python/polymetis/robot_client/robotiq_gripper/third_party/robotiq_2finger_grippers/robotiq_2f_gripper.py", line 64, in getStatus
    status = self.client.getStatus(6)
  File "/home/wangaustin/dev/fairo/polymetis/polymetis/python/polymetis/robot_client/robotiq_gripper/third_party/robotiq_2finger_grippers/robotiq_modbus_rtu/comModbusRtu.py", line 122, in getStatus
    output.append((response.getRegister(i) & 0xFF00) >> 8)
AttributeError: 'ModbusIOException' object has no attribute 'getRegister'

Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.
```
(program terminates)

Client side:
```py
>>> gripper.get_state()
timestamp {
  seconds: 1665449135
  nanos: 304429000
}
width: 0.08500000089406967
```

### After
Server side:
```
[2022-10-10 17:42:35,257][polymetis.robot_client.robotiq_gripper.robotiq_gripper_client][WARNING] - Failed to read gripper state. Returning last observed state instead.
[2022-10-10 17:42:35,274][pymodbus.client.sync][ERROR] - [Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
Modbus Error: [Connection] Failed to connect[ModbusSerialClient(rtu baud[115200])]
[2022-10-10 17:42:35,274][polymetis.robot_client.robotiq_gripper.robotiq_gripper_client][WARNING] - Failed to read gripper state. Returning last observed state instead.
[2022-10-10 17:42:35,290][pymodbus.client.sync][ERROR] - [Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
Modbus Error: [Connection] Failed to connect[ModbusSerialClient(rtu baud[115200])]
[2022-10-10 17:42:35,290][polymetis.robot_client.robotiq_gripper.robotiq_gripper_client][WARNING] - Failed to read gripper state. Returning last observed state instead.
[2022-10-10 17:42:35,307][pymodbus.client.sync][ERROR] - [Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
Modbus Error: [Connection] Failed to connect[ModbusSerialClient(rtu baud[115200])]
.
.
.
```
(program continues running, recovers when plugged back in)

Client side:
```py
>>> gripper.get_state()
timestamp {
  seconds: 1665449009
  nanos: 715200000
}
width: 0.08500000089406967
error_code: 1
```


# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
