### PR TITLE
[Polymetis] Fix spdlog dependency break

### DIFF
--- a/perception/sandbox/eyehandcal/environment.yml
+++ b/perception/sandbox/eyehandcal/environment.yml
@@ -6,7 +6,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - polymetis=685_g1d486298
+  - polymetis
   - opencv=4.5.1
   - librealsense=2.50.0
   - scipy=1.7.3

--- a/perception/sandbox/eyehandcal/environment.yml
+++ b/perception/sandbox/eyehandcal/environment.yml
@@ -6,12 +6,13 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - polymetis
+  - polymetis=685_g1d486298
   - opencv=4.5.1
   - librealsense=2.50.0
   - scipy=1.7.3
   - cmake
   - pybind11
+  - py
   - pip
   - pip:
     - ../../realsense_driver/

--- a/polymetis/polymetis/conda/conda_recipe/meta.yaml
+++ b/polymetis/polymetis/conda/conda_recipe/meta.yaml
@@ -59,7 +59,7 @@ requirements:
     - pymodbus
     - pyserial
     - pytest
-    - pytest-benchmark <4.0.0
+    - pytest-benchmark=3.4.1
     - python ==3.8
     - pytorch ==1.10.0
     - scipy

--- a/polymetis/polymetis/conda/conda_recipe/meta.yaml
+++ b/polymetis/polymetis/conda/conda_recipe/meta.yaml
@@ -59,7 +59,7 @@ requirements:
     - pymodbus
     - pyserial
     - pytest
-    - pytest-benchmark=3.4.1
+    - pytest-benchmark=4.0.0
     - python ==3.8
     - pytorch ==1.10.0
     - scipy

--- a/polymetis/polymetis/conda/conda_recipe/meta.yaml
+++ b/polymetis/polymetis/conda/conda_recipe/meta.yaml
@@ -63,7 +63,7 @@ requirements:
     - python ==3.8
     - pytorch ==1.10.0
     - scipy
-    - spdlog
+    - spdlog=1.10.0=h924138e_0
     - sphinx
     - sphinx-book-theme
     - tqdm

--- a/polymetis/polymetis/conda/conda_recipe/meta.yaml
+++ b/polymetis/polymetis/conda/conda_recipe/meta.yaml
@@ -59,7 +59,7 @@ requirements:
     - pymodbus
     - pyserial
     - pytest
-    - pytest-benchmark
+    - pytest-benchmark <4.0.0
     - python ==3.8
     - pytorch ==1.10.0
     - scipy

--- a/polymetis/polymetis/conda/conda_recipe/meta.yaml
+++ b/polymetis/polymetis/conda/conda_recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - poco ==1.9.0 # needed by libfranka
     - python ==3.8
     - pytorch ==1.10.0
-    - spdlog
+    - spdlog=1.10.0=h924138e_0
     - urdfdom=2.3.3=hc9558a2_0
     - urdfdom_headers=1.0.5=hc9558a2_2
     - yaml-cpp ==0.6.3

--- a/polymetis/polymetis/environment.yml
+++ b/polymetis/polymetis/environment.yml
@@ -48,7 +48,7 @@ dependencies:
     - pymodbus ==2.5.3
     - pyserial
     - pytest
-    - pytest-benchmark=3.4.1
+    - pytest-benchmark=4.0.0
     - scipy
     - spdlog=1.10.0=h924138e_0
     - sphinx

--- a/polymetis/polymetis/environment.yml
+++ b/polymetis/polymetis/environment.yml
@@ -50,7 +50,7 @@ dependencies:
     - pytest
     - pytest-benchmark
     - scipy
-    - spdlog
+    - spdlog=1.10.0=h924138e_0
     - sphinx
     - sphinx-copybutton
     - sphinx-book-theme

--- a/polymetis/polymetis/environment.yml
+++ b/polymetis/polymetis/environment.yml
@@ -48,7 +48,7 @@ dependencies:
     - pymodbus ==2.5.3
     - pyserial
     - pytest
-    - pytest-benchmark <4.0.0
+    - pytest-benchmark=3.4.1
     - scipy
     - spdlog=1.10.0=h924138e_0
     - sphinx

--- a/polymetis/polymetis/environment.yml
+++ b/polymetis/polymetis/environment.yml
@@ -48,7 +48,7 @@ dependencies:
     - pymodbus ==2.5.3
     - pyserial
     - pytest
-    - pytest-benchmark
+    - pytest-benchmark <4.0.0
     - scipy
     - spdlog=1.10.0=h924138e_0
     - sphinx


### PR DESCRIPTION
# Description

Yet another issue due to an updated dependency.
The [spdlog conda package](https://anaconda.org/conda-forge/spdlog/files) was updated on Oct 21st, causing [linking issues](https://pastebin.com/tz7waK6z).
This is not an issue of different build vs. run spdlog versions, as using the newer spdlog to build & run still results in the same issue.

The PR simply pins the spdlog dependency to the older, stable build.

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

If this PR introduces a change or fixes a bug, please add before and after screenshots (if this is causes a UX change) or before and after examples(this could be plain text, videos etc ) to demonstrate the change.

If this PR introduces a new feature, please also add examples or screenshots demonstrating the feature.

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
