### PR TITLE
[Polymetis] Completely expose Franka Hand gripper API

### DIFF
--- a/polymetis/polymetis/include/polymetis/clients/franka_hand_client.hpp
+++ b/polymetis/polymetis/include/polymetis/clients/franka_hand_client.hpp
@@ -25,6 +25,7 @@ private:
   GripperState gripper_state_;
   GripperCommand gripper_cmd_;
   int prev_cmd_timestamp_ns_;
+  bool prev_cmd_successful_ = true;
 
   // Franka
   std::shared_ptr<franka::Gripper> gripper_;

--- a/polymetis/polymetis/include/polymetis/clients/franka_hand_client.hpp
+++ b/polymetis/polymetis/include/polymetis/clients/franka_hand_client.hpp
@@ -10,8 +10,8 @@
 #define GRIPPER_HZ 30
 
 // Define tolerances to be able to grasp any object without specifying width
-#define EPSILON_INNER -0.0005
-#define EPSILON_OUTER 0.15
+#define EPSILON_INNER 0.2
+#define EPSILON_OUTER 0.2
 
 class FrankaHandClient {
 private:

--- a/polymetis/polymetis/protos/polymetis.proto
+++ b/polymetis/polymetis/protos/polymetis.proto
@@ -78,6 +78,8 @@ message GripperCommand {
     float speed = 3;
     float force = 4;
     bool grasp = 5;
+    float epsilon_inner = 6;
+    float epsilon_outer = 7;
 }
 
 message GripperState {

--- a/polymetis/polymetis/protos/polymetis.proto
+++ b/polymetis/polymetis/protos/polymetis.proto
@@ -87,6 +87,7 @@ message GripperState {
     float width = 2;
     bool is_grasped = 3;
     bool is_moving = 4;
+    bool prev_command_successful = 6;
     int32 error_code = 5;
 }
 

--- a/polymetis/polymetis/python/polymetis/gripper_interface.py
+++ b/polymetis/polymetis/python/polymetis/gripper_interface.py
@@ -94,10 +94,22 @@ class GripperInterface:
         epsilon_outer: float = -1.0,
         blocking: bool = True,
     ):
-        """Commands the gripper to a certain width
+        """Commands the gripper to a close
+
+        For Robotiq grippers, this is equivalent to calling `goto` with grasp_width (0 by default).
+
+        For the Franka Hand, see documentation for franka::Gripper::move in libfranka.
+        Basically the gripper will perform the grasp if grasp_width - epsilon_inner < final_width < grasp_width + epsilon_outer.
+        Else the gripper will not continue to exert force.
+        The default width and epsilon values ensures that the gripper closes to the minimum width possible and continues to exert force.
+
+
         Args:
             vel: Velocity of the movement
             force: Maximum force the gripper will exert
+            grasp_width: Target width of the grasp
+            epsilon_inner: Maximum tolerated deviation when the actual grasped width is smaller than the commanded grasp width
+            epsilon_outer: Maximum tolerated deviation when the actual grasped width is larger than the commanded grasp width
         """
         cmd = polymetis_pb2.GripperCommand(
             width=grasp_width,

--- a/polymetis/polymetis/python/polymetis/gripper_interface.py
+++ b/polymetis/polymetis/python/polymetis/gripper_interface.py
@@ -85,14 +85,27 @@ class GripperInterface:
             blocking=blocking,
         )
 
-    def grasp(self, speed: float, force: float, blocking: bool = True):
+    def grasp(
+        self,
+        speed: float,
+        force: float,
+        grasp_width: float = 0.0,
+        epsilon_inner: float = -1.0,
+        epsilon_outer: float = -1.0,
+        blocking: bool = True,
+    ):
         """Commands the gripper to a certain width
         Args:
             vel: Velocity of the movement
             force: Maximum force the gripper will exert
         """
         cmd = polymetis_pb2.GripperCommand(
-            width=0.0, speed=speed, force=force, grasp=True
+            width=grasp_width,
+            speed=speed,
+            force=force,
+            grasp=True,
+            epsilon_inner=epsilon_inner,
+            epsilon_outer=epsilon_outer,
         )
         cmd.timestamp.GetCurrentTime()
 

--- a/polymetis/polymetis/src/clients/franka_panda_client/franka_hand_client.cpp
+++ b/polymetis/polymetis/src/clients/franka_panda_client/franka_hand_client.cpp
@@ -55,8 +55,14 @@ void FrankaHandClient::applyGripperCommand(void) {
   if (gripper_cmd_.grasp()) {
     spdlog::info("Grasping at width {} at speed={}", gripper_cmd_.width(),
                  gripper_cmd_.speed());
+    double eps_inner = (gripper_cmd_.epsilon_inner() < 0)
+                           ? EPSILON_INNER
+                           : gripper_cmd_.epsilon_inner();
+    double eps_outer = (gripper_cmd_.epsilon_outer() < 0)
+                           ? EPSILON_OUTER
+                           : gripper_cmd_.epsilon_outer();
     gripper_->grasp(gripper_cmd_.width(), gripper_cmd_.speed(),
-                    gripper_cmd_.force(), EPSILON_INNER, EPSILON_OUTER);
+                    gripper_cmd_.force(), eps_inner, eps_outer);
 
   } else {
     spdlog::info("Moving to width {} at speed={}", gripper_cmd_.width(),

--- a/polymetis/polymetis/src/clients/franka_panda_client/franka_hand_client.cpp
+++ b/polymetis/polymetis/src/clients/franka_panda_client/franka_hand_client.cpp
@@ -44,6 +44,7 @@ void FrankaHandClient::getGripperState(void) {
   gripper_state_.set_width(franka_gripper_state.width);
   gripper_state_.set_is_grasped(franka_gripper_state.is_grasped);
   gripper_state_.set_is_moving(is_moving_);
+  gripper_state_.set_prev_command_successful(prev_cmd_successful_);
 
   // gripper_state.time();  // Use current timestamp instead!
   setTimestampToNow(gripper_state_.mutable_timestamp());
@@ -61,13 +62,15 @@ void FrankaHandClient::applyGripperCommand(void) {
     double eps_outer = (gripper_cmd_.epsilon_outer() < 0)
                            ? EPSILON_OUTER
                            : gripper_cmd_.epsilon_outer();
-    gripper_->grasp(gripper_cmd_.width(), gripper_cmd_.speed(),
-                    gripper_cmd_.force(), eps_inner, eps_outer);
+    prev_cmd_successful_ =
+        gripper_->grasp(gripper_cmd_.width(), gripper_cmd_.speed(),
+                        gripper_cmd_.force(), eps_inner, eps_outer);
 
   } else {
     spdlog::info("Moving to width {} at speed={}", gripper_cmd_.width(),
                  gripper_cmd_.speed());
-    gripper_->move(gripper_cmd_.width(), gripper_cmd_.speed());
+    prev_cmd_successful_ =
+        gripper_->move(gripper_cmd_.width(), gripper_cmd_.speed());
   }
 
   is_moving_ = false;


### PR DESCRIPTION
# Description

Issue #1398 highlights an inflexibility of [`franka::Gripper::move`](http://docs.ros.org/en/kinetic/api/libfranka/html/classfranka_1_1Gripper.html#a331720c9e26f23a5fa3de1e171b1a684), which is currently the only API Polymetis is using to command the Franka Hand.
Basically the move command blocks until it reaches the desired goal, which causes problems during grasping.
This PR exposes [`franka::Gripper::grasp`](http://docs.ros.org/en/kinetic/api/libfranka/html/classfranka_1_1Gripper.html#a19b711cc7eb4cb560d1c52f0864fdc0d), which is a clunky API that at least allows the user to execute a grasp instead of commanding the gripper to 0 width. 

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

If this PR introduces a change or fixes a bug, please add before and after screenshots (if this is causes a UX change) or before and after examples(this could be plain text, videos etc ) to demonstrate the change.

If this PR introduces a new feature, please also add examples or screenshots demonstrating the feature.

# Testing

Tested on hardware

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
