### PR TITLE
[Polymetis] Bump Pytorch version

### DIFF
--- a/polymetis/polymetis/conda/conda_recipe/meta.yaml
+++ b/polymetis/polymetis/conda/conda_recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - pinocchio ==2.5.2
     - poco ==1.9.0 # needed by libfranka
     - python ==3.8
-    - pytorch ==1.10.0
+    - pytorch
     - spdlog=1.10.0=h924138e_0
     - urdfdom=2.3.3=hc9558a2_0
     - urdfdom_headers=1.0.5=hc9558a2_2
@@ -61,7 +61,7 @@ requirements:
     - pytest
     - pytest-benchmark=4.0.0
     - python ==3.8
-    - pytorch ==1.10.0
+    - pytorch
     - scipy
     - spdlog=1.10.0=h924138e_0
     - sphinx

--- a/polymetis/polymetis/conda/conda_recipe/meta.yaml
+++ b/polymetis/polymetis/conda/conda_recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - pinocchio ==2.5.2
     - poco ==1.9.0 # needed by libfranka
     - python ==3.8
-    - pytorch
+    - pytorch ==1.13.1
     - spdlog=1.10.0=h924138e_0
     - urdfdom=2.3.3=hc9558a2_0
     - urdfdom_headers=1.0.5=hc9558a2_2
@@ -61,7 +61,7 @@ requirements:
     - pytest
     - pytest-benchmark=4.0.0
     - python ==3.8
-    - pytorch
+    - pytorch ==1.13.1
     - scipy
     - spdlog=1.10.0=h924138e_0
     - sphinx

--- a/polymetis/polymetis/environment.yml
+++ b/polymetis/polymetis/environment.yml
@@ -21,7 +21,7 @@ dependencies:
     - pinocchio ==2.5.2
     - poco ==1.9.0 # needed by libfranka
     - python ==3.8
-    - pytorch
+    - pytorch ==1.13.1
     - urdfdom=2.3.3=hc9558a2_0
     - urdfdom_headers=1.0.5=hc9558a2_2
     - yaml-cpp ==0.6.3

--- a/polymetis/polymetis/environment.yml
+++ b/polymetis/polymetis/environment.yml
@@ -21,7 +21,7 @@ dependencies:
     - pinocchio ==2.5.2
     - poco ==1.9.0 # needed by libfranka
     - python ==3.8
-    - pytorch=1.10.0
+    - pytorch
     - urdfdom=2.3.3=hc9558a2_0
     - urdfdom_headers=1.0.5=hc9558a2_2
     - yaml-cpp ==0.6.3


### PR DESCRIPTION
# Description

Bump Pytorch to latest version as the previously pinned version `1.10.0` is no longer pip-installable.
Tried removing pin but conda somehow installs `pytorch==1.4.0` instead of the latest version.

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [ ] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

If this PR introduces a change or fixes a bug, please add before and after screenshots (if this is causes a UX change) or before and after examples(this could be plain text, videos etc ) to demonstrate the change.

If this PR introduces a new feature, please also add examples or screenshots demonstrating the feature.

# Testing

Please describe the tests that you ran to verify your changes and how we can reproduce.

# Checklist:

- [ ] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.
- [ ] [Polymetis only] I ran on hardware (1) all scripts in `tests/scripts`, (2) asv benchmarks.
